### PR TITLE
fix: pass chatmodel config parameters

### DIFF
--- a/python/beeai_framework/adapters/litellm/chat.py
+++ b/python/beeai_framework/adapters/litellm/chat.py
@@ -166,6 +166,7 @@ class LiteLLMChatModel(ChatModel, ABC):
             messages=messages,
             tools=tools,
             response_format=input.response_format,
+            **self.parameters.model_dump(),
             **self.settings,
         )
 

--- a/python/beeai_framework/backend/chat.py
+++ b/python/beeai_framework/backend/chat.py
@@ -42,7 +42,7 @@ class ChatModelParameters(BaseModel):
     max_tokens: int | None = None
     top_p: int | None = None
     frequency_penalty: int | None = None
-    temperature: int | None = None
+    temperature: int | None = 0
     top_k: int | None = None
     n: int | None = None
     presence_penalty: int | None = None
@@ -56,7 +56,7 @@ class ChatConfig(BaseModel):
     parameters: ChatModelParameters | Callable[[ChatModelParameters], ChatModelParameters] | None = None
 
 
-class ChatModelStructureInput(BaseModel):
+class ChatModelStructureInput(ChatModelParameters):
     input_schema: type[T] = Field(..., alias="schema")
     messages: list[InstanceOf[Message]] = Field(..., min_length=1)
     abort_signal: AbortSignal | None = None


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review and complete the sections below.
-->

### Which issue(s) does this pull-request address?

<!--
Please include a link to an issue in the tracker.  The issue describes the problem to be solved.  If there is no issue raised for this PR then either raise one with a summary and description of the problem or add a summary and description of the problem here
-->

Closes: #453 

### Description

this PR updates chat models to include/make use of the `parameters` which can be passed in via `ChatModel.config`. in addition, the default for `temperature` is set to `0`

### Checklist

<!-- For completed items, change [ ] to [x]. -->

- [x] I have read the [contributor guide](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have [signed off](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-dco) on my commit
- [x] Linting passes: `poe lint --fix`
- [x] Formatting is applied: `poe format --fix`
- [x] Unit tests pass: `poe test --type unit`
- [ ] E2E tests pass: `poe test --type e2e`
- [ ] Tests are included <!-- Bug fixes and new features should include tests -->
- [ ] Documentation is changed or added
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
