### PR TITLE
fix: emitter required for tools

### DIFF
--- a/python/beeai_framework/tools/mcp_tools.py
+++ b/python/beeai_framework/tools/mcp_tools.py
@@ -63,11 +63,6 @@ class MCPTool(Tool[MCPToolOutput]):
         self._name = tool.name
         self._description = tool.description or "No available description, use the tool based on its name and schema."
 
-        self._emitter = Emitter.root().child(
-            namespace=["tool", "mcp", self._name],
-            creator=self,
-        )
-
     @property
     def name(self) -> str:
         return self._name
@@ -79,9 +74,11 @@ class MCPTool(Tool[MCPToolOutput]):
     def input_schema(self) -> str:
         return self._tool.inputSchema
 
-    @property
-    def emitter(self) -> Emitter:
-        return self._emitter
+    def create_emitter(self) -> Emitter:
+        return Emitter.root().child(
+            namespace=["tool", "mcp", self.name],
+            creator=self,
+        )
 
     async def _run(self, input_data: Any, options: dict | None = None) -> MCPToolOutput:
         """Execute the tool with given input."""

--- a/python/beeai_framework/tools/mcp_tools.py
+++ b/python/beeai_framework/tools/mcp_tools.py
@@ -74,7 +74,7 @@ class MCPTool(Tool[MCPToolOutput]):
     def input_schema(self) -> str:
         return self._tool.inputSchema
 
