### PR TITLE
fix: index workflow with step definitions - typescript

### DIFF
--- a/typescript/src/workflows/workflow.test.ts
+++ b/typescript/src/workflows/workflow.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Workflow } from "@/workflows/workflow.js";
+import { z } from "zod";
+
+describe("Workflow", () => {
+
+  it("runs the next step when a synchronous step does not return a value", async () => {
+    const schema = z.object({});
+
+    const step = {
+      a: vi.fn(() => {}),
+      b: vi.fn(() => {}),
+    }
+    
+    const workflow = new Workflow({ schema })
+      .addStep("a", step.a)
+      .addStep("b", step.b)
+
+    await workflow.run({})
+    expect(step.a).toHaveBeenCalledTimes(1);
+    expect(step.a).toHaveReturnedWith(undefined);
+    expect(step.b).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs the next step when an asynchronous step does not return a value", async () => {
+    const schema = z.object({});
+
+    const step = {
+      a: vi.fn(async () => {}),
+      b: vi.fn(async () => {}),
+    }
+    
+    const workflow = new Workflow({ schema })
+      .addStep("a", step.a)
+      .addStep("b", step.b)
+
+    await workflow.run({})
+    expect(step.a).toHaveBeenCalledTimes(1);
+    expect(step.a.mock.settledResults[0].value).toBeUndefined();
+    expect(step.b).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs the next step when a synchronous step returns 'next'", async () => {
+    const schema = z.object({});
+
+    const step = {
+      a: vi.fn(() => { return Workflow.NEXT; }),
+      b: vi.fn(() => {}),
+    }  
+    
+    const workflow = new Workflow({ schema })
+      .addStep("a", step.a)
+      .addStep("b", step.b)
+
+    await workflow.run({})
+    expect(step.a).toHaveBeenCalledTimes(1);
+    expect(step.a).toHaveReturnedWith(Workflow.NEXT);
+    expect(step.b).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs the next step when an asynchronous step returns 'next'", async () => {
+    const schema = z.object({});
+
+    const step = {
+      a: vi.fn(async () => { return Workflow.NEXT; }),
+      b: vi.fn(async () => {}),
+    }  
+    
+    const workflow = new Workflow({ schema })
+      .addStep("a", step.a)
+      .addStep("b", step.b)
+
+    await workflow.run({})
+    expect(step.a).toHaveBeenCalledTimes(1);
+    expect(step.a.mock.settledResults[0].value).toBe(Workflow.NEXT);
+    expect(step.b).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs no subsequent steps when a synchronous step returns 'end'", async () => {
+    const schema = z.object({});
+
+    const step = {
+      a: vi.fn(() => { return Workflow.END; }),
+      b: vi.fn(() => {}),
+    }
+    
+    const workflow = new Workflow({ schema })
+      .addStep("a", step.a)
+      .addStep("b", step.b)
+
+    await workflow.run({});
+    expect(step.a).toHaveBeenCalledTimes(1);
+    expect(step.b).not.toHaveBeenCalled();
+  });
+  
+  it("runs no subsequent steps when an asynchronous step returns 'end'", async () => {
+    const schema = z.object({});
+
+    const step = {
+      a: vi.fn(async () => { return Workflow.END; }),
+      b: vi.fn(async () => {}),
+    }
+    
+    const workflow = new Workflow({ schema })
+      .addStep("a", step.a)
+      .addStep("b", step.b)
+
+    await workflow.run({});
+    expect(step.a).toHaveBeenCalledTimes(1);
+    expect(step.b).not.toHaveBeenCalled();
+  });
+
+  it("reruns the first step when a synchrounous step returns 'start'", async () => {
+    const schema = z.object({});
+
+    const step = {
+      a: vi.fn(() => {}),
+      b: vi.fn(() => {}),
+      c: vi.fn(() => {
+        if(step.b.mock.calls.length === 1) {
+          return Workflow.START;
+        }
+      }),
+      d: vi.fn(() => {}),
+    }
+
+    const workflow = new Workflow({ schema })
+      .addStep("a", step.a)
+      .addStep("b", step.b)
+      .addStep("c", step.c)
+      .addStep("d", step.d);
+
+    await workflow.run({})
+    expect(step.a).toHaveBeenCalledTimes(2);
+    expect(step.b).toHaveBeenCalledTimes(2);
+    expect(step.c).toHaveBeenCalledTimes(2);
+    expect(step.d).toHaveBeenCalledTimes(1);
+  });
+
+  it("reruns the first step when an asynchrounous step returns 'start'", async () => {
+    const schema = z.object({});
+
+    const step = {
+      a: vi.fn(async () => {}),
+      b: vi.fn(async () => {}),
+      c: vi.fn(async () => {
+        if(step.b.mock.calls.length === 1) {
+          return Workflow.START;
+        }
+      }),
+      d: vi.fn(async () => {}),
+    }
+
+    const workflow = new Workflow({ schema })
+      .addStep("a", step.a)
+      .addStep("b", step.b)
+      .addStep("c", step.c)
+      .addStep("d", step.d);
+
+    await workflow.run({})
+    expect(step.a).toHaveBeenCalledTimes(2);
+    expect(step.b).toHaveBeenCalledTimes(2);
+    expect(step.c).toHaveBeenCalledTimes(2);
+    expect(step.d).toHaveBeenCalledTimes(1);
+  });
+
+  it("reruns the current step when a synchrounous step returns 'self'", async () => {
+    const schema = z.object({});
+
+    const step = {
+      a: vi.fn(() => {}),
+      b: vi.fn(() => { 
+        if(step.b.mock.calls.length === 1) {
+          return Workflow.SELF;
+        }
+      }),
+      c: vi.fn(() => {}),
+    }
+
+    const workflow = new Workflow({ schema })
+      .addStep("a", step.a)
+      .addStep("b", step.b)
+      .addStep("c", step.c)
+
+    const response = await workflow.run({})
+    expect(step.a).toHaveBeenCalledTimes(1);
+    expect(step.b).toHaveBeenCalledTimes(2);
+    expect(step.c).toHaveBeenCalledTimes(1);
+  });
+  
+  it("reruns the current step when an asynchrounous step returns 'self'", async () => {
+    const schema = z.object({});
+
+    const step = {
+      a: vi.fn(async () => {}),
+      b: vi.fn(async () => { 
+        if(step.b.mock.calls.length === 1) {
+          return Workflow.SELF;
+        }
+      }),
+      c: vi.fn(async () => {}),
+    }
+
+    const workflow = new Workflow({ schema })
+      .addStep("a", step.a)
+      .addStep("b", step.b)
+      .addStep("c", step.c)
+
+    const response = await workflow.run({})
+    expect(step.a).toHaveBeenCalledTimes(1);
+    expect(step.b).toHaveBeenCalledTimes(2);
+    expect(step.c).toHaveBeenCalledTimes(1);
+  });
+
+});
+

