### PR TITLE
fix(agents): improve PromptTemplate.render API

### DIFF
--- a/python/beeai_framework/agents/runners/base.py
+++ b/python/beeai_framework/agents/runners/base.py
@@ -25,6 +25,7 @@ from beeai_framework.agents.types import (
     BeeMeta,
     BeeRunInput,
     BeeRunOptions,
+    BeeTemplateFactory,
 )
 from beeai_framework.cancellation import AbortSignal
 from beeai_framework.context import RunContext
@@ -134,7 +135,7 @@ class BaseRunner(ABC):
         templates = {}
 
         for key, default_template in self.default_templates().model_dump().items():
-            override = overrides.get(key) or default_template
+            override: PromptTemplate | BeeTemplateFactory = overrides.get(key) or default_template
             if isinstance(override, PromptTemplate):
                 templates[key] = override
                 continue

--- a/python/beeai_framework/agents/types.py
+++ b/python/beeai_framework/agents/types.py
@@ -101,6 +101,6 @@ class BeeInput(BaseModel):
     tools: list[InstanceOf[Tool]]
     memory: InstanceOf[BaseMemory]
     meta: InstanceOf[AgentMeta] | None = None
-    templates: dict[ModelKeysType, InstanceOf[BeeAgentTemplates] | BeeTemplateFactory] | None = None
+    templates: dict[ModelKeysType, InstanceOf[PromptTemplate] | BeeTemplateFactory] | None = None
     execution: AgentExecutionConfig | None = None
     stream: bool | None = None


### PR DESCRIPTION
### Which issue(s) does this pull-request address?

Closes: #385

### Description

Update `PromptTemplate.render` to accept a `TemplateInput` schema object, a schema `dict`, or the schema values as `kwargs` for more flexibility for users

Also does some followup cleanup from #462 in relation to `PromptTemplate.fork`

### Checklist

<!-- For completed items, change [ ] to [x]. -->

- [x] I have read the [contributor guide](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have [signed off](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-dco) on my commit
- [ ] Tests are included <!-- Bug fixes and new features should include tests -->
- [ ] Documentation is changed or added
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