-    def create_emitter(self) -> Emitter:
+    def _create_emitter(self) -> Emitter:
         return Emitter.root().child(
             namespace=["tool", "mcp", self.name],
             creator=self,

--- a/python/beeai_framework/tools/mcp_tools.py
+++ b/python/beeai_framework/tools/mcp_tools.py
@@ -63,7 +63,7 @@ class MCPTool(Tool[MCPToolOutput]):
         self._name = tool.name
         self._description = tool.description or "No available description, use the tool based on its name and schema."
 
-        self.emitter = Emitter.root().child(
+        self._emitter = Emitter.root().child(
             namespace=["tool", "mcp", self._name],
             creator=self,
         )
@@ -78,6 +78,10 @@ class MCPTool(Tool[MCPToolOutput]):
 
     def input_schema(self) -> str:
         return self._tool.inputSchema
+
+    @property
+    def emitter(self) -> Emitter:
+        return self._emitter
 
     async def _run(self, input_data: Any, options: dict | None = None) -> MCPToolOutput:
         """Execute the tool with given input."""

--- a/python/beeai_framework/tools/search/base.py
+++ b/python/beeai_framework/tools/search/base.py
@@ -37,4 +37,4 @@ class SearchToolOutput(ToolOutput):
         return len(self.results) == 0
 
     def sources(self) -> list[str]:
-        return {result.url for result in self.results}
+        return [result.url for result in self.results]

--- a/python/beeai_framework/tools/search/duckduckgo.py
+++ b/python/beeai_framework/tools/search/duckduckgo.py
@@ -54,10 +54,14 @@ class DuckDuckGoSearchTool(Tool[DuckDuckGoSearchToolInput]):
         super().__init__()
         self.max_results = max_results
         self.safe_search = safe_search
-        self.emitter = Emitter.root().child(
+        self._emitter = Emitter.root().child(
             namespace=["tool", "search", "duckduckgo"],
             creator=self,
         )
+
+    @property
+    def emitter(self) -> Emitter:
+        return self._emitter
 
     async def _run(self, input: DuckDuckGoSearchToolInput, _: Any | None = None) -> DuckDuckGoSearchToolOutput:
         try:

--- a/python/beeai_framework/tools/search/duckduckgo.py
+++ b/python/beeai_framework/tools/search/duckduckgo.py
@@ -54,14 +54,12 @@ class DuckDuckGoSearchTool(Tool[DuckDuckGoSearchToolInput]):
         super().__init__()
         self.max_results = max_results
         self.safe_search = safe_search
-        self._emitter = Emitter.root().child(
+
+    def create_emitter(self) -> Emitter:
+        return Emitter.root().child(
             namespace=["tool", "search", "duckduckgo"],
             creator=self,
         )
-
-    @property
-    def emitter(self) -> Emitter:
-        return self._emitter
 
     async def _run(self, input: DuckDuckGoSearchToolInput, _: Any | None = None) -> DuckDuckGoSearchToolOutput:
         try:

--- a/python/beeai_framework/tools/search/duckduckgo.py
+++ b/python/beeai_framework/tools/search/duckduckgo.py
@@ -55,7 +55,7 @@ class DuckDuckGoSearchTool(Tool[DuckDuckGoSearchToolInput]):
         self.max_results = max_results
         self.safe_search = safe_search
 
-    def create_emitter(self) -> Emitter:
+    def _create_emitter(self) -> Emitter:
         return Emitter.root().child(
             namespace=["tool", "search", "duckduckgo"],
             creator=self,

--- a/python/beeai_framework/tools/search/wikipedia.py
+++ b/python/beeai_framework/tools/search/wikipedia.py
@@ -48,16 +48,11 @@ class WikipediaTool(Tool[WikipediaToolInput]):
         user_agent="beeai-framework https://github.com/i-am-bee/beeai-framework", language="en"
     )
 
-    def __init__(self, options: dict[str, Any] | None = None) -> None:
-        super().__init__(options)
-        self._emitter = Emitter.root().child(
+    def create_emitter(self) -> Emitter:
+        return Emitter.root().child(
             namespace=["tool", "search", "wikipedia"],
             creator=self,
         )
-
-    @property
-    def emitter(self) -> Emitter:
-        return self._emitter
 
     def get_section_titles(self, sections: wikipediaapi.WikipediaPage.sections) -> str:
         titles = []

--- a/python/beeai_framework/tools/search/wikipedia.py
+++ b/python/beeai_framework/tools/search/wikipedia.py
@@ -50,10 +50,14 @@ class WikipediaTool(Tool[WikipediaToolInput]):
 
     def __init__(self, options: dict[str, Any] | None = None) -> None:
         super().__init__(options)
-        self.emitter = Emitter.root().child(
+        self._emitter = Emitter.root().child(
             namespace=["tool", "search", "wikipedia"],
             creator=self,
         )
+
+    @property
+    def emitter(self) -> Emitter:
+        return self._emitter
 
     def get_section_titles(self, sections: wikipediaapi.WikipediaPage.sections) -> str:
         titles = []

--- a/python/beeai_framework/tools/search/wikipedia.py
+++ b/python/beeai_framework/tools/search/wikipedia.py
@@ -48,7 +48,7 @@ class WikipediaTool(Tool[WikipediaToolInput]):
         user_agent="beeai-framework https://github.com/i-am-bee/beeai-framework", language="en"
     )
 
-    def create_emitter(self) -> Emitter:
+    def _create_emitter(self) -> Emitter:
         return Emitter.root().child(
             namespace=["tool", "search", "wikipedia"],
             creator=self,

--- a/python/beeai_framework/tools/weather/openmeteo.py
+++ b/python/beeai_framework/tools/weather/openmeteo.py
@@ -52,12 +52,16 @@ class OpenMeteoTool(Tool[OpenMeteoToolInput]):
 
     def __init__(self, options: dict[str, Any] | None = None) -> None:
         super().__init__(options)
-        self.emitter = Emitter.root().child(
+        self._emitter = Emitter.root().child(
             namespace=["tool", "weather", "openmeteo"],
             creator=self,
         )
 
-    def _geocode(self, input: OpenMeteoToolInput) -> dict[str, Any]:
+    @property
+    def emitter(self) -> Emitter:
+        return self._emitter
+
+    def _geocode(self, input: OpenMeteoToolInput) -> dict[str, str]:
         params = {"format": "json", "count": 1}
         if input.location_name:
             params["name"] = input.location_name
@@ -90,8 +94,8 @@ class OpenMeteoTool(Tool[OpenMeteoToolInput]):
         }
 
         geocode = self._geocode(input)
-        params["latitude"] = geocode.get("latitude")
-        params["longitude"] = geocode.get("longitude")
+        params["latitude"] = geocode.get("latitude") or ""
+        params["longitude"] = geocode.get("longitude") or ""
 
         Dates = namedtuple("Dates", ["start_date", "end_date"])
 

--- a/python/beeai_framework/tools/weather/openmeteo.py
+++ b/python/beeai_framework/tools/weather/openmeteo.py
@@ -53,7 +53,7 @@ class OpenMeteoTool(Tool[OpenMeteoToolInput]):
     def __init__(self, options: dict[str, Any] | None = None) -> None:
         super().__init__(options)
 
-    def create_emitter(self) -> Emitter:
+    def _create_emitter(self) -> Emitter:
         return Emitter.root().child(
             namespace=["tool", "weather", "openmeteo"],
             creator=self,

--- a/python/beeai_framework/tools/weather/openmeteo.py
+++ b/python/beeai_framework/tools/weather/openmeteo.py
@@ -52,14 +52,12 @@ class OpenMeteoTool(Tool[OpenMeteoToolInput]):
 
     def __init__(self, options: dict[str, Any] | None = None) -> None:
         super().__init__(options)
-        self._emitter = Emitter.root().child(
+
+    def create_emitter(self) -> Emitter:
+        return Emitter.root().child(
             namespace=["tool", "weather", "openmeteo"],
             creator=self,
         )
-
-    @property
-    def emitter(self) -> Emitter:
-        return self._emitter
 
     def _geocode(self, input: OpenMeteoToolInput) -> dict[str, str]:
         params = {"format": "json", "count": 1}
@@ -94,8 +92,8 @@ class OpenMeteoTool(Tool[OpenMeteoToolInput]):
         }
 
         geocode = self._geocode(input)
-        params["latitude"] = geocode.get("latitude") or ""
-        params["longitude"] = geocode.get("longitude") or ""
+        params["latitude"] = geocode.get("latitude", "")
+        params["longitude"] = geocode.get("longitude", "")
 
         Dates = namedtuple("Dates", ["start_date", "end_date"])
 

--- a/python/docs/tools.md
+++ b/python/docs/tools.md
@@ -374,7 +374,7 @@ class RiddleTool(Tool[RiddleToolInput]):
     def __init__(self, options: dict[str, Any] | None = None) -> None:
         super().__init__(options)
 
-    def create_emitter(self) -> Emitter:
+    def _create_emitter(self) -> Emitter:
         return Emitter.root().child(
             namespace=["tool", "example", "riddle"],
             creator=self,
@@ -451,7 +451,7 @@ class OpenLibraryTool(Tool[OpenLibraryToolInput]):
     def __init__(self, options: dict[str, Any] | None = None) -> None:
         super().__init__(options)
 
-    def create_emitter(self) -> Emitter:
+    def _create_emitter(self) -> Emitter:
         return Emitter.root().child(
             namespace=["tool", "example", "openlibrary"],
             creator=self,

--- a/python/docs/tools.md
+++ b/python/docs/tools.md
@@ -373,14 +373,12 @@ class RiddleTool(Tool[RiddleToolInput]):
 
     def __init__(self, options: dict[str, Any] | None = None) -> None:
         super().__init__(options)
-        self._emitter = Emitter.root().child(
+
+    def create_emitter(self) -> Emitter:
+        return Emitter.root().child(
             namespace=["tool", "example", "riddle"],
             creator=self,
         )
-
-    @property
-    def emitter(self) -> Emitter:
-        return self._emitter
 
     async def _run(self, input: RiddleToolInput, _: Any | None = None) -> StringToolOutput:
         index = input.riddle_number % (len(self.data))
@@ -452,14 +450,12 @@ class OpenLibraryTool(Tool[OpenLibraryToolInput]):
 
     def __init__(self, options: dict[str, Any] | None = None) -> None:
         super().__init__(options)
-        self._emitter = Emitter.root().child(
+
+    def create_emitter(self) -> Emitter:
+        return Emitter.root().child(
             namespace=["tool", "example", "openlibrary"],
             creator=self,
         )
-
-    @property
-    def emitter(self) -> Emitter:
-        return self._emitter
 
     async def _run(self, tool_input: OpenLibraryToolInput, _: Any | None = None) -> OpenLibraryToolResult:
         key = ""
@@ -484,9 +480,9 @@ class OpenLibraryTool(Tool[OpenLibraryToolInput]):
             json_output = response.json()[f"{key}:{value}"]
 
         return OpenLibraryToolResult(
-            preview_url=json_output.get("preview_url") or "",
-            info_url=json_output.get("info_url") or "",
-            bib_key=json_output.get("bib_key") or "",
+            preview_url=json_output.get("preview_url", ""),
+            info_url=json_output.get("info_url", ""),
+            bib_key=json_output.get("bib_key", ""),
         )
 
 

--- a/python/examples/notebooks/agents.ipynb
+++ b/python/examples/notebooks/agents.ipynb
@@ -39,9 +39,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Agent(thought) 🤖 :  The user is asking for the chemical components of a water molecule. I'll provide this information concisely as the Final Answer.\n",
+      "Agent(thought) 🤖 :  The user is asking for the chemical elements that compose a water molecule. A water molecule (H2O) is composed of two hydrogen atoms and one oxygen atom.\n",
       "\n",
-      "Agent(final_answer) 🤖 :  A water molecule consists of two hydrogen atoms and one oxygen atom, represented as H2O.\n"
+      "Agent(final_answer) 🤖 :  A water molecule consists of two hydrogen atoms and one oxygen atom.\n"
      ]
     }
    ],
@@ -118,10 +118,10 @@
       "\n",
       "Agent(tool_name) 🤖 :  OpenMeteoTool\n",
       "Agent(tool_input) 🤖 :  {'location_name': 'London', 'temperature_unit': 'celsius'}\n",
-      "Agent(tool_output) 🤖 :  {\"latitude\": 51.5, \"longitude\": -0.120000124, \"generationtime_ms\": 0.048160552978515625, \"utc_offset_seconds\": 0, \"timezone\": \"GMT\", \"timezone_abbreviation\": \"GMT\", \"elevation\": 23.0, \"current_units\": {\"time\": \"iso8601\", \"interval\": \"seconds\", \"temperature_2m\": \"\\u00b0C\", \"rain\": \"mm\", \"relative_humidity_2m\": \"%\", \"wind_speed_10m\": \"km/h\"}, \"current\": {\"time\": \"2025-03-04T19:00\", \"interval\": 900, \"temperature_2m\": 10.1, \"rain\": 0.0, \"relative_humidity_2m\": 45, \"wind_speed_10m\": 6.5}, \"daily_units\": {\"time\": \"iso8601\", \"temperature_2m_max\": \"\\u00b0C\", \"temperature_2m_min\": \"\\u00b0C\", \"rain_sum\": \"mm\"}, \"daily\": {\"time\": [\"2025-03-04\"], \"temperature_2m_max\": [12.6], \"temperature_2m_min\": [-0.4], \"rain_sum\": [0.0]}}\n",
-      "Agent(thought) 🤖 :  I have successfully retrieved the current weather information for London with temperature, rain, relative humidity, and wind speed.\n",
+      "Agent(tool_output) 🤖 :  {\"latitude\": 51.5, \"longitude\": -0.120000124, \"generationtime_ms\": 0.07617473602294922, \"utc_offset_seconds\": 0, \"timezone\": \"GMT\", \"timezone_abbreviation\": \"GMT\", \"elevation\": 23.0, \"current_units\": {\"time\": \"iso8601\", \"interval\": \"seconds\", \"temperature_2m\": \"\\u00b0C\", \"rain\": \"mm\", \"relative_humidity_2m\": \"%\", \"wind_speed_10m\": \"km/h\"}, \"current\": {\"time\": \"2025-03-04T22:15\", \"interval\": 900, \"temperature_2m\": 6.8, \"rain\": 0.0, \"relative_humidity_2m\": 66, \"wind_speed_10m\": 5.0}, \"daily_units\": {\"time\": \"iso8601\", \"temperature_2m_max\": \"\\u00b0C\", \"temperature_2m_min\": \"\\u00b0C\", \"rain_sum\": \"mm\"}, \"daily\": {\"time\": [\"2025-03-04\"], \"temperature_2m_max\": [12.6], \"temperature_2m_min\": [-0.4], \"rain_sum\": [0.0]}}\n",
+      "Agent(thought) 🤖 :  I have obtained the current weather information for London using the OpenMeteoTool. The current temperature in London is 6.8°C, with a relative humidity of 66%, wind speeds at 5 km/h, and no rainfall recorded over the past hour.\n",
       "\n",
-      "Agent(final_answer) 🤖 :  The current weather in London is 10.1°C with no rainfall, a relative humidity of 45%, and a wind speed of 6.5 km/h.\n"
+      "Agent(final_answer) 🤖 :  The current weather in London is 6.8°C with a relative humidity of 66%, light winds at 5 km/h, and no rainfall.\n"
      ]
     }
    ],
@@ -159,9 +159,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Agent(thought) 🤖 :  I know how to perform a search on Wikipedia.\n",
+      "Agent(thought) 🤖 :  The user is asking about the current president of the European Commission. I should use the Wikipedia function to find this information.\n",
       "Agent(tool_name) 🤖 :  Wikipedia\n",
-      "Agent(tool_input) 🤖 :  {'query': 'Current President of the European Commission'}\n",
+      "Agent(tool_input) 🤖 :  {'query': 'current president of the European Commission'}\n",
       "Agent(tool_output) 🤖 :  Page: Vice-President of the European Commission\n",
       "Summary: A Vice-President of the European Commission is a member of the European Commission who leads the commission's work in particular focus areas in which multiple European Commissioners participate.\n",
       "Currently, the European Commission has a total of six Vice-Presidents: five Executive-Vice Presidents, and the High Representative who is ex officio one of the Vice-Presidents as well.\n",
@@ -174,8 +174,8 @@
       "Summary: This is a list of presidents of the institutions of the European Union (EU). Each of the institutions is headed by a president or a presidency, with some being more prominent than others. Both the President of the European Council and the President of the European Commission are sometimes wrongly termed the President of the European Union. Most go back to 1957 but others, such as the President of the Auditors Court or of the European Central Bank, have been created recently. Currently (2025), the President of the European Commission is Ursula von der Leyen and the President of the European Council is António Costa.\n",
       "\n",
       "\n",
-      "Agent(thought) 🤖 :  The information provided on Wikipedia indicates that there are multiple vice-presidents and one president in the European Commission. Based on my research, Ursula von der Leyen currently serves as the President of the European Commission.\n",
-      "Agent(final_answer) 🤖 :  Ursula von der Leyen is the current president of the European Commission.\n"
+      "Agent(thought) 🤖 :  I found information about the Vice-Presidents and the current President of the European Commission, Ursula von der Leyen. However, there are also six Executive Vice-Presidents. The user might be asking for a single individual in the role. I need to consolidate this information into a clear answer.\n",
+      "Agent(final_answer) 🤖 :  The current president of the European Commission is Ursula von der Leyen. There are also six Executive Vice-Presidents and the High Representative who is ex officio one of the Vice-Presidents as well. All members, including the President, represent the general interest of the EU as a whole rather than their home state.\n"
      ]
     }
    ],
@@ -206,7 +206,7 @@
     "        super().__init__()\n",
     "        self._wikipedia = WikipediaQueryRun(api_wrapper=WikipediaAPIWrapper())\n",
     "\n",
-    "    def create_emitter(self) -> Emitter:\n",
+    "    def _create_emitter(self) -> Emitter:\n",
     "        return Emitter.root().child(\n",
     "            namespace=[\"tool\", \"search\", \"langchain_wikipedia\"],\n",
     "            creator=self,\n",
@@ -237,14 +237,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Agent(thought) 🤖 :  I can find this information using the langchain_wikipedia_tool.\n",
+      "Agent(thought) 🤖 :  The user wants to know about the longest living vertebrate. I will use the 'langchain_wikipedia_tool' to search for this information on Wikipedia.\n",
       "Agent(tool_name) 🤖 :  langchain_wikipedia_tool\n",
       "Agent(tool_input) 🤖 :  {'query': 'longest living vertebrate'}\n",
       "Agent(tool_output) 🤖 :  Page: Hákarl\n",
@@ -266,8 +266,8 @@
       "Greenland sharks have the longest lifespan of any known vertebrate, estimated to be between 250 and 500 years. They are among the largest extant species of shark, reaching a maximum confirmed length of 6.4 m (21 ft) long and weighing over 1,000 kg (2,200 lb). They reach sexual maturity at about 150 years of age, and their pups are born alive after an estimated gestation period of 8 to 18 years.\n",
       "The shark is a generalist feeder, consuming a variety of available foods, including carrion.\n",
       "Greenland shark \n",
-      "Agent(thought) 🤖 :  According to the information above, the Greenland shark has been identified as the longest living vertebrate, with an estimated lifespan between 250 and 500 years.\n",
-      "Agent(final_answer) 🤖 :  The Greenland shark is the longest living vertebrate, with an estimated lifespan of between 250 to 500 years.\n"
+      "Agent(thought) 🤖 :  I have retrieved information from Wikipedia. The longest-living vertebrate is the Greenland Shark with an estimated lifespan of 250 to 500 years.\n",
+      "Agent(final_answer) 🤖 :  The longest living vertebrate is the Greenland Shark, which can live for an estimated period of 250 to 500 years.\n"
      ]
     }
    ],

