### PR TITLE
fix: index workflow with step definitions

### DIFF
--- a/python/beeai_framework/workflows/workflow.py
+++ b/python/beeai_framework/workflows/workflow.py
@@ -110,7 +110,7 @@ class Workflow(Generic[T, K]):
         return self._start_step
 
     def add_step(self, step_name: K, runnable: WorkflowHandler[T, K]) -> "Workflow[T, K]":
-        if (len(step_name.strip())) == 0:
+        if (len(str(step_name).strip())) == 0:
             raise ValueError("Step name cannot be empty!")
 
         if step_name in self.steps:
@@ -169,9 +169,9 @@ class Workflow(Generic[T, K]):
                     if step_next == Workflow.START:
                         next = run.steps[0].name
                     elif step_next == Workflow.PREV:
-                        next = run.steps[-2].name
+                        next = self._find_step(next).prev or Workflow.END
                     elif step_next == Workflow.SELF:
-                        next = run.steps[-1].name
+                        next = self._find_step(next).current
                     elif step_next is None or step_next == Workflow.NEXT:
                         next = self._find_step(next).next or Workflow.END
                     else:

--- a/python/tests/workflows/test_workflow_nav.py
+++ b/python/tests/workflows/test_workflow_nav.py
@@ -1,0 +1,56 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from pydantic import BaseModel
+
+from beeai_framework.workflows import Workflow
+
+"""
+Unit Tests
+"""
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_workflow_nav() -> None:
+    # State
+    class State(BaseModel):
+        hops: int
+        seq: list[str]
+
+    # Steps
+    async def first(state: State) -> str:
+        state.seq.append("first")
+        state.hops += 1
+        if state.hops < 5:
+            return Workflow.SELF
+        else:
+            return Workflow.NEXT
+
+    def second(state: State) -> str:
+        state.seq.append("second")
+        if state.hops < 6:
+            state.hops += 1
+            return Workflow.SELF
+        elif state.hops < 10:
+            return Workflow.PREV
+
+        return Workflow.END
+
+    workflow: Workflow = Workflow(schema=State)
+    workflow.add_step("first", first)
+    workflow.add_step("second", second)
+    response = await workflow.run(State(hops=0, seq=[]))
+    assert response.state.hops == 10


### PR DESCRIPTION
FIxes a potential issue that can occur based on how we navigate workflow steps by using the executed step history. 

The fix is to transition based on the user defined step definitions, rather than the execution history. Also includes a testcase that recreates the issue. 

Ref #444 

### Checklist

<!-- For completed items, change [ ] to [x]. -->

- [x] I have read the [contributor guide](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have [signed off](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-dco) on my commit
- [x] Linting passes: `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: `yarn format` or `yarn format:fix`
- [x] Unit tests pass: `yarn test:unit`
- [x] E2E tests pass: `yarn test:e2e`
- [x] Tests are included <!-- Bug fixes and new features should include tests -->
- [ ] Documentation is changed or added
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
