### PR TITLE
docs: use absolute links for Pypi

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -198,7 +198,9 @@ sequence = [
     { shell = '[ -z "$(git status -uno --porcelain)" ] || { echo "Your index contains uncommitted changes! Commit them and try again." && exit 1; }' },
     { "ref" = "clean"},
     { "cmd" = "cz bump"},
-    { "cmd" = "poetry publish --build" },
+    { "script" = "scripts.absolute_links:update('README.md')"},
+    { "cmd" = "poetry publish --build --dry-run" },
+    { "shell" = "git add README.md >/dev/null && git checkout HEAD README.md >/dev/null" },
     { "cmd" = "git push && git push origin $(git describe --tags --exact-match)"}
 ]
 

--- a/python/scripts/absolute_links.py
+++ b/python/scripts/absolute_links.py
@@ -1,0 +1,27 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+
+
+def update(path: str) -> None:
+    with open(path, encoding="utf-8") as file:
+        content = file.read()
+
+    pattern1 = r"(\[.*?\]\()(?!https?:\/\/)(.*?)\)"
+    replacement1 = "\\1https://github.com/i-am-bee/beeai-framework/tree/main\\2)"
+    content = re.sub(pattern1, replacement1, content, flags=re.MULTILINE)
+
+    with open(path, "w", encoding="utf-8") as file:
+        file.write(content)

--- a/python/scripts/copyright.sh
+++ b/python/scripts/copyright.sh
@@ -16,7 +16,7 @@
 set -e
 
 if [ "$#" -eq 0 ]; then
-  TARGETS=('beeai_framework/**/*.py' "cz_commitizen/**/*.py" "tests/**/*.py" "scripts/**/*.{sh,ts,js}")
+  TARGETS=('beeai_framework/**/*.py' "cz_commitizen/**/*.py" "tests/**/*.py" "scripts/**/*.{sh,py}")
 else
   TARGETS=("${@/#$PWD\//}")
 fi


### PR DESCRIPTION
Pypi needs absolute links in README.md to display them correctly.

Closes: #346 