--- a/python/examples/notebooks/agents.ipynb
+++ b/python/examples/notebooks/agents.ipynb
@@ -39,8 +39,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Agent(thought) 🤖 :  The user wants to know the chemical elements that form a water molecule. This information can be retrieved from general knowledge.\n",
-      "Agent(final_answer) 🤖 :  A water molecule is composed of two hydrogen atoms and one oxygen atom, represented chemically as H2O.\n"
+      "Agent(thought) 🤖 :  The user wants to know the composition of a water molecule in terms of its constituent chemical elements. A water molecule (H2O) consists of two hydrogen atoms (H) and one oxygen atom (O).\n",
+      "\n",
+      "Agent(final_answer) 🤖 :  A water molecule is composed of two hydrogen atoms and one oxygen atom, making it a compound.\n"
      ]
     }
    ],
@@ -113,12 +114,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Agent(thought) 🤖 :  The user wants to know the current weather in London. I will use the OpenMeteoTool with location_name as \"London\" and temperature_unit set to \"celsius\".\n",
+      "Agent(thought) 🤖 :  The user wants to know the current weather conditions in London. I need to use the OpenMeteoTool for this purpose, specifying \"London\" as the location_name and \"celsius\" as the temperature_unit.\n",
+      "\n",
       "Agent(tool_name) 🤖 :  OpenMeteoTool\n",
