### PR TITLE
fix: emit parsed react elements

### DIFF
--- a/python/examples/agents/bee.py
+++ b/python/examples/agents/bee.py
@@ -94,6 +94,8 @@ async def process_agent_events(event_data: dict[str, Any], event_meta: EventMeta
         reader.write(f"Agent({event_data['update']['key']}) 🤖 : ", event_data["update"]["parsedValue"])
     # elif event_meta.name == "start":
     #     reader.write("Agent 🤖 : ", "starting new iteration")
+    # elif event_meta.name == "success":
+    #     reader.write("Agent 🤖 : ", "success")
 
 
 async def observer(emitter: Emitter) -> None:


### PR DESCRIPTION
Emits parsed react constructs such as thought, tool_input etc from the line parser.

<!-- For completed items, change [ ] to [x]. -->

- [x] I have read the [contributor guide](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have [signed off](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-dco) on my commit
- [x] Linting passes: `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: `yarn format` or `yarn format:fix`
- [x] Unit tests pass: `yarn test:unit`
- [ ] E2E tests pass: `yarn test:e2e`
- [ ] Tests are included <!-- Bug fixes and new features should include tests -->
- [ ] Documentation is changed or added
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
