### PR TITLE
fix: ability to specify external Ollama server

### DIFF
--- a/python/.env.example
+++ b/python/.env.example
@@ -17,3 +17,10 @@ BEEAI_LOG_LEVEL=INFO
 # WATSONX_URL=your-watsonx-instance-base-url
 # WATSONX_PROJECT_ID=your-watsonx-project-id
 # WATSONX_APIKEY=your-watsonx-api-key
+
+########################
+### Ollama specific configuration
+########################
+
+# OLLAMA_BASE_URL=http://localhost:11434
+# OLLAMA_CHAT_MODEL=llama3.1:8b

--- a/python/beeai_framework/adapters/ollama/backend/chat.py
+++ b/python/beeai_framework/adapters/ollama/backend/chat.py
@@ -28,6 +28,9 @@ class OllamaChatModel(LiteLLMChatModel):
         return "ollama"
 
     def __init__(self, model_id: str | None = None, settings: dict | None = None) -> None:
+        if not hasattr(settings, "base_url") and "OLLAMA_BASE_URL" in os.environ:
+            settings["base_url"] = os.getenv("OLLAMA_BASE_URL")
+
         super().__init__(
             model_id if model_id else os.getenv("OLLAMA_CHAT_MODEL", "llama3.1:8b"),
             settings={"base_url": "http://localhost:11434"} | (settings or {}),

--- a/python/beeai_framework/adapters/ollama/backend/chat.py
+++ b/python/beeai_framework/adapters/ollama/backend/chat.py
@@ -28,10 +28,12 @@ class OllamaChatModel(LiteLLMChatModel):
         return "ollama"
 
     def __init__(self, model_id: str | None = None, settings: dict | None = None) -> None:
-        if settings is not None and not hasattr(settings, "base_url") and "OLLAMA_BASE_URL" in os.environ:
-            settings["base_url"] = os.getenv("OLLAMA_BASE_URL")
+        _settings = settings.copy()
+
+        if _settings is not None and not hasattr(_settings, "base_url") and "OLLAMA_BASE_URL" in os.environ:
+            _settings["base_url"] = os.getenv("OLLAMA_BASE_URL")
 
         super().__init__(
             model_id if model_id else os.getenv("OLLAMA_CHAT_MODEL", "llama3.1:8b"),
-            settings={"base_url": "http://localhost:11434"} | (settings or {}),
+            settings={"base_url": "http://localhost:11434"} | (_settings or {}),
         )

--- a/python/beeai_framework/adapters/ollama/backend/chat.py
+++ b/python/beeai_framework/adapters/ollama/backend/chat.py
@@ -28,7 +28,7 @@ class OllamaChatModel(LiteLLMChatModel):
         return "ollama"
 
     def __init__(self, model_id: str | None = None, settings: dict | None = None) -> None:
-        if not hasattr(settings, "base_url") and "OLLAMA_BASE_URL" in os.environ:
+        if settings is not None and not hasattr(settings, "base_url") and "OLLAMA_BASE_URL" in os.environ:
             settings["base_url"] = os.getenv("OLLAMA_BASE_URL")
 
         super().__init__(

--- a/python/beeai_framework/adapters/ollama/backend/chat.py
+++ b/python/beeai_framework/adapters/ollama/backend/chat.py
@@ -28,7 +28,7 @@ class OllamaChatModel(LiteLLMChatModel):
         return "ollama"
 
     def __init__(self, model_id: str | None = None, settings: dict | None = None) -> None:
-        _settings = settings.copy()
+        _settings = settings.copy() if settings is not None else None
 
         if _settings is not None and not hasattr(_settings, "base_url") and "OLLAMA_BASE_URL" in os.environ:
             _settings["base_url"] = os.getenv("OLLAMA_BASE_URL")

--- a/python/tests/backend/test_chatmodel.py
+++ b/python/tests/backend/test_chatmodel.py
@@ -131,7 +131,7 @@ async def test_chat_model_abort(reverse_words_chat: ChatModel, chat_messages_lis
 @pytest.mark.unit
 def test_chat_model_from() -> None:
     # Ollama with Llama model and base_url specified in code
-    del os.environ["OLLAMA_BASE_URL"]
+    os.environ.pop("OLLAMA_BASE_URL", None)
     ollama_chat_model = ChatModel.from_name("ollama:llama3.1", {"base_url": "http://somewhere:12345"})
     assert isinstance(ollama_chat_model, OllamaChatModel)
     assert ollama_chat_model.settings["base_url"] == "http://somewhere:12345"

--- a/python/tests/backend/test_chatmodel.py
+++ b/python/tests/backend/test_chatmodel.py
@@ -14,6 +14,7 @@
 
 
 import asyncio
+import os
 from collections.abc import AsyncGenerator
 
 import pytest
@@ -129,8 +130,17 @@ async def test_chat_model_abort(reverse_words_chat: ChatModel, chat_messages_lis
 
 @pytest.mark.unit
 def test_chat_model_from() -> None:
-    ollama_chat_model = ChatModel.from_name("ollama:llama3.1")
+    # Ollama with Llama model and base_url specified in code
+    del os.environ["OLLAMA_BASE_URL"]
+    ollama_chat_model = ChatModel.from_name("ollama:llama3.1", {"base_url": "http://somewhere:12345"})
     assert isinstance(ollama_chat_model, OllamaChatModel)
+    assert ollama_chat_model.settings["base_url"] == "http://somewhere:12345"
+
+    # Ollama with Granite model and base_url specified in env var
+    os.environ["OLLAMA_BASE_URL"] = "http://somewhere-else:12345"
+    ollama_chat_model = ChatModel.from_name("ollama:granite3.1-dense:8b")
+    assert isinstance(ollama_chat_model, OllamaChatModel)
+    assert ollama_chat_model.settings["base_url"] == "http://somewhere-else:12345"
 
     watsonx_chat_model = ChatModel.from_name("watsonx:ibm/granite-3-8b-instruct")
     assert isinstance(watsonx_chat_model, WatsonxChatModel)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review and complete the sections below.
-->

### Which issue(s) does this pull-request address?

<!--
Please include a link to an issue in the tracker.  The issue describes the problem to be solved.  If there is no issue raised for this PR then either raise one with a summary and description of the problem or add a summary and description of the problem here
-->

Closes: #387

### Description

<!-- Provide a description of the change, pay special attention to describing any breaking changes.  The description describes the resolution to the problem described in the linked issue (or to the problem outlined in this PR). -->

Allow connection to a different Ollama server through env vars (and add tests).

### Checklist

<!-- For completed items, change [ ] to [x]. -->

- [x] I have read the [contributor guide](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have [signed off](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-dco) on my commit
- [ ] Linting passes: `yarn lint` or `yarn lint:fix`
- [ ] Formatting is applied: `yarn format` or `yarn format:fix`
- [ ] Unit tests pass: `yarn test:unit`
- [ ] E2E tests pass: `yarn test:e2e`
- [x] Tests are included <!-- Bug fixes and new features should include tests -->
- [ ] Documentation is changed or added
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