-      "Agent(tool_input) 🤖 :  {\"location_name\": \"London\", \"temperature_unit\": \"celsius\"}\n",
-      "Agent(tool_output) 🤖 :  {\"latitude\": 51.5, \"longitude\": -0.120000124, \"generationtime_ms\": 0.06175041198730469, \"utc_offset_seconds\": 0, \"timezone\": \"GMT\", \"timezone_abbreviation\": \"GMT\", \"elevation\": 23.0, \"current_units\": {\"time\": \"iso8601\", \"interval\": \"seconds\", \"temperature_2m\": \"\\u00b0C\", \"rain\": \"mm\", \"relative_humidity_2m\": \"%\", \"wind_speed_10m\": \"km/h\"}, \"current\": {\"time\": \"2025-02-21T17:30\", \"interval\": 900, \"temperature_2m\": 13.4, \"rain\": 0.1, \"relative_humidity_2m\": 77, \"wind_speed_10m\": 17.7}, \"daily_units\": {\"time\": \"iso8601\", \"temperature_2m_max\": \"\\u00b0C\", \"temperature_2m_min\": \"\\u00b0C\", \"rain_sum\": \"mm\"}, \"daily\": {\"time\": [\"2025-02-21\"], \"temperature_2m_max\": [14.9], \"temperature_2m_min\": [11.8], \"rain_sum\": [2.8]}}\n",
-      "Agent(thought) 🤖 :  I have retrieved the current weather information for London. The temperature is 13.4 degrees Celsius with light rain and a wind speed of 17.7 km/h.\n",
-      "Agent(final_answer) 🤖 :  The current weather in London is 13.4 degrees Celsius with light rain and a wind speed of 17.7 km/h.\n"
+      "Agent(tool_input) 🤖 :  {'location_name': 'London', 'start_date': '2025-03-04 00:00:00 (UTC)', 'end_date': '2025-03-04 12:00:00 (UTC)', 'temperature_unit': 'celsius'}\n",
+      "Agent(tool_output) 🤖 :  {\"latitude\": 51.5, \"longitude\": -0.120000124, \"generationtime_ms\": 0.05459785461425781, \"utc_offset_seconds\": 0, \"timezone\": \"GMT\", \"timezone_abbreviation\": \"GMT\", \"elevation\": 23.0, \"current_units\": {\"time\": \"iso8601\", \"interval\": \"seconds\", \"temperature_2m\": \"\\u00b0C\", \"rain\": \"mm\", \"relative_humidity_2m\": \"%\", \"wind_speed_10m\": \"km/h\"}, \"current\": {\"time\": \"2025-03-04T02:30\", \"interval\": 900, \"temperature_2m\": 4.2, \"rain\": 0.0, \"relative_humidity_2m\": 82, \"wind_speed_10m\": 3.1}, \"daily_units\": {\"time\": \"iso8601\", \"temperature_2m_max\": \"\\u00b0C\", \"temperature_2m_min\": \"\\u00b0C\", \"rain_sum\": \"mm\"}, \"daily\": {\"time\": [\"2025-03-04\"], \"temperature_2m_max\": [12.7], \"temperature_2m_min\": [2.5], \"rain_sum\": [0.0]}}\n",
+      "Agent(thought) 🤖 :  The weather in London is currently 4.2 degrees Celsius with no rain, wind speed around 3.1 km/h, and moderate humidity (around 82%). Based on the retrieved information, it seems that the OpenMeteoTool provided detailed current weather conditions as well as forecasts for the next day.\n",
+      "\n",
+      "Agent(final_answer) 🤖 :  The current weather in London is 4.2 degrees Celsius, with no rain, wind speed around 3.1 km/h, and moderate humidity (around 82%).\n"
      ]
     }
    ],
@@ -156,20 +159,23 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Agent(thought) 🤖 :  I can find this information using the Wikipedia tool.\n",
+      "Agent(thought) 🤖 :  I don't have this information readily available. I need to use the Wikipedia tool to find out.\n",
       "Agent(tool_name) 🤖 :  Wikipedia\n",
-      "Agent(tool_input) 🤖 :  {\"query\": \"current president of the European Commission\"}\n",
+      "Agent(tool_input) 🤖 :  {'query': 'Current President of the European Commission'}\n",
       "Agent(tool_output) 🤖 :  Page: Vice-President of the European Commission\n",
       "Summary: A Vice-President of the European Commission is a member of the European Commission who leads the commission's work in particular focus areas in which multiple European Commissioners participate.\n",
       "Currently, the European Commission has a total of six Vice-Presidents: five Executive-Vice Presidents, and the High Representative who is ex officio one of the Vice-Presidents as well.\n",
       "\n",
-      "Page: List of presidents of the institutions of the European Union\n",
-      "Summary: This is a list of presidents of the institutions of the European Union (EU). Each of the institutions is headed by a president or a presidency, with some being more prominent than others. Both the President of the European Council and the President of the European Commission are sometimes wrongly termed the President of the European Union.  Most go back to 1957 but others, such as the Presidents of the Auditors or the European Central Bank have been created recently. Currently (2025), the President of the European Commission is Ursula von der Leyen and the President of the European Council is António Costa.\n",
-      "\n",
       "Page: European Commission\n",
       "Summary: The European Commission (EC) is the primary executive arm of the European Union (EU). It operates as a cabinet government, with a number of members of the Commission (directorial system, informally known as \"Commissioners\") corresponding to two thirds of the number of member states, unless the European Council, acting unanimously, decides to alter this number. The current number of Commissioners is 27, including the President. It includes an administrative body of about 32,000 European civil servants. The commission is divided into departments known as Directorates-General (DGs) that can be likened to departments or ministries each headed by a Director-General who is responsible to a Commissioner.\n",
       "Currently, there is one member per member state, but members are bound by their oath of office to represent the general interest of the EU as a whole rather than their home state. The Commission President (currently Ursula von der Leyen) is proposed by the European Council (the 27 heads of state/governments) and elected by the European Parliament. The Council of the European Union then nominates the other members of the Commission in agreement with the nominated President, and the 27 members as a team are then subject to a vote of approval by the European Parliament. The current Commission is the Von der Leyen Commission II, which took office in December 2024, following the European Parliament elections in June of the same year.\n",
-      "Agent(thought) 🤖 :  Based on the Wikipedia search results, Ursula von der Leyen is the current president of the European Commission.\n",
+      "\n",
+      "Page: List of presidents of the institutions of the European Union\n",
+      "Summary: This is a list of presidents of the institutions of the European Union (EU). Each of the institutions is headed by a president or a presidency, with some being more prominent than others. Both the President of the European Council and the President of the European Commission are sometimes wrongly termed the President of the European Union. Most go back to 1957 but others, such as the President of the Auditors Court or of the European Central Bank, have been created recently. Currently (2025), the President of the European Commission is Ursula von der Leyen and the President of the European Council is António Costa.\n",
+      "\n",
+      "\n",
+      "Agent(thought) 🤖 :  The Wikipedia search indicates that there are two executive Vice-Presidents in the European Commission, but the position of \"President\" corresponds to Ursula von der Leyen. She holds the role of President, and alongside her, there are five other Executive Vice-Presidents leading specific focus areas within the commission's work.\n",
+      "\n",
       "Agent(final_answer) 🤖 :  The current President of the European Commission is Ursula von der Leyen.\n"
      ]
     }
@@ -199,13 +205,20 @@
     "\n",
     "    def __init__(self) -> None:\n",
     "        super().__init__()\n",
-    "        wikipedia = WikipediaAPIWrapper()\n",
-    "        self.wikipedia = WikipediaQueryRun(api_wrapper=wikipedia)\n",
+    "        self._wikipedia = WikipediaQueryRun(api_wrapper=WikipediaAPIWrapper())\n",
+    "        self._emitter = Emitter.root().child(\n",
+    "            namespace=[\"tool\", \"search\", \"langchain_wikipedia\"],\n",
+    "            creator=self,\n",
+    "        )\n",
     "\n",
