### PR TITLE
fix(adapters): ollama adapter to use client settings and base url

### DIFF
--- a/typescript/src/adapters/ollama/backend/client.ts
+++ b/typescript/src/adapters/ollama/backend/client.ts
@@ -21,10 +21,10 @@ import { BackendClient } from "@/backend/client.js";
 export type OllamaClientSettings = OllamaProviderSettings;
 
 export class OllamaClient extends BackendClient<OllamaClientSettings, OllamaProvider> {
-  protected create(settings?: OllamaClientSettings): OllamaProvider {
+  protected create(): OllamaProvider {
     return createOllama({
-      ...settings,
-      baseURL: getEnv("OLLAMA_BASE_URL"),
+      ...(this.settings ?? {}),
+      baseURL: this.settings?.baseURL ?? getEnv("OLLAMA_BASE_URL"),
     });
   }
 }


### PR DESCRIPTION
Fixes #319

<!--
Thank you for your pull request. Please review and complete the sections below.
-->

### Which issue(s) does this pull-request address?

#319
<!--
Please include a link to an issue in the tracker.  The issue describes the problem to be solved.  If there is no issue raised for this PR then either raise one with a summary and description of the problem or add a summary and description of the problem here
-->

Closes: #

### Description

Removed the settings parameter as it was not being passed from the base adapters.
Started taking base URL from this.settings.baseURL (if present.)

<!-- Provide a description of the change, pay special attention to describing any breaking changes.  The description describes the resolution to the problem described in the linked issue (or to the problem outlined in this PR). -->

### Checklist

<!-- For completed items, change [ ] to [x]. -->

- [x] I have read the [contributor guide](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have [signed off](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-dco) on my commit
- [x] Linting passes: `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: `yarn format` or `yarn format:fix`
- [x] Unit tests pass: `yarn test:unit`
- [ ] E2E tests pass: `yarn test:e2e`
- [ ] Tests are included <!-- Bug fixes and new features should include tests -->
- [ ] Documentation is changed or added
- [ ] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
