### PR TITLE
fix: make `createHash` work in Electron.

### DIFF
--- a/typescript/src/internals/helpers/hash.ts
+++ b/typescript/src/internals/helpers/hash.ts
@@ -15,13 +15,17 @@
  */
 
 import { createHash as _createHash, randomBytes } from "node:crypto";
+import { NotImplementedError } from "@/errors.js";
 
 export function createHash(input: string, length = 4) {
-  return _createHash("shake256", {
-    outputLength: length,
-  })
+  if (length > 32) {
+    throw new NotImplementedError("Max supported hash length is 32");
+  }
+
+  return _createHash("sha256")
     .update(input)
-    .digest("hex");
+    .digest("hex")
+    .slice(0, length * 2);
 }
 
 export function createRandomHash(length = 4) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review and complete the sections below.
-->

### Which issue(s) does this pull-request address?

<!--
Please include a link to an issue in the tracker.  The issue describes the problem to be solved.  If there is no issue raised for this PR then either raise one with a summary and description of the problem or add a summary and description of the problem here
-->

Closes: #478 

### Description

Switch from SHAKE256 to SHA256 and a manual slice. As far as I can see, the "arbitrary length" feature of shake256 is not used anywhere, but to prevent accidental misuse I added a `NotImplemented` guard.

Not sure how to best test this fix, let me know your thoughts.

### Checklist

<!-- For completed items, change [ ] to [x]. -->

- [x] I have read the [contributor guide](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have [signed off](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-dco) on my commit
- [x] Linting passes: `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: `yarn format` or `yarn format:fix`
- [x] Unit tests pass: `yarn test:unit`
- [x] E2E tests pass: `yarn test:e2e`
- [ ] Tests are included <!-- Bug fixes and new features should include tests -->
- [ ] Documentation is changed or added
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