-    "    def _run(self, input: LangChainWikipediaToolInput, _: Any | None = None) -> None:\n",
+    "    @property\n",
+    "    def emitter(self) -> Emitter:\n",
+    "        return self._emitter\n",
+    "\n",
+    "    async def _run(self, input: LangChainWikipediaToolInput, _: Any | None = None) -> StringToolOutput:\n",
     "        query = input.query\n",
     "        try:\n",
-    "            result = self.wikipedia.run(query)\n",
+    "            result = self._wikipedia.run(query)\n",
     "            return StringToolOutput(result=result)\n",
     "        except Exception as e:\n",
     "            print(f\"Wikipedia search error: {e!s}\")\n",
@@ -234,12 +247,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Agent(thought) 🤖 :  The user wants to know about the longest living vertebrate. I can use the Wikipedia tool to search for this information.\n",
+      "Agent(thought) 🤖 :  I need to use a fact-checking tool to answer this question accurately.\n",
       "Agent(tool_name) 🤖 :  langchain_wikipedia_tool\n",
-      "Agent(tool_input) 🤖 :  {\"query\": \"Longest living vertebrate\"}\n",
+      "Agent(tool_input) 🤖 :  {'query': 'longest living vertebrate'}\n",
       "Agent(tool_output) 🤖 :  Page: Hákarl\n",
       "Summary: Hákarl (an abbreviation of kæstur hákarl [ˈcʰaistʏr ˈhauːˌkʰa(r)tl̥]), referred to as fermented shark in English, is a national dish of Iceland consisting of Greenland shark or other sleeper shark that has been cured with a particular fermentation process and hung to dry for four to five months. It has a strong ammonia-rich smell and fishy taste, making hákarl an acquired taste.\n",
       "Fermented shark is readily available in Icelandic stores and may be eaten year-round, but is most often served as part of a Þorramatur, a selection of traditional Icelandic food served at the midwinter festival þorrablót.\n",
+      "\n",
+      "Page: Greenland shark\n",
+      "Summary: The Greenland shark (Somniosus microcephalus), also known as the gurry shark or grey shark, is a large shark of the family Somniosidae (\"sleeper sharks\"), closely related to the Pacific and southern sleeper sharks. Inhabiting the North Atlantic and Arctic Oceans, they are notable for their exceptional longevity, although they are poorly studied due to the depth and remoteness of their natural habitat.\n",
+      "Greenland sharks have the longest lifespan of any known vertebrate, estimated to be between 250 and 500 years. They are among the largest extant species of shark, reaching a maximum confirmed length of 6.4 m (21 ft) long and weighing over 1,000 kg (2,200 lb). They reach sexual maturity at about 150 years of age, and their pups are born alive after an estimated gestation period of 8 to 18 years.\n",
+      "The shark is a generalist feeder, consuming a variety of available foods, including carrion.\n",
+      "Greenland shark meat is toxic to mammals due to its high levels of trimethylamine N-oxide, although a treated form of it is eaten in Iceland as a delicacy known as kæstur hákarl. Because they live deep in remote parts of the northern oceans, Greenland sharks are not considered a threat to humans. A possible attack occurred in August 1936 on two British fisherman, but the species was never identified.\n",
       "\n",
       "Page: List of longest-living organisms\n",
       "Summary: This is a list of the longest-living biological organisms: the individual(s) (or in some instances, clones) of a species with the longest natural maximum life spans. For a given species, such a designation may include:\n",
@@ -247,17 +266,10 @@
       "The oldest known individual(s) that are currently alive, with verified ages.\n",
       "Verified individual record holders, such as the longest-lived human, Jeanne Calment, or the longest-lived domestic cat, Creme Puff.\n",
       "The definition of \"longest-living\" used in this article considers only the observed or estimated length of an individual organism's natural lifespan – that is, the duration of time between its birth or conception, or the earliest emergence of its identity as an individual organism, and its death – and does not consider other conceivable interpretations of \"longest-living\", such as the length of time between the earliest appearance of a species in the fossil record and the present (the historical \"age\" of the species as a whole), the time between a species' first speciation and its extinction (the phylogenetic \"lifespan\" of the species), or the range of possible lifespans of a species' individuals. This list includes long-lived organisms that are currently still alive as well as those that are dead.\n",
-      "Determining the length of an organism's natural lifespan is complicated by many problems of definition and interpretation, as well as by practical difficulties in reliably measuring age, particularly for extremely old organisms and for those that reproduce by asexual cloning. In many cases the ages listed below are estimates based on observed present-day growth rates, which may differ significantly from the growth rates experienced thousands of years ago. Identifying the longest-living organisms also depends on defining what constitutes an \"individual\" organism, which can be problematic, since many asexual organisms and clonal colonies defy one or both of the traditional colloquial definitions of individuality (having a distinct genotype and having an independent, physically separate body). Additionally, some organisms maintain the capability to reproduce through very long periods of metabolic dormancy, during which they may not be considered \"alive\" by certain definitions but nonetheless can resume normal metabolism afterward; it is unclear whether the dormant periods should be counted as part of the organism's lifespan.\n",
+      "Determining the length of an organism's natural lifespan is complicated by many problems of definition and interpretation, as well as by practical difficulties in reliably measuring age, particularly for extremely old organisms and for those that reproduce by asexual cloning. In many cases the ages listed below are estimates based on observed present-day growth rates, which may differ significantly from the growth rates experienced thousands of years ago. Identifying the longest-living organisms also depends on defining what constitutes an \"individual\" organism, which can be problematic, since many asexual organisms and clonal colonies defy one or both of the traditional colloquial definitions of individuality (having a distinct genotype and ha\n",
+      "Agent(thought) 🤖 :  I have retrieved information from Wikipedia about the longest living vertebrate. The Greenland shark has the longest lifespan of any known vertebrate, estimated to be between 250 and 500 years.\n",
       "\n",
-      "\n",
-      "\n",
-      "Page: Greenland shark\n",
-      "Summary: The Greenland shark (Somniosus microcephalus), also known as the gurry shark or grey shark, is a large shark of the family Somniosidae (\"sleeper sharks\"), closely related to the Pacific and southern sleeper sharks. Inhabiting the North Atlantic and Arctic Oceans, they are notable for their exceptional longevity, although they are poorly studied due to the depth and remoteness of their natural habitat.\n",
-      "Greenland sharks have the longest lifespan of any known vertebrate, estimated to be between 250 and 500 years. They are among the largest extant species of shark, reaching a maximum confirmed length of 6.4 m (21 ft) long and weighing over 1,000 kg (2,200 lb). They reach sexual maturity at about 150 years of age, and their pups are born alive after an estimated gestation period of 8 to 18 years.\n",
-      "The shark is a generalist feeder, consuming a variety of available foods, including carrion.\n",
-      "Greenland shark \n",
-      "Agent(thought) 🤖 :  The Wikipedia page \"List of longest-living organisms\" mentions that the Greenland shark has an estimated lifespan between 250 and 500 years, making it the longest living vertebrate known to science.\n",
-      "Agent(final_answer) 🤖 :  The Greenland shark is the longest living vertebrate with an estimated lifespan of 250 to 500 years.\n"
+      "Agent(final_answer) 🤖 :  The longest living vertebrate is the Greenland shark with an estimated lifespan of 250 to 500 years.\n"
      ]
     }
    ],
@@ -278,7 +290,7 @@
     "    science, technology, people, animal species, mathematics, and other subjects.\n",
     "\n",
     "    Args:\n",
-    "        expression: The topic or question to search for on Wikipedia.\n",
+    "        query: The topic or question to search for on Wikipedia.\n",
     "\n",
     "    Returns:\n",
     "        The information found via searching Wikipedia.\n",
