### PR TITLE
fix: pass through chatmodel params

### DIFF
--- a/python/beeai_framework/adapters/litellm/chat.py
+++ b/python/beeai_framework/adapters/litellm/chat.py
@@ -58,13 +58,13 @@ class LiteLLMChatModel(ChatModel, ABC):
     def model_id(self) -> str:
         return self._model_id
 
-    def __init__(self, model_id: str, **settings: Any) -> None:
+    def __init__(self, model_id: str, settings: dict | None = None) -> None:
         self._model_id = model_id
         llm_provider = "ollama_chat" if self.provider_id == "ollama" else self.provider_id
         self.supported_params = get_supported_openai_params(model=self.model_id, custom_llm_provider=llm_provider) or []
         # drop any unsupported parameters that were passed in
         litellm.drop_params = True
-        self.settings = settings
+        self.settings = settings or {}
         super().__init__()
 
     async def _create(

--- a/python/beeai_framework/adapters/ollama/backend/chat.py
+++ b/python/beeai_framework/adapters/ollama/backend/chat.py
@@ -14,7 +14,6 @@
 
 
 import os
-from typing import Any
 
 from beeai_framework.adapters.litellm.chat import LiteLLMChatModel
 from beeai_framework.backend.constants import ProviderName
@@ -28,8 +27,8 @@ class OllamaChatModel(LiteLLMChatModel):
     def provider_id(self) -> ProviderName:
         return "ollama"
 
-    def __init__(self, model_id: str | None = None, **settings: Any) -> None:
+    def __init__(self, model_id: str | None = None, settings: dict | None = None) -> None:
         super().__init__(
             model_id if model_id else os.getenv("OLLAMA_CHAT_MODEL", "llama3.1:8b"),
-            settings={"base_url": "http://localhost:11434"} | settings,
+            settings={"base_url": "http://localhost:11434"} | (settings or {}),
         )

--- a/python/beeai_framework/adapters/watsonx/backend/chat.py
+++ b/python/beeai_framework/adapters/watsonx/backend/chat.py
@@ -14,7 +14,6 @@
 
 
 import os
-from typing import Any
 
 from beeai_framework.adapters.litellm.chat import LiteLLMChatModel
 from beeai_framework.backend.constants import ProviderName
@@ -28,7 +27,9 @@ class WatsonxChatModel(LiteLLMChatModel):
     def provider_id(self) -> ProviderName:
         return "watsonx"
 
-    def __init__(self, model_id: str | None = None, **settings: Any) -> None:
+    def __init__(self, model_id: str | None = None, settings: dict | None = None) -> None:
+        if settings is None:
+            settings = {}
         super().__init__(
-            model_id if model_id else os.getenv("WATSONX_CHAT_MODEL", "ibm/granite-3-8b-instruct"), **settings
+            model_id if model_id else os.getenv("WATSONX_CHAT_MODEL", "ibm/granite-3-8b-instruct"), settings=settings
         )

--- a/python/beeai_framework/backend/chat.py
+++ b/python/beeai_framework/backend/chat.py
@@ -278,4 +278,4 @@ IMPORTANT: You MUST answer with a JSON object that matches the JSON schema above
 
         settings = options.model_dump() if isinstance(options, ChatModelParameters) else options
 
-        return TargetChatModel(parsed_model.model_id, **(settings or {}))
+        return TargetChatModel(parsed_model.model_id, settings=settings or {})

--- a/python/examples/backend/providers/watsonx.py
+++ b/python/examples/backend/providers/watsonx.py
@@ -9,20 +9,22 @@ from beeai_framework.cancellation import AbortSignal
 # Setting can be passed here during initiation or pre-configured via environment variables
 llm = WatsonxChatModel(
     "ibm/granite-3-8b-instruct",
-    # project_id="WATSONX_PROJECT_ID",
-    # api_key="WATSONX_API_KEY",
-    # api_base="WATSONX_API_URL",
+    # settings={
+    #     "project_id": "WATSONX_PROJECT_ID",
+    #     "api_key": "WATSONX_API_KEY",
+    #     "api_base": "WATSONX_API_URL",
+    # },
 )
 
 
 async def watsonx_from_name() -> None:
-    watsonx_llm = await WatsonxChatModel.from_name(
-        "ollama:llama3.1",
-        {
-            # "project_id": "WATSONX_PROJECT_ID",
-            # "api_key": "WATSONX_API_KEY",
-            # "api_base": "WATSONX_API_URL",
-        },
+    watsonx_llm = WatsonxChatModel.from_name(
+        "watsonx:ibm/granite-3-8b-instruct",
+        # {
+        #     "project_id": "WATSONX_PROJECT_ID",
+        #     "api_key": "WATSONX_API_KEY",
+        #     "api_base": "WATSONX_API_URL",
+        # },
     )
     user_message = UserMessage("what states are part of New England?")
     response = await watsonx_llm.create({"messages": [user_message]})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review and complete the sections below.
-->

### Which issue(s) does this pull-request address?

<!--
Please include a link to an issue in the tracker.  The issue describes the problem to be solved.  If there is no issue raised for this PR then either raise one with a summary and description of the problem or add a summary and description of the problem here
-->

Closes: #377 

### Description

this PR updates how the `settings` parameters is handled and passed through to subsequent functions. it should allow for `base_url` and other parameters to be defined and properly propagated, e.g.,

```
llm = OllamaChatModel("llama3.1", settings={"base_url": "http://127.0.0.1:11444"})
```

```
llm = WatsonxChatModel(
    "ibm/granite-3-8b-instruct",
    settings={
        "project_id": "WATSONX_PROJECT_ID",
        "api_key": "WATSONX_API_KEY",
        "api_base": "WATSONX_API_URL",
    },
)
```

### Checklist

<!-- For completed items, change [ ] to [x]. -->

- [x] I have read the [contributor guide](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have [signed off](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-dco) on my commit
- [x] Linting passes: `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: `yarn format` or `yarn format:fix`
- [x] Unit tests pass: `yarn test:unit`
- [x] E2E tests pass: `yarn test:e2e`
- [ ] Tests are included <!-- Bug fixes and new features should include tests -->
- [ ] Documentation is changed or added
- [ ] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
