### PR TITLE
test(examples): fix emitters/base.py example breaking e2e tests

### DIFF
--- a/python/docs/emitter.md
+++ b/python/docs/emitter.md
@@ -46,13 +46,12 @@ from beeai_framework.errors import FrameworkError
 
 
 async def main() -> None:
-    # Get the root emitter or create your own
-    root = Emitter.root()
+    emitter: Emitter = Emitter(namespace=["base"])
 
-    root.match("*.*", lambda data, event: print(f"Received event '{event.path}' with data {json.dumps(data)}"))
+    emitter.match("*.*", lambda data, event: print(f"Received event '{event.path}' with data {json.dumps(data)}"))
 
-    await root.emit("start", {"id": 123})
-    await root.emit("end", {"id": 123})
+    await emitter.emit("start", {"id": 123})
+    await emitter.emit("end", {"id": 123})
 
 
 if __name__ == "__main__":

--- a/python/examples/emitter/base.py
+++ b/python/examples/emitter/base.py
@@ -8,13 +8,12 @@ from beeai_framework.errors import FrameworkError
 
 
 async def main() -> None:
-    # Get the root emitter or create your own
-    root = Emitter.root()
+    emitter: Emitter = Emitter(namespace=["base"])
 
-    root.match("*.*", lambda data, event: print(f"Received event '{event.path}' with data {json.dumps(data)}"))
+    emitter.match("*.*", lambda data, event: print(f"Received event '{event.path}' with data {json.dumps(data)}"))
 
-    await root.emit("start", {"id": 123})
-    await root.emit("end", {"id": 123})
+    await emitter.emit("start", {"id": 123})
+    await emitter.emit("end", {"id": 123})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description

emitters/base.py example added a listener on the root emitter, which was breaking all tests where it would later emit since all the tests share the root Emitter. This was caused by a descrepancy with how TS runs

### Checklist

<!-- For completed items, change [ ] to [x]. -->

- [x] I have read the [contributor guide](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have [signed off](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-dco) on my commit
- [x] Tests are included <!-- Bug fixes and new features should include tests -->
- [x] Documentation is changed or added
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