@@ -297,7 +309,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "beeai-framework-IVd76ig_-py3.12",
    "language": "python",
    "name": "python3"
   },

--- a/python/examples/notebooks/agents.ipynb
+++ b/python/examples/notebooks/agents.ipynb
@@ -39,9 +39,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Agent(thought) 🤖 :  The user wants to know the composition of a water molecule in terms of its constituent chemical elements. A water molecule (H2O) consists of two hydrogen atoms (H) and one oxygen atom (O).\n",
+      "Agent(thought) 🤖 :  The user is asking for the chemical components of a water molecule. I'll provide this information concisely as the Final Answer.\n",
       "\n",
-      "Agent(final_answer) 🤖 :  A water molecule is composed of two hydrogen atoms and one oxygen atom, making it a compound.\n"
+      "Agent(final_answer) 🤖 :  A water molecule consists of two hydrogen atoms and one oxygen atom, represented as H2O.\n"
      ]
     }
    ],
@@ -114,14 +114,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Agent(thought) 🤖 :  The user wants to know the current weather conditions in London. I need to use the OpenMeteoTool for this purpose, specifying \"London\" as the location_name and \"celsius\" as the temperature_unit.\n",
+      "Agent(thought) 🤖 :  I need to use the OpenMeteoTool to get the current weather information for London.\n",
       "\n",
       "Agent(tool_name) 🤖 :  OpenMeteoTool\n",
-      "Agent(tool_input) 🤖 :  {'location_name': 'London', 'start_date': '2025-03-04 00:00:00 (UTC)', 'end_date': '2025-03-04 12:00:00 (UTC)', 'temperature_unit': 'celsius'}\n",
-      "Agent(tool_output) 🤖 :  {\"latitude\": 51.5, \"longitude\": -0.120000124, \"generationtime_ms\": 0.05459785461425781, \"utc_offset_seconds\": 0, \"timezone\": \"GMT\", \"timezone_abbreviation\": \"GMT\", \"elevation\": 23.0, \"current_units\": {\"time\": \"iso8601\", \"interval\": \"seconds\", \"temperature_2m\": \"\\u00b0C\", \"rain\": \"mm\", \"relative_humidity_2m\": \"%\", \"wind_speed_10m\": \"km/h\"}, \"current\": {\"time\": \"2025-03-04T02:30\", \"interval\": 900, \"temperature_2m\": 4.2, \"rain\": 0.0, \"relative_humidity_2m\": 82, \"wind_speed_10m\": 3.1}, \"daily_units\": {\"time\": \"iso8601\", \"temperature_2m_max\": \"\\u00b0C\", \"temperature_2m_min\": \"\\u00b0C\", \"rain_sum\": \"mm\"}, \"daily\": {\"time\": [\"2025-03-04\"], \"temperature_2m_max\": [12.7], \"temperature_2m_min\": [2.5], \"rain_sum\": [0.0]}}\n",
-      "Agent(thought) 🤖 :  The weather in London is currently 4.2 degrees Celsius with no rain, wind speed around 3.1 km/h, and moderate humidity (around 82%). Based on the retrieved information, it seems that the OpenMeteoTool provided detailed current weather conditions as well as forecasts for the next day.\n",
+      "Agent(tool_input) 🤖 :  {'location_name': 'London', 'temperature_unit': 'celsius'}\n",
+      "Agent(tool_output) 🤖 :  {\"latitude\": 51.5, \"longitude\": -0.120000124, \"generationtime_ms\": 0.048160552978515625, \"utc_offset_seconds\": 0, \"timezone\": \"GMT\", \"timezone_abbreviation\": \"GMT\", \"elevation\": 23.0, \"current_units\": {\"time\": \"iso8601\", \"interval\": \"seconds\", \"temperature_2m\": \"\\u00b0C\", \"rain\": \"mm\", \"relative_humidity_2m\": \"%\", \"wind_speed_10m\": \"km/h\"}, \"current\": {\"time\": \"2025-03-04T19:00\", \"interval\": 900, \"temperature_2m\": 10.1, \"rain\": 0.0, \"relative_humidity_2m\": 45, \"wind_speed_10m\": 6.5}, \"daily_units\": {\"time\": \"iso8601\", \"temperature_2m_max\": \"\\u00b0C\", \"temperature_2m_min\": \"\\u00b0C\", \"rain_sum\": \"mm\"}, \"daily\": {\"time\": [\"2025-03-04\"], \"temperature_2m_max\": [12.6], \"temperature_2m_min\": [-0.4], \"rain_sum\": [0.0]}}\n",
+      "Agent(thought) 🤖 :  I have successfully retrieved the current weather information for London with temperature, rain, relative humidity, and wind speed.\n",
       "\n",
-      "Agent(final_answer) 🤖 :  The current weather in London is 4.2 degrees Celsius, with no rain, wind speed around 3.1 km/h, and moderate humidity (around 82%).\n"
+      "Agent(final_answer) 🤖 :  The current weather in London is 10.1°C with no rainfall, a relative humidity of 45%, and a wind speed of 6.5 km/h.\n"
      ]
     }
    ],
@@ -159,7 +159,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Agent(thought) 🤖 :  I don't have this information readily available. I need to use the Wikipedia tool to find out.\n",
+      "Agent(thought) 🤖 :  I know how to perform a search on Wikipedia.\n",
       "Agent(tool_name) 🤖 :  Wikipedia\n",
       "Agent(tool_input) 🤖 :  {'query': 'Current President of the European Commission'}\n",
       "Agent(tool_output) 🤖 :  Page: Vice-President of the European Commission\n",
@@ -174,9 +174,8 @@
       "Summary: This is a list of presidents of the institutions of the European Union (EU). Each of the institutions is headed by a president or a presidency, with some being more prominent than others. Both the President of the European Council and the President of the European Commission are sometimes wrongly termed the President of the European Union. Most go back to 1957 but others, such as the President of the Auditors Court or of the European Central Bank, have been created recently. Currently (2025), the President of the European Commission is Ursula von der Leyen and the President of the European Council is António Costa.\n",
       "\n",
       "\n",
-      "Agent(thought) 🤖 :  The Wikipedia search indicates that there are two executive Vice-Presidents in the European Commission, but the position of \"President\" corresponds to Ursula von der Leyen. She holds the role of President, and alongside her, there are five other Executive Vice-Presidents leading specific focus areas within the commission's work.\n",
-      "\n",
-      "Agent(final_answer) 🤖 :  The current President of the European Commission is Ursula von der Leyen.\n"
+      "Agent(thought) 🤖 :  The information provided on Wikipedia indicates that there are multiple vice-presidents and one president in the European Commission. Based on my research, Ursula von der Leyen currently serves as the President of the European Commission.\n",
+      "Agent(final_answer) 🤖 :  Ursula von der Leyen is the current president of the European Commission.\n"
      ]
     }
    ],
@@ -206,14 +205,12 @@
     "    def __init__(self) -> None:\n",
     "        super().__init__()\n",
     "        self._wikipedia = WikipediaQueryRun(api_wrapper=WikipediaAPIWrapper())\n",
-    "        self._emitter = Emitter.root().child(\n",
+    "\n",
+    "    def create_emitter(self) -> Emitter:\n",
+    "        return Emitter.root().child(\n",
     "            namespace=[\"tool\", \"search\", \"langchain_wikipedia\"],\n",
     "            creator=self,\n",
     "        )\n",
-    "\n",
-    "    @property\n",
-    "    def emitter(self) -> Emitter:\n",
-    "        return self._emitter\n",
     "\n",
     "    async def _run(self, input: LangChainWikipediaToolInput, _: Any | None = None) -> StringToolOutput:\n",
     "        query = input.query\n",