--- a/typescript/src/workflows/workflow.test.ts
+++ b/typescript/src/workflows/workflow.test.ts
@@ -18,20 +18,17 @@ import { Workflow } from "@/workflows/workflow.js";
 import { z } from "zod";
 
 describe("Workflow", () => {
-
   it("runs the next step when a synchronous step does not return a value", async () => {
     const schema = z.object({});
 
     const step = {
       a: vi.fn(() => {}),
       b: vi.fn(() => {}),
-    }
-    
-    const workflow = new Workflow({ schema })
-      .addStep("a", step.a)
-      .addStep("b", step.b)
+    };
 
-    await workflow.run({})
+    const workflow = new Workflow({ schema }).addStep("a", step.a).addStep("b", step.b);
+
+    await workflow.run({});
     expect(step.a).toHaveBeenCalledTimes(1);
     expect(step.a).toHaveReturnedWith(undefined);
     expect(step.b).toHaveBeenCalledTimes(1);
@@ -43,13 +40,11 @@ describe("Workflow", () => {
     const step = {
       a: vi.fn(async () => {}),
       b: vi.fn(async () => {}),
-    }
-    
-    const workflow = new Workflow({ schema })
-      .addStep("a", step.a)
-      .addStep("b", step.b)
+    };
 
-    await workflow.run({})
+    const workflow = new Workflow({ schema }).addStep("a", step.a).addStep("b", step.b);
+
+    await workflow.run({});
     expect(step.a).toHaveBeenCalledTimes(1);
     expect(step.a.mock.settledResults[0].value).toBeUndefined();
     expect(step.b).toHaveBeenCalledTimes(1);
@@ -59,15 +54,15 @@ describe("Workflow", () => {
     const schema = z.object({});
 
     const step = {
-      a: vi.fn(() => { return Workflow.NEXT; }),
+      a: vi.fn(() => {
+        return Workflow.NEXT;
+      }),
       b: vi.fn(() => {}),
-    }  
-    
-    const workflow = new Workflow({ schema })
-      .addStep("a", step.a)
-      .addStep("b", step.b)
+    };
 
-    await workflow.run({})
+    const workflow = new Workflow({ schema }).addStep("a", step.a).addStep("b", step.b);
+
+    await workflow.run({});
     expect(step.a).toHaveBeenCalledTimes(1);
     expect(step.a).toHaveReturnedWith(Workflow.NEXT);
     expect(step.b).toHaveBeenCalledTimes(1);
@@ -77,15 +72,15 @@ describe("Workflow", () => {
     const schema = z.object({});
 
     const step = {
-      a: vi.fn(async () => { return Workflow.NEXT; }),
+      a: vi.fn(async () => {
+        return Workflow.NEXT;
+      }),
       b: vi.fn(async () => {}),
-    }  
-    
-    const workflow = new Workflow({ schema })
-      .addStep("a", step.a)
-      .addStep("b", step.b)
+    };
 
-    await workflow.run({})
+    const workflow = new Workflow({ schema }).addStep("a", step.a).addStep("b", step.b);
+
+    await workflow.run({});
     expect(step.a).toHaveBeenCalledTimes(1);
     expect(step.a.mock.settledResults[0].value).toBe(Workflow.NEXT);
     expect(step.b).toHaveBeenCalledTimes(1);
@@ -95,30 +90,29 @@ describe("Workflow", () => {
     const schema = z.object({});
 
     const step = {
-      a: vi.fn(() => { return Workflow.END; }),
+      a: vi.fn(() => {
+        return Workflow.END;
+      }),
       b: vi.fn(() => {}),
-    }
-    
-    const workflow = new Workflow({ schema })
-      .addStep("a", step.a)
-      .addStep("b", step.b)
+    };
+
+    const workflow = new Workflow({ schema }).addStep("a", step.a).addStep("b", step.b);
 
     await workflow.run({});
     expect(step.a).toHaveBeenCalledTimes(1);
     expect(step.b).not.toHaveBeenCalled();
   });
-  
   it("runs no subsequent steps when an asynchronous step returns 'end'", async () => {
     const schema = z.object({});
 
     const step = {
-      a: vi.fn(async () => { return Workflow.END; }),
+      a: vi.fn(async () => {
+        return Workflow.END;
+      }),
       b: vi.fn(async () => {}),
-    }
-    
-    const workflow = new Workflow({ schema })
-      .addStep("a", step.a)
-      .addStep("b", step.b)
+    };
+
+    const workflow = new Workflow({ schema }).addStep("a", step.a).addStep("b", step.b);
 
     await workflow.run({});
     expect(step.a).toHaveBeenCalledTimes(1);
@@ -132,12 +126,12 @@ describe("Workflow", () => {
       a: vi.fn(() => {}),
       b: vi.fn(() => {}),
       c: vi.fn(() => {
-        if(step.b.mock.calls.length === 1) {
+        if (step.b.mock.calls.length === 1) {
           return Workflow.START;
         }
       }),
       d: vi.fn(() => {}),
-    }
+    };
 
     const workflow = new Workflow({ schema })
       .addStep("a", step.a)
@@ -145,7 +139,7 @@ describe("Workflow", () => {
       .addStep("c", step.c)
       .addStep("d", step.d);
 
-    await workflow.run({})
+    await workflow.run({});
     expect(step.a).toHaveBeenCalledTimes(2);
     expect(step.b).toHaveBeenCalledTimes(2);
     expect(step.c).toHaveBeenCalledTimes(2);
@@ -159,12 +153,12 @@ describe("Workflow", () => {
       a: vi.fn(async () => {}),
       b: vi.fn(async () => {}),
       c: vi.fn(async () => {
-        if(step.b.mock.calls.length === 1) {
+        if (step.b.mock.calls.length === 1) {
           return Workflow.START;
         }
       }),
       d: vi.fn(async () => {}),
-    }
+    };
 
     const workflow = new Workflow({ schema })
       .addStep("a", step.a)
@@ -172,7 +166,7 @@ describe("Workflow", () => {
       .addStep("c", step.c)
       .addStep("d", step.d);
 
-    await workflow.run({})
+    await workflow.run({});
     expect(step.a).toHaveBeenCalledTimes(2);
     expect(step.b).toHaveBeenCalledTimes(2);
     expect(step.c).toHaveBeenCalledTimes(2);
@@ -184,48 +178,45 @@ describe("Workflow", () => {
 
     const step = {
       a: vi.fn(() => {}),
-      b: vi.fn(() => { 
-        if(step.b.mock.calls.length === 1) {
+      b: vi.fn(() => {
+        if (step.b.mock.calls.length === 1) {
           return Workflow.SELF;
         }
       }),
       c: vi.fn(() => {}),
-    }
+    };
 
     const workflow = new Workflow({ schema })
       .addStep("a", step.a)
       .addStep("b", step.b)
-      .addStep("c", step.c)
+      .addStep("c", step.c);
 
-    const response = await workflow.run({})
+    await workflow.run({});
     expect(step.a).toHaveBeenCalledTimes(1);
     expect(step.b).toHaveBeenCalledTimes(2);
     expect(step.c).toHaveBeenCalledTimes(1);
   });
-  
   it("reruns the current step when an asynchrounous step returns 'self'", async () => {
     const schema = z.object({});
 
     const step = {
       a: vi.fn(async () => {}),
-      b: vi.fn(async () => { 
-        if(step.b.mock.calls.length === 1) {
+      b: vi.fn(async () => {
+        if (step.b.mock.calls.length === 1) {
           return Workflow.SELF;
         }
       }),
       c: vi.fn(async () => {}),
-    }
+    };
 
     const workflow = new Workflow({ schema })
       .addStep("a", step.a)
       .addStep("b", step.b)
-      .addStep("c", step.c)
+      .addStep("c", step.c);
 
-    const response = await workflow.run({})
+    await workflow.run({});
     expect(step.a).toHaveBeenCalledTimes(1);
     expect(step.b).toHaveBeenCalledTimes(2);
     expect(step.c).toHaveBeenCalledTimes(1);
   });
-
 });
-

--- a/typescript/src/workflows/workflow.ts
+++ b/typescript/src/workflows/workflow.ts
@@ -244,9 +244,9 @@ export class Workflow<
             if (nextStepRaw === Workflow.START) {
               next = run.steps.at(0)?.name!;
             } else if (nextStepRaw === Workflow.PREV) {
-              next = run.steps.at(-2)?.name!;
+              next = this.findStep(next).prev;
             } else if (nextStepRaw === Workflow.SELF) {
-              next = run.steps.at(-1)?.name!;
+              next = this.findStep(next).current;
             } else if (!nextStepRaw || nextStepRaw === Workflow.NEXT) {
               next = this.findStep(next).next || Workflow.END;
             } else {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review and complete the sections below.
-->

### Which issue(s) does this pull-request address?

<!--
Please include a link to an issue in the tracker.  The issue describes the problem to be solved.  If there is no issue raised for this PR then either raise one with a summary and description of the problem or add a summary and description of the problem here
-->

Closes: #444  
Related to #463 in python 🐍  

### Description

<!-- Provide a description of the change, pay special attention to describing any breaking changes.  The description describes the resolution to the problem described in the linked issue (or to the problem outlined in this PR). -->



This corrects in Typescript Workflow when the .addStep callback returned either SELF or PREV. It was trying to assign the appropriate subsequent step relative to the array of steps rather than the member representing the current step of the workflow.

### Checklist

<!-- For completed items, change [ ] to [x]. -->

- [x] I have read the [contributor guide](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have [signed off](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-dco) on my commit
- [x] Linting passes: `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: `yarn format` or `yarn format:fix`
- [x] Unit tests pass: `yarn test:unit`
- [x] E2E tests pass: `yarn test:e2e`
- [x] Tests are included <!-- Bug fixes and new features should include tests -->
- [ ] Documentation is changed or added
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)

eca19e fix: assign subsequent step relative to current step in Workflow
b9c26a test: add tests for workflow step changes
c61618: chore: lint and format workflow test