@@ -247,18 +244,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Agent(thought) 🤖 :  I need to use a fact-checking tool to answer this question accurately.\n",
+      "Agent(thought) 🤖 :  I can find this information using the langchain_wikipedia_tool.\n",
       "Agent(tool_name) 🤖 :  langchain_wikipedia_tool\n",
       "Agent(tool_input) 🤖 :  {'query': 'longest living vertebrate'}\n",
       "Agent(tool_output) 🤖 :  Page: Hákarl\n",
       "Summary: Hákarl (an abbreviation of kæstur hákarl [ˈcʰaistʏr ˈhauːˌkʰa(r)tl̥]), referred to as fermented shark in English, is a national dish of Iceland consisting of Greenland shark or other sleeper shark that has been cured with a particular fermentation process and hung to dry for four to five months. It has a strong ammonia-rich smell and fishy taste, making hákarl an acquired taste.\n",
       "Fermented shark is readily available in Icelandic stores and may be eaten year-round, but is most often served as part of a Þorramatur, a selection of traditional Icelandic food served at the midwinter festival þorrablót.\n",
-      "\n",
-      "Page: Greenland shark\n",
-      "Summary: The Greenland shark (Somniosus microcephalus), also known as the gurry shark or grey shark, is a large shark of the family Somniosidae (\"sleeper sharks\"), closely related to the Pacific and southern sleeper sharks. Inhabiting the North Atlantic and Arctic Oceans, they are notable for their exceptional longevity, although they are poorly studied due to the depth and remoteness of their natural habitat.\n",
-      "Greenland sharks have the longest lifespan of any known vertebrate, estimated to be between 250 and 500 years. They are among the largest extant species of shark, reaching a maximum confirmed length of 6.4 m (21 ft) long and weighing over 1,000 kg (2,200 lb). They reach sexual maturity at about 150 years of age, and their pups are born alive after an estimated gestation period of 8 to 18 years.\n",
-      "The shark is a generalist feeder, consuming a variety of available foods, including carrion.\n",
-      "Greenland shark meat is toxic to mammals due to its high levels of trimethylamine N-oxide, although a treated form of it is eaten in Iceland as a delicacy known as kæstur hákarl. Because they live deep in remote parts of the northern oceans, Greenland sharks are not considered a threat to humans. A possible attack occurred in August 1936 on two British fisherman, but the species was never identified.\n",
       "\n",
       "Page: List of longest-living organisms\n",
       "Summary: This is a list of the longest-living biological organisms: the individual(s) (or in some instances, clones) of a species with the longest natural maximum life spans. For a given species, such a designation may include:\n",
@@ -266,10 +257,17 @@
       "The oldest known individual(s) that are currently alive, with verified ages.\n",
       "Verified individual record holders, such as the longest-lived human, Jeanne Calment, or the longest-lived domestic cat, Creme Puff.\n",
       "The definition of \"longest-living\" used in this article considers only the observed or estimated length of an individual organism's natural lifespan – that is, the duration of time between its birth or conception, or the earliest emergence of its identity as an individual organism, and its death – and does not consider other conceivable interpretations of \"longest-living\", such as the length of time between the earliest appearance of a species in the fossil record and the present (the historical \"age\" of the species as a whole), the time between a species' first speciation and its extinction (the phylogenetic \"lifespan\" of the species), or the range of possible lifespans of a species' individuals. This list includes long-lived organisms that are currently still alive as well as those that are dead.\n",
-      "Determining the length of an organism's natural lifespan is complicated by many problems of definition and interpretation, as well as by practical difficulties in reliably measuring age, particularly for extremely old organisms and for those that reproduce by asexual cloning. In many cases the ages listed below are estimates based on observed present-day growth rates, which may differ significantly from the growth rates experienced thousands of years ago. Identifying the longest-living organisms also depends on defining what constitutes an \"individual\" organism, which can be problematic, since many asexual organisms and clonal colonies defy one or both of the traditional colloquial definitions of individuality (having a distinct genotype and ha\n",
-      "Agent(thought) 🤖 :  I have retrieved information from Wikipedia about the longest living vertebrate. The Greenland shark has the longest lifespan of any known vertebrate, estimated to be between 250 and 500 years.\n",
+      "Determining the length of an organism's natural lifespan is complicated by many problems of definition and interpretation, as well as by practical difficulties in reliably measuring age, particularly for extremely old organisms and for those that reproduce by asexual cloning. In many cases the ages listed below are estimates based on observed present-day growth rates, which may differ significantly from the growth rates experienced thousands of years ago. Identifying the longest-living organisms also depends on defining what constitutes an \"individual\" organism, which can be problematic, since many asexual organisms and clonal colonies defy one or both of the traditional colloquial definitions of individuality (having a distinct genotype and having an independent, physically separate body). Additionally, some organisms maintain the capability to reproduce through very long periods of metabolic dormancy, during which they may not be considered \"alive\" by certain definitions but nonetheless can resume normal metabolism afterward; it is unclear whether the dormant periods should be counted as part of the organism's lifespan.\n",
       "\n",
-      "Agent(final_answer) 🤖 :  The longest living vertebrate is the Greenland shark with an estimated lifespan of 250 to 500 years.\n"
+      "\n",
+      "\n",
+      "Page: Greenland shark\n",
+      "Summary: The Greenland shark (Somniosus microcephalus), also known as the gurry shark or grey shark, is a large shark of the family Somniosidae (\"sleeper sharks\"), closely related to the Pacific and southern sleeper sharks. Inhabiting the North Atlantic and Arctic Oceans, they are notable for their exceptional longevity, although they are poorly studied due to the depth and remoteness of their natural habitat.\n",
+      "Greenland sharks have the longest lifespan of any known vertebrate, estimated to be between 250 and 500 years. They are among the largest extant species of shark, reaching a maximum confirmed length of 6.4 m (21 ft) long and weighing over 1,000 kg (2,200 lb). They reach sexual maturity at about 150 years of age, and their pups are born alive after an estimated gestation period of 8 to 18 years.\n",
+      "The shark is a generalist feeder, consuming a variety of available foods, including carrion.\n",
+      "Greenland shark \n",
+      "Agent(thought) 🤖 :  According to the information above, the Greenland shark has been identified as the longest living vertebrate, with an estimated lifespan between 250 and 500 years.\n",
+      "Agent(final_answer) 🤖 :  The Greenland shark is the longest living vertebrate, with an estimated lifespan of between 250 to 500 years.\n"
      ]
     }
    ],

--- a/python/examples/tools/custom/base.py
+++ b/python/examples/tools/custom/base.py
@@ -31,14 +31,12 @@ class RiddleTool(Tool[RiddleToolInput]):
 
     def __init__(self, options: dict[str, Any] | None = None) -> None:
         super().__init__(options)
-        self._emitter = Emitter.root().child(
+
+    def create_emitter(self) -> Emitter:
+        return Emitter.root().child(
             namespace=["tool", "example", "riddle"],
             creator=self,
         )
-
-    @property
-    def emitter(self) -> Emitter:
-        return self._emitter
 
     async def _run(self, input: RiddleToolInput, _: Any | None = None) -> StringToolOutput:
         index = input.riddle_number % (len(self.data))

--- a/python/examples/tools/custom/base.py
+++ b/python/examples/tools/custom/base.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, Field
 
 from beeai_framework.emitter.emitter import Emitter
 from beeai_framework.errors import FrameworkError
-from beeai_framework.tools.tool import Tool
+from beeai_framework.tools.tool import StringToolOutput, Tool
 
 
 class RiddleToolInput(BaseModel):
@@ -31,15 +31,19 @@ class RiddleTool(Tool[RiddleToolInput]):
 
     def __init__(self, options: dict[str, Any] | None = None) -> None:
         super().__init__(options)
-        self.emitter = Emitter.root().child(
+        self._emitter = Emitter.root().child(
             namespace=["tool", "example", "riddle"],
             creator=self,
         )
 
-    async def _run(self, input: RiddleToolInput, _: Any | None = None) -> None:
+    @property
+    def emitter(self) -> Emitter:
+        return self._emitter
+
+    async def _run(self, input: RiddleToolInput, _: Any | None = None) -> StringToolOutput:
         index = input.riddle_number % (len(self.data))
         riddle = self.data[index]
-        return riddle
+        return StringToolOutput(result=riddle)
 
 
 async def main() -> None:

--- a/python/examples/tools/custom/base.py
+++ b/python/examples/tools/custom/base.py
@@ -32,7 +32,7 @@ class RiddleTool(Tool[RiddleToolInput]):
     def __init__(self, options: dict[str, Any] | None = None) -> None:
         super().__init__(options)
 
-    def create_emitter(self) -> Emitter:
+    def _create_emitter(self) -> Emitter:
         return Emitter.root().child(
             namespace=["tool", "example", "riddle"],
             creator=self,

--- a/python/examples/tools/custom/openlibrary.py
+++ b/python/examples/tools/custom/openlibrary.py
@@ -31,14 +31,12 @@ class OpenLibraryTool(Tool[OpenLibraryToolInput]):
 
     def __init__(self, options: dict[str, Any] | None = None) -> None:
         super().__init__(options)
-        self._emitter = Emitter.root().child(
+
+    def create_emitter(self) -> Emitter:
+        return Emitter.root().child(
             namespace=["tool", "example", "openlibrary"],
             creator=self,
         )
-
-    @property
-    def emitter(self) -> Emitter:
-        return self._emitter
 
     async def _run(self, tool_input: OpenLibraryToolInput, _: Any | None = None) -> OpenLibraryToolResult:
         key = ""
@@ -63,9 +61,9 @@ class OpenLibraryTool(Tool[OpenLibraryToolInput]):
             json_output = response.json()[f"{key}:{value}"]
 
         return OpenLibraryToolResult(
-            preview_url=json_output.get("preview_url") or "",
-            info_url=json_output.get("info_url") or "",
-            bib_key=json_output.get("bib_key") or "",
+            preview_url=json_output.get("preview_url", ""),
+            info_url=json_output.get("info_url", ""),
+            bib_key=json_output.get("bib_key", ""),
         )
 
 

--- a/python/examples/tools/custom/openlibrary.py
+++ b/python/examples/tools/custom/openlibrary.py
@@ -32,7 +32,7 @@ class OpenLibraryTool(Tool[OpenLibraryToolInput]):
     def __init__(self, options: dict[str, Any] | None = None) -> None:
         super().__init__(options)
 
-    def create_emitter(self) -> Emitter:
+    def _create_emitter(self) -> Emitter:
         return Emitter.root().child(
             namespace=["tool", "example", "openlibrary"],
             creator=self,

--- a/python/examples/tools/custom/openlibrary.py
+++ b/python/examples/tools/custom/openlibrary.py
@@ -31,10 +31,14 @@ class OpenLibraryTool(Tool[OpenLibraryToolInput]):
 
     def __init__(self, options: dict[str, Any] | None = None) -> None:
         super().__init__(options)
-        self.emitter = Emitter.root().child(
+        self._emitter = Emitter.root().child(
             namespace=["tool", "example", "openlibrary"],
             creator=self,
         )
+
+    @property
+    def emitter(self) -> Emitter:
+        return self._emitter
 
     async def _run(self, tool_input: OpenLibraryToolInput, _: Any | None = None) -> OpenLibraryToolResult:
         key = ""
@@ -59,9 +63,9 @@ class OpenLibraryTool(Tool[OpenLibraryToolInput]):
             json_output = response.json()[f"{key}:{value}"]
 
         return OpenLibraryToolResult(
-            preview_url=json_output.get("preview_url"),
-            info_url=json_output.get("info_url"),
-            bib_key=json_output.get("bib_key"),
+            preview_url=json_output.get("preview_url") or "",
+            info_url=json_output.get("info_url") or "",
+            bib_key=json_output.get("bib_key") or "",
         )
 
 

--- a/python/tests/tools/test_decorator.py
+++ b/python/tests/tools/test_decorator.py
@@ -1,0 +1,83 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+
+from beeai_framework.tools import tool
+
+"""
+Unit Tests
+"""
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_tool_annotation() -> None:
+    @tool
+    def test_tool(query: str) -> str:
+        """
+        Search factual and historical information, including biography, history, politics, geography, society, culture,
+        science, technology, people, animal species, mathematics, and other subjects.
+
+        Args:
+            query: The topic or question to search for on Wikipedia.
+
+        Returns:
+            The information found via searching Wikipedia.
+        """
+        return query
+
+    query = "Hello!"
+    result = await test_tool.run({"query": query})
+    assert result == query
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_tool_annotation_no_params() -> None:
+    @tool
+    def test_tool() -> str:
+        """
+        Search factual and historical information, including biography, history, politics, geography, society, culture,
+        science, technology, people, animal species, mathematics, and other subjects.
+        """
+        return "Hello!"
+
+    result = await test_tool.run({})
+    assert result == "Hello!"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_tool_annotation_empty_desc() -> None:
+    @tool
+    def test_tool() -> str:
+        """"""
+        return "Hello!"
+
+    result = await test_tool.run({})
+    assert result == "Hello!"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_tool_annotation_no_desc() -> None:
+    with pytest.raises(ValueError):  # No description provided
+
+        @tool
+        def test_tool(query: str) -> str:
+            return query
+
+        await test_tool.run({"query": "Hello!"})

--- a/python/tests/tools/test_emitter.py
+++ b/python/tests/tools/test_emitter.py
@@ -1,0 +1,55 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from typing import Any
+
+import pytest
+
+from beeai_framework.emitter.emitter import Emitter, EventMeta
+from beeai_framework.emitter.types import EmitterOptions
+from beeai_framework.tools import tool
+
+"""
+Unit Tests
+"""
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_tool_emitter() -> None:
+    async def process_agent_events(event_data: dict[str, Any], event_meta: EventMeta) -> None:
+        print(event_meta.name, event_meta.path, event_data)
+
+    # Observe the agent
+    async def observer(emitter: Emitter) -> None:
+        emitter.on("*.*", process_agent_events, EmitterOptions(match_nested=True))
+
+    @tool
+    def test_tool(query: str) -> str:
+        """
+        Search factual and historical information, including biography, history, politics, geography, society, culture,
+        science, technology, people, animal species, mathematics, and other subjects.
+
+        Args:
+            query: The topic or question to search for on Wikipedia.
+
+        Returns:
+            The information found via searching Wikipedia.
+        """
+        return query
+
+    query = "Hello!"
+    result = await test_tool.run({"query": query}).observe(observer)
+    assert result == query


### PR DESCRIPTION
Adds a required emitter property on tools. All tool implementations now need to implement this property- providing an emitter instance.

I suggest we also change our tool implementations so that name, description and input_schema are implemented in the same manner for consistency. 

I also fixed a bunch of mypy errors in the code that I touched.

<!-- For completed items, change [ ] to [x]. -->

- [x] I have read the [contributor guide](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have [signed off](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-dco) on my commit
- [x] Linting passes: `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: `yarn format` or `yarn format:fix`
- [x] Unit tests pass: `yarn test:unit`
- [x] E2E tests pass: `yarn test:e2e`
- [ ] Tests are included <!-- Bug fixes and new features should include tests -->
- [ ] Documentation is changed or added
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
