### PR TITLE
fix: improve decorated tool output

### DIFF
--- a/python/beeai_framework/adapters/langchain/tools.py
+++ b/python/beeai_framework/adapters/langchain/tools.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel, ConfigDict
 
 from beeai_framework.context import RunContext
 from beeai_framework.emitter.emitter import Emitter
-from beeai_framework.tools.tool import Tool, ToolRunOptions
+from beeai_framework.tools.tool import StringToolOutput, Tool, ToolRunOptions
 from beeai_framework.utils.strings import to_safe_word
 
 
@@ -35,7 +35,7 @@ class LangChainToolRunOptions(ToolRunOptions):
 T = TypeVar("T", bound=BaseModel)
 
 
-class LangChainTool(Tool[T, LangChainToolRunOptions]):
+class LangChainTool(Tool[T, LangChainToolRunOptions, StringToolOutput]):
     @property
     def name(self) -> str:
         return self._tool.name
@@ -58,7 +58,7 @@ class LangChainTool(Tool[T, LangChainToolRunOptions]):
         super().__init__(options)
         self._tool = tool
 
-    async def _run(self, input: T, options: LangChainToolRunOptions | None, context: RunContext) -> Any:
+    async def _run(self, input: T, options: LangChainToolRunOptions | None, context: RunContext) -> StringToolOutput:
         langchain_runnable_config = options.langchain_runnable_config or {} if options else {}
         args = (
             input if isinstance(input, dict) else input.model_dump(),
@@ -74,4 +74,5 @@ class LangChainTool(Tool[T, LangChainToolRunOptions]):
             response = await self._tool.ainvoke(*args)
         else:
             response = self._tool.invoke(*args)
-        return response
+
+        return StringToolOutput(result=str(response))

--- a/python/beeai_framework/context.py
+++ b/python/beeai_framework/context.py
@@ -30,7 +30,7 @@ from beeai_framework.errors import AbortError, FrameworkError
 from beeai_framework.utils.asynchronous import ensure_async
 from beeai_framework.utils.custom_logger import BeeLogger
 
-R = TypeVar("R", bound=BaseModel)
+R = TypeVar("R")
 
 logger = BeeLogger(__name__)
 

--- a/python/beeai_framework/tools/mcp_tools.py
+++ b/python/beeai_framework/tools/mcp_tools.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel
 from beeai_framework.context import RunContext
 from beeai_framework.emitter import Emitter
 from beeai_framework.tools import Tool
-from beeai_framework.tools.tool import JSONToolOutput, ToolRunOptions
+from beeai_framework.tools.tool import JSONToolOutput, ToolOutput, ToolRunOptions
 from beeai_framework.utils import BeeLogger
 from beeai_framework.utils.models import json_to_model
 from beeai_framework.utils.strings import to_safe_word
@@ -31,7 +31,7 @@ from beeai_framework.utils.strings import to_safe_word
 logger = BeeLogger(__name__)
 
 
-class MCPTool(Tool[BaseModel, ToolRunOptions]):
+class MCPTool(Tool[BaseModel, ToolRunOptions, ToolOutput]):
     """Tool implementation for Model Context Protocol."""
 
     def __init__(self, server_params: StdioServerParameters, tool: MCPToolInfo, **options: int) -> None:

--- a/python/beeai_framework/tools/search/duckduckgo.py
+++ b/python/beeai_framework/tools/search/duckduckgo.py
@@ -44,7 +44,7 @@ class DuckDuckGoSearchToolOutput(SearchToolOutput):
     pass
 
 
-class DuckDuckGoSearchTool(Tool[DuckDuckGoSearchToolInput, ToolRunOptions]):
+class DuckDuckGoSearchTool(Tool[DuckDuckGoSearchToolInput, ToolRunOptions, DuckDuckGoSearchToolOutput]):
     name = "DuckDuckGo"
     description = "Search for online trends, news, current events, real-time information, or research topics."
     input_schema = DuckDuckGoSearchToolInput

--- a/python/beeai_framework/tools/search/wikipedia.py
+++ b/python/beeai_framework/tools/search/wikipedia.py
@@ -37,7 +37,7 @@ class WikipediaToolOutput(SearchToolOutput):
     pass
 
 
-class WikipediaTool(Tool[WikipediaToolInput, ToolRunOptions]):
+class WikipediaTool(Tool[WikipediaToolInput, ToolRunOptions, WikipediaToolOutput]):
     name = "Wikipedia"
     description = "Search factual and historical information, including biography, \
         history, politics, geography, society, culture, science, technology, people, \

--- a/python/beeai_framework/tools/tool.py
+++ b/python/beeai_framework/tools/tool.py
@@ -60,6 +60,9 @@ class ToolOutput(ABC):
         return self.get_text_content()
 
 
+OUT = TypeVar("OUT", bound=ToolOutput)
+
+
 class StringToolOutput(ToolOutput):
     def __init__(self, result: str = "") -> None:
         super().__init__()
@@ -83,7 +86,7 @@ class JSONToolOutput(ToolOutput):
         return not self.result
 
 
-class Tool(Generic[IN, OPT], ABC):
+class Tool(Generic[IN, OPT, OUT], ABC):
     def __init__(self, options: dict[str, Any] | None = None) -> None:
         self.options: dict[str, Any] | None = options or None
 
@@ -111,7 +114,7 @@ class Tool(Generic[IN, OPT], ABC):
         pass
 
     @abstractmethod
-    async def _run(self, input: IN, options: OPT | None, context: RunContext) -> Any:
+    async def _run(self, input: IN, options: OPT | None, context: RunContext) -> OUT:
         pass
 
     def validate_input(self, input: IN | dict[str, Any]) -> IN:
@@ -120,8 +123,8 @@ class Tool(Generic[IN, OPT], ABC):
         except ValidationError as e:
             raise ToolInputValidationError("Tool input validation error", cause=e)
 
-    def run(self, input: IN | dict[str, Any], options: OPT | None = None) -> Run[IN]:
-        async def run_tool(context: RunContext) -> IN:
+    def run(self, input: IN | dict[str, Any], options: OPT | None = None) -> Run[OUT]:
+        async def run_tool(context: RunContext) -> OUT:
             error_propagated = False
 
             try:
@@ -217,7 +220,7 @@ def tool(tool_function: Callable) -> Tool:
     if tool_description is None:
         raise ValueError("No tool description provided.")
 
-    class FunctionTool(Tool[Any, ToolRunOptions]):
+    class FunctionTool(Tool[Any, ToolRunOptions, ToolOutput]):
         name = tool_name
         description = tool_description or ""
         input_schema = tool_input
@@ -231,12 +234,17 @@ def tool(tool_function: Callable) -> Tool:
                 creator=self,
             )
 
-        async def _run(self, input: Any, options: ToolRunOptions | None, context: RunContext) -> StringToolOutput:
+        async def _run(self, input: Any, options: ToolRunOptions | None, context: RunContext) -> ToolOutput:
             tool_input_dict = input.model_dump()
             if inspect.iscoroutinefunction(tool_function):
-                return StringToolOutput(str(await tool_function(**tool_input_dict)))
+                result = await tool_function(**tool_input_dict)
             else:
-                return StringToolOutput(str(tool_function(**tool_input_dict)))
+                result = tool_function(**tool_input_dict)
+
+            if isinstance(result, ToolOutput):
+                return result
+            else:
+                return StringToolOutput(result=str(result))
 
     f_tool = FunctionTool()
     return f_tool

--- a/python/beeai_framework/tools/tool.py
+++ b/python/beeai_framework/tools/tool.py
@@ -56,7 +56,7 @@ class ToolOutput(ABC):
     def is_empty(self) -> bool:
         pass
 
-    def to_string(self) -> str:
+    def __str__(self) -> str:
         return self.get_text_content()
 
 
@@ -220,12 +220,12 @@ def tool(tool_function: Callable) -> Tool:
                 creator=self,
             )
 
-        async def _run(self, input: Any, options: ToolRunOptions | None, context: RunContext) -> Any:
+        async def _run(self, input: Any, options: ToolRunOptions | None, context: RunContext) -> StringToolOutput:
             tool_input_dict = input.model_dump()
             if inspect.iscoroutinefunction(tool_function):
-                return await tool_function(**tool_input_dict)
+                return StringToolOutput(str(await tool_function(**tool_input_dict)))
             else:
-                return tool_function(**tool_input_dict)
+                return StringToolOutput(str(tool_function(**tool_input_dict)))
 
     f_tool = FunctionTool()
     return f_tool

--- a/python/beeai_framework/tools/tool.py
+++ b/python/beeai_framework/tools/tool.py
@@ -17,9 +17,10 @@ import inspect
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from functools import cached_property
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic
 
 from pydantic import BaseModel, ConfigDict, ValidationError, create_model
+from typing_extensions import TypeVar
 
 from beeai_framework.cancellation import AbortSignal
 from beeai_framework.context import Run, RunContext, RunContextInput, RunInstance
@@ -44,7 +45,7 @@ class ToolRunOptions(BaseModel):
     signal: AbortSignal | None = None
 
 
-OPT = TypeVar("OPT", bound=ToolRunOptions)
+OPT = TypeVar("OPT", bound=ToolRunOptions, default=ToolRunOptions)
 
 
 class ToolOutput(ABC):
@@ -60,7 +61,7 @@ class ToolOutput(ABC):
         return self.get_text_content()
 
 
-OUT = TypeVar("OUT", bound=ToolOutput)
+OUT = TypeVar("OUT", bound=ToolOutput, default=ToolOutput)
 
 
 class StringToolOutput(ToolOutput):

--- a/python/beeai_framework/tools/weather/openmeteo.py
+++ b/python/beeai_framework/tools/weather/openmeteo.py
@@ -46,7 +46,7 @@ class OpenMeteoToolInput(BaseModel):
     )
 
 
-class OpenMeteoTool(Tool[OpenMeteoToolInput, ToolRunOptions]):
+class OpenMeteoTool(Tool[OpenMeteoToolInput, ToolRunOptions, StringToolOutput]):
     name = "OpenMeteoTool"
     description = "Retrieve current, past, or future weather forecasts for a location."
     input_schema = OpenMeteoToolInput

--- a/python/docs/tools.md
+++ b/python/docs/tools.md
@@ -361,7 +361,7 @@ class RiddleToolInput(BaseModel):
     riddle_number: int = Field(description="Index of riddle to retrieve.")
 
 
-class RiddleTool(Tool[RiddleToolInput, ToolRunOptions]):
+class RiddleTool(Tool[RiddleToolInput, ToolRunOptions, StringToolOutput]):
     name = "Riddle"
     description = "It selects a riddle to test your knowledge."
     input_schema = RiddleToolInput
@@ -435,7 +435,7 @@ from beeai_framework.context import RunContext
 from beeai_framework.emitter.emitter import Emitter
 from beeai_framework.errors import FrameworkError
 from beeai_framework.tools import ToolInputValidationError
-from beeai_framework.tools.tool import Tool, ToolRunOptions
+from beeai_framework.tools.tool import JSONToolOutput, Tool, ToolRunOptions
 
 
 class OpenLibraryToolInput(BaseModel):
@@ -450,7 +450,7 @@ class OpenLibraryToolResult(BaseModel):
     bib_key: str
 
 
-class OpenLibraryTool(Tool[OpenLibraryToolInput, ToolRunOptions]):
+class OpenLibraryTool(Tool[OpenLibraryToolInput, ToolRunOptions, JSONToolOutput]):
     name = "OpenLibrary"
     description = """Provides access to a library of books with information about book titles,
         authors, contributors, publication dates, publisher and isbn."""
@@ -467,7 +467,7 @@ class OpenLibraryTool(Tool[OpenLibraryToolInput, ToolRunOptions]):
 
     async def _run(
         self, tool_input: OpenLibraryToolInput, options: ToolRunOptions | None, context: RunContext
-    ) -> OpenLibraryToolResult:
+    ) -> JSONToolOutput:
         key = ""
         value = ""
         input_vars = vars(tool_input)
@@ -489,10 +489,12 @@ class OpenLibraryTool(Tool[OpenLibraryToolInput, ToolRunOptions]):
 
             json_output = response.json()[f"{key}:{value}"]
 
-        return OpenLibraryToolResult(
-            preview_url=json_output.get("preview_url", ""),
-            info_url=json_output.get("info_url", ""),
-            bib_key=json_output.get("bib_key", ""),
+        return JSONToolOutput(
+            result={
+                "preview_url": json_output.get("preview_url", ""),
+                "info_url": json_output.get("info_url", ""),
+                "bib_key": json_output.get("bib_key", ""),
+            }
         )
 
 

--- a/python/examples/notebooks/agents.ipynb
+++ b/python/examples/notebooks/agents.ipynb
@@ -118,10 +118,10 @@
       "\n",
       "Agent(tool_name) 🤖 :  OpenMeteoTool\n",
       "Agent(tool_input) 🤖 :  {'location_name': 'London', 'temperature_unit': 'celsius'}\n",
-      "Agent(tool_output) 🤖 :  {\"latitude\": 51.5, \"longitude\": -0.120000124, \"generationtime_ms\": 0.06449222564697266, \"utc_offset_seconds\": 0, \"timezone\": \"GMT\", \"timezone_abbreviation\": \"GMT\", \"elevation\": 23.0, \"current_units\": {\"time\": \"iso8601\", \"interval\": \"seconds\", \"temperature_2m\": \"\\u00b0C\", \"rain\": \"mm\", \"relative_humidity_2m\": \"%\", \"wind_speed_10m\": \"km/h\"}, \"current\": {\"time\": \"2025-03-06T04:00\", \"interval\": 900, \"temperature_2m\": 6.7, \"rain\": 0.0, \"relative_humidity_2m\": 63, \"wind_speed_10m\": 3.3}, \"daily_units\": {\"time\": \"iso8601\", \"temperature_2m_max\": \"\\u00b0C\", \"temperature_2m_min\": \"\\u00b0C\", \"rain_sum\": \"mm\"}, \"daily\": {\"time\": [\"2025-03-06\"], \"temperature_2m_max\": [15.1], \"temperature_2m_min\": [5.1], \"rain_sum\": [0.0]}}\n",
-      "Agent(thought) 🤖 :  The OpenMeteoTool returned the current weather information for London. The temperature is 6.7°C, with no rain and a wind speed of 3.3 km/h.\n",
+      "Agent(tool_output) 🤖 :  {\"latitude\": 51.5, \"longitude\": -0.120000124, \"generationtime_ms\": 0.04935264587402344, \"utc_offset_seconds\": 0, \"timezone\": \"GMT\", \"timezone_abbreviation\": \"GMT\", \"elevation\": 23.0, \"current_units\": {\"time\": \"iso8601\", \"interval\": \"seconds\", \"temperature_2m\": \"\\u00b0C\", \"rain\": \"mm\", \"relative_humidity_2m\": \"%\", \"wind_speed_10m\": \"km/h\"}, \"current\": {\"time\": \"2025-03-06T14:00\", \"interval\": 900, \"temperature_2m\": 15.8, \"rain\": 0.0, \"relative_humidity_2m\": 46, \"wind_speed_10m\": 13.7}, \"daily_units\": {\"time\": \"iso8601\", \"temperature_2m_max\": \"\\u00b0C\", \"temperature_2m_min\": \"\\u00b0C\", \"rain_sum\": \"mm\"}, \"daily\": {\"time\": [\"2025-03-06\"], \"temperature_2m_max\": [15.7], \"temperature_2m_min\": [3.7], \"rain_sum\": [0.0]}}\n",
+      "Agent(thought) 🤖 :  The OpenMeteoTool returned the current weather information for London. The temperature is 15.8°C, with no rain and a wind speed of 13.7 km/h.\n",
       "\n",
-      "Agent(final_answer) 🤖 :  The current weather in London is 6.7°C with no rain and a wind speed of 3.3 km/h.\n"
+      "Agent(final_answer) 🤖 :  The current weather in London is 15.8°C with clear skies and light winds.\n"
      ]
     }
    ],
@@ -159,7 +159,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Agent(thought) 🤖 :  I can find this information using the Wikipedia tool.\n",
+      "Agent(thought) 🤖 :  I need to find out who the current president of the European Commission is. I will use the Wikipedia tool to search for this information.\n",
       "Agent(tool_name) 🤖 :  Wikipedia\n",
       "Agent(tool_input) 🤖 :  {'query': 'Current President of the European Commission'}\n",
       "Agent(tool_output) 🤖 :  Page: Vice-President of the European Commission\n",
@@ -172,7 +172,7 @@
       "\n",
       "Page: List of presidents of the institutions of the European Union\n",
       "Summary: This is a list of presidents of the institutions of the European Union (EU). Each of the institutions is headed by a president or a presidency, with some being more prominent than others. Both the President of the European Council and the President of the European Commission are sometimes wrongly termed the President of the European Union. Most go back to 1957 but others, such as the President of the Auditors Court or of the European Central Bank, have been created recently. Currently (2025), the President of the European Commission is Ursula von der Leyen and the President of the European Council is António Costa.\n",
-      "Agent(thought) 🤖 :  The current president of the European Commission is Ursula von der Leyen, as per the information retrieved from Wikipedia.\n",
+      "Agent(thought) 🤖 :  The Wikipedia search results indicate that the current president of the European Commission is Ursula von der Leyen, who took office in December 2019.\n",
       "Agent(final_answer) 🤖 :  The current president of the European Commission is Ursula von der Leyen.\n"
      ]
     }
@@ -194,7 +194,7 @@
     "    query: str = Field(description=\"The topic or question to search for on Wikipedia.\")\n",
     "\n",
     "\n",
-    "class LangChainWikipediaTool(Tool[LangChainWikipediaToolInput, ToolRunOptions]):\n",
+    "class LangChainWikipediaTool(Tool[LangChainWikipediaToolInput, ToolRunOptions, StringToolOutput]):\n",
     "    \"\"\"Adapter class to integrate LangChain's Wikipedia tool with our framework\"\"\"\n",
     "\n",
     "    name = \"Wikipedia\"\n",
@@ -245,12 +245,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Agent(thought) 🤖 :  I need to use the langchain_wikipedia_tool to find the longest living vertebrate.\n",
+      "Agent(thought) 🤖 :  I need to find factual and historical information about the longest living vertebrate. I will use the langchain_wikipedia_tool for this purpose.\n",
       "Agent(tool_name) 🤖 :  langchain_wikipedia_tool\n",
       "Agent(tool_input) 🤖 :  {'query': 'longest living vertebrate'}\n",
       "Agent(tool_output) 🤖 :  Page: Hákarl\n",
       "Summary: Hákarl (an abbreviation of kæstur hákarl [ˈcʰaistʏr ˈhauːˌkʰa(r)tl̥]), referred to as fermented shark in English, is a national dish of Iceland consisting of Greenland shark or other sleeper shark that has been cured with a particular fermentation process and hung to dry for four to five months. It has a strong ammonia-rich smell and fishy taste, making hákarl an acquired taste.\n",
       "Fermented shark is readily available in Icelandic stores and may be eaten year-round, but is most often served as part of a Þorramatur, a selection of traditional Icelandic food served at the midwinter festival þorrablót.\n",
+      "\n",
+      "Page: Greenland shark\n",
+      "Summary: The Greenland shark (Somniosus microcephalus), also known as the gurry shark or grey shark, is a large shark of the family Somniosidae (\"sleeper sharks\"), closely related to the Pacific and southern sleeper sharks. Inhabiting the North Atlantic and Arctic Oceans, they are notable for their exceptional longevity, although they are poorly studied due to the depth and remoteness of their natural habitat.\n",
+      "Greenland sharks have the longest lifespan of any known vertebrate, estimated to be between 250 and 500 years. They are among the largest extant species of shark, reaching a maximum confirmed length of 6.4 m (21 ft) long and weighing over 1,000 kg (2,200 lb). They reach sexual maturity at about 150 years of age, and their pups are born alive after an estimated gestation period of 8 to 18 years.\n",
+      "The shark is a generalist feeder, consuming a variety of available foods, including carrion.\n",
+      "Greenland shark meat is toxic to mammals due to its high levels of trimethylamine N-oxide, although a treated form of it is eaten in Iceland as a delicacy known as kæstur hákarl. Because they live deep in remote parts of the northern oceans, Greenland sharks are not considered a threat to humans. A possible attack occurred in August 1936 on two British fisherman, but the species was never identified.\n",
+      "\n",
+      "\n",
       "\n",
       "Page: List of longest-living organisms\n",
       "Summary: This is a list of the longest-living biological organisms: the individual(s) (or in some instances, clones) of a species with the longest natural maximum life spans. For a given species, such a designation may include:\n",
@@ -258,15 +266,9 @@
       "The oldest known individual(s) that are currently alive, with verified ages.\n",
       "Verified individual record holders, such as the longest-lived human, Jeanne Calment, or the longest-lived domestic cat, Creme Puff.\n",
       "The definition of \"longest-living\" used in this article considers only the observed or estimated length of an individual organism's natural lifespan – that is, the duration of time between its birth or conception, or the earliest emergence of its identity as an individual organism, and its death – and does not consider other conceivable interpretations of \"longest-living\", such as the length of time between the earliest appearance of a species in the fossil record and the present (the historical \"age\" of the species as a whole), the time between a species' first speciation and its extinction (the phylogenetic \"lifespan\" of the species), or the range of possible lifespans of a species' individuals. This list includes long-lived organisms that are currently still alive as well as those that are dead.\n",
-      "Determining the length of an organism's natural lifespan is complicated by many problems of definition and interpretation, as well as by practical difficulties in reliably measuring age, particularly for extremely old organisms and for those that reproduce by asexual cloning. In many cases the ages listed below are estimates based on observed present-day growth rates, which may differ significantly from the growth rates experienced thousands of years ago. Identifying the longest-living organisms also depends on defining what constitutes an \"individual\" organism, which can be problematic, since many asexual organisms and clonal colonies defy one or both of the traditional colloquial definitions of individuality (having a distinct genotype and having an independent, physically separate body). Additionally, some organisms maintain the capability to reproduce through very long periods of metabolic dormancy, during which they may not be considered \"alive\" by certain definitions but nonetheless can resume normal metabolism afterward; it is unclear whether the dormant periods should be counted as part of the organism's lifespan.\n",
-      "\n",
-      "Page: Greenland shark\n",
-      "Summary: The Greenland shark (Somniosus microcephalus), also known as the gurry shark or grey shark, is a large shark of the family Somniosidae (\"sleeper sharks\"), closely related to the Pacific and southern sleeper sharks. Inhabiting the North Atlantic and Arctic Oceans, they are notable for their exceptional longevity, although they are poorly studied due to the depth and remoteness of their natural habitat.\n",
-      "Greenland sharks have the longest lifespan of any known vertebrate, estimated to be between 250 and 500 years. They are among the largest extant species of shark, reaching a maximum confirmed length of 6.4 m (21 ft) long and weighing over 1,000 kg (2,200 lb). They reach sexual maturity at about 150 years of age, and their pups are born alive after an estimated gestation period of 8 to 18 years.\n",
-      "The shark is a generalist feeder, consuming a variety of available foods, including carrion.\n",
-      "Greenland shark me\n",
-      "Agent(thought) 🤖 :  The information provided indicates that the Greenland shark has the longest lifespan among vertebrates, estimated to be between 250 and 500 years.\n",
-      "Agent(final_answer) 🤖 :  The Greenland shark is the longest living vertebrate, with an estimated lifespan of 250 to 500 years.\n"
+      "Determining the length of an organism's natural lifespan is complicated by many problems of definition and interpretation, as well as by practical difficulties in reliably measuring age, particularly for extremely old organisms and for those that reproduce by asexual cloning. In many cases the ages listed below are estimates based on observed present-day growth rates, which may differ significantly from the growth rates experienced thousands of years ago. Identifying the longest-living organisms also depends on defining what constitutes an \"individual\" organism, which can be problematic, since many asexual organisms and clonal colonies defy one or both of the traditional colloquial definitions of individuality (having a distinct genotype and \n",
+      "Agent(thought) 🤖 :  The Greenland shark is identified as the longest living vertebrate in the provided information. It has an estimated lifespan between 250 and 500 years, making it the longest-lived vertebrate known to science.\n",
+      "Agent(final_answer) 🤖 :  The Greenland shark (Somniosus microcephalus) is the longest living vertebrate, with an estimated lifespan of 250 to 500 years.\n"
      ]
     }
    ],

--- a/python/examples/notebooks/agents.ipynb
+++ b/python/examples/notebooks/agents.ipynb
@@ -1,326 +1,328 @@
 {
-      "cells": [
-            {
-                  "cell_type": "markdown",
-                  "metadata": {},
-                  "source": [
-                        "# BeeAI ReAct agents\n",
-                        "\n",
-                        "The BeeAI ReAct agent is a pre-configured implementation of the ReAct (Reasoning and Acting) pattern. It can be customized with tools and instructions to suit different tasks.\n",
-                        "\n",
-                        "The ReAct pattern is a framework used in AI models, particularly language models, to separate the reasoning process from the action-taking process. This pattern enhances the model's ability to handle complex queries by enabling it to:\n",
-                        "\n",
-                        "- Reason about the problem.\n",
-                        "- Decide on an action to take.\n",
-                        "- Observe the result of that action to inform further reasoning and actions.\n",
-                        "\n",
-                        "The ReAct agent provides a convenient out-of-the-box agent implementation that makes it easier to build agents using this pattern."
-                  ]
-            },
-            {
-                  "cell_type": "markdown",
-                  "metadata": {},
-                  "source": [
-                        "## Basic ReAct Agent\n",
-                        "\n",
-                        "To configure a ReAct agent, you need to define a ChatModel and construct a BeeAgent.\n",
-                        "\n",
-                        "In this example, we won't provide any external tools to the agent. It will rely solely on its own memory to provide answers. This is a basic setup where the agent tries to reason and act based on the context it has built internally.\n",
-                        "\n",
-                        "Try modifying the input text in the call to agent.run() to experiment with obtaining different answers. This will help you see how the agent's reasoning and response vary with different prompts."
-                  ]
-            },
-            {
-                  "cell_type": "code",
-                  "execution_count": 1,
-                  "metadata": {},
-                  "outputs": [
-                        {
-                              "name": "stdout",
-                              "output_type": "stream",
-                              "text": [
-                                    "Agent(thought) 🤖 :  The user wants to know the chemical composition of a water molecule. A water molecule is composed of two hydrogen atoms and one oxygen atom, represented as H2O.\n",
-                                    "\n",
-                                    "Agent(final_answer) 🤖 :  A water molecule consists of two hydrogen atoms and one oxygen atom, chemically represented as H2O.\n"
-                              ]
-                        }
-                  ],
-                  "source": [
-                        "from typing import Any\n",
-                        "\n",
-                        "from beeai_framework.agents.bee.agent import BeeAgent\n",
-                        "from beeai_framework.agents.types import BeeRunOutput\n",
-                        "from beeai_framework.backend.chat import ChatModel\n",
-                        "from beeai_framework.emitter.emitter import Emitter, EventMeta\n",
-                        "from beeai_framework.emitter.types import EmitterOptions\n",
-                        "from beeai_framework.memory.unconstrained_memory import UnconstrainedMemory\n",
-                        "\n",
-                        "# Construct ChatModel\n",
-                        "chat_model: ChatModel = ChatModel.from_name(\"ollama:granite3.1-dense:8b\")\n",
-                        "\n",
-                        "# Construct Agent instance with the chat model\n",
-                        "agent = BeeAgent(llm=chat_model, tools=[], memory=UnconstrainedMemory())\n",
-                        "\n",
-                        "\n",
-                        "async def process_agent_events(event_data: dict[str, Any], event_meta: EventMeta) -> None:\n",
-                        "    \"\"\"Process agent events and log appropriately\"\"\"\n",
-                        "\n",
-                        "    if event_meta.name == \"error\":\n",
-                        "        print(\"Agent 🤖 : \", event_data[\"error\"])\n",
-                        "    elif event_meta.name == \"retry\":\n",
-                        "        print(\"Agent 🤖 : \", \"retrying the action...\")\n",
-                        "    elif event_meta.name == \"update\":\n",
-                        "        print(f\"Agent({event_data['update']['key']}) 🤖 : \", event_data[\"update\"][\"parsedValue\"])\n",
-                        "\n",
-                        "\n",
-                        "# Observe the agent\n",
-                        "async def observer(emitter: Emitter) -> None:\n",
-                        "    emitter.on(\"*.*\", process_agent_events, EmitterOptions(match_nested=True))\n",
-                        "\n",
-                        "\n",
-                        "# Run the agent\n",
-                        "result: BeeRunOutput = await agent.run(\"What chemical elements make up a water molecule?\").observe(observer)"
-                  ]
-            },
-            {
-                  "cell_type": "markdown",
-                  "metadata": {},
-                  "source": [
-                        "## Using Tools\n",
-                        "\n",
-                        "To go beyond just chatting with an LLM, you can provide tools to the agent. This enables the agent to perform specific tasks and interact with external systems, enhancing its functionality. There are different ways to add tools to the agent:\n",
-                        "\n",
-                        "- Built-in tools from the framework: BeeAI provides several built-in tools that you can easily integrate with your agent.\n",
-                        "- Importing tools from other libraries: You can bring in external tools or APIs to extend your agent's capabilities.\n",
-                        "- Custom tooling: You can also write your own custom tools tailored to your specific use case.\n",
-                        "\n",
-                        "By equipping the agent with these tools, you allow it to perform more complex actions, such as querying databases, interacting with APIs, or manipulating data.\n",
-                        "\n",
-                        "## Built-in tools\n",
-                        "\n",
-                        "BeeAI comes with several built-in tools that are part of the library, which can be easily imported and added to your agent.\n",
-                        "\n",
-                        "In this example, we provide the agent with a weather forecast lookup tool called OpenMeteoTool. With this tool, the agent can retrieve real-time weather data, enabling it to answer weather-related queries with more accuracy.\n",
-                        "\n",
-                        "Follow the agent's thoughts and actions to understand how it approaches and solves the problem."
-                  ]
-            },
-            {
-                  "cell_type": "code",
-                  "execution_count": 2,
-                  "metadata": {},
-                  "outputs": [
-                        {
-                              "name": "stdout",
-                              "output_type": "stream",
-                              "text": [
-                                    "Agent(thought) 🤖 :  I need to use the OpenMeteoTool to get the current weather information for London.\n",
-                                    "\n",
-                                    "Agent(tool_name) 🤖 :  OpenMeteoTool\n",
-                                    "Agent(tool_input) 🤖 :  {'location_name': 'London', 'temperature_unit': 'celsius'}\n",
-                                    "Agent(tool_output) 🤖 :  {\"latitude\": 51.5, \"longitude\": -0.120000124, \"generationtime_ms\": 0.06449222564697266, \"utc_offset_seconds\": 0, \"timezone\": \"GMT\", \"timezone_abbreviation\": \"GMT\", \"elevation\": 23.0, \"current_units\": {\"time\": \"iso8601\", \"interval\": \"seconds\", \"temperature_2m\": \"\\u00b0C\", \"rain\": \"mm\", \"relative_humidity_2m\": \"%\", \"wind_speed_10m\": \"km/h\"}, \"current\": {\"time\": \"2025-03-06T04:00\", \"interval\": 900, \"temperature_2m\": 6.7, \"rain\": 0.0, \"relative_humidity_2m\": 63, \"wind_speed_10m\": 3.3}, \"daily_units\": {\"time\": \"iso8601\", \"temperature_2m_max\": \"\\u00b0C\", \"temperature_2m_min\": \"\\u00b0C\", \"rain_sum\": \"mm\"}, \"daily\": {\"time\": [\"2025-03-06\"], \"temperature_2m_max\": [15.1], \"temperature_2m_min\": [5.1], \"rain_sum\": [0.0]}}\n",
-                                    "Agent(thought) 🤖 :  The OpenMeteoTool returned the current weather information for London. The temperature is 6.7°C, with no rain and a wind speed of 3.3 km/h.\n",
-                                    "\n",
-                                    "Agent(final_answer) 🤖 :  The current weather in London is 6.7°C with no rain and a wind speed of 3.3 km/h.\n"
-                              ]
-                        }
-                  ],
-                  "source": [
-                        "from beeai_framework.backend.chat import ChatModel\n",
-                        "from beeai_framework.tools.weather.openmeteo import OpenMeteoTool\n",
-                        "\n",
-                        "chat_model: ChatModel = ChatModel.from_name(\"ollama:granite3.1-dense:8b\")\n",
-                        "\n",
-                        "# create an agent using the default LLM and add the OpenMeteoTool that is capable of fetching weather-based information\n",
-                        "agent = BeeAgent(llm=chat_model, tools=[OpenMeteoTool()], memory=UnconstrainedMemory())\n",
-                        "\n",
-                        "\n",
-                        "# Run the agent\n",
-                        "result: BeeRunOutput = await agent.run(\"What's the current weather in London?\").observe(observer)"
-                  ]
-            },
-            {
-                  "cell_type": "markdown",
-                  "metadata": {},
-                  "source": [
-                        "### Imported Tools\n",
-                        "\n",
-                        "Tools can also be imported from other libraries to extend the functionality of your agent. For example, you can integrate tools from libraries like LangChain to give your agent access to even more capabilities.\n",
-                        "\n",
-                        "Here’s an example showing how to integrate the Wikipedia tool from LangChain, written in long form (without using the @tool decorator):"
-                  ]
-            },
-            {
-                  "cell_type": "code",
-                  "execution_count": 3,
-                  "metadata": {},
-                  "outputs": [
-                        {
-                              "name": "stdout",
-                              "output_type": "stream",
-                              "text": [
-                                    "Agent(thought) 🤖 :  I can find this information using the Wikipedia tool.\n",
-                                    "Agent(tool_name) 🤖 :  Wikipedia\n",
-                                    "Agent(tool_input) 🤖 :  {'query': 'Current President of the European Commission'}\n",
-                                    "Agent(tool_output) 🤖 :  Page: Vice-President of the European Commission\n",
-                                    "Summary: A Vice-President of the European Commission is a member of the European Commission who leads the commission's work in particular focus areas in which multiple European Commissioners participate.\n",
-                                    "Currently, the European Commission has a total of six Vice-Presidents: five Executive-Vice Presidents, and the High Representative who is ex officio one of the Vice-Presidents as well.\n",
-                                    "\n",
-                                    "Page: European Commission\n",
-                                    "Summary: The European Commission (EC) is the primary executive arm of the European Union (EU). It operates as a cabinet government, with a number of members of the Commission (directorial system, informally known as \"Commissioners\") corresponding to two thirds of the number of member states, unless the European Council, acting unanimously, decides to alter this number. The current number of Commissioners is 27, including the President. It includes an administrative body of about 32,000 European civil servants. The commission is divided into departments known as Directorates-General (DGs) that can be likened to departments or ministries each headed by a Director-General who is responsible to a Commissioner.\n",
-                                    "Currently, there is one member per member state, but members are bound by their oath of office to represent the general interest of the EU as a whole rather than their home state. The Commission President (currently Ursula von der Leyen) is proposed by the European Council (the 27 heads of state/governments) and elected by the European Parliament. The Council of the European Union then nominates the other members of the Commission in agreement with the nominated President, and the 27 members as a team are then subject to a vote of approval by the European Parliament. The current Commission is the Von der Leyen Commission II, which took office in December 2024, following the European Parliament elections in June of the same year.\n",
-                                    "\n",
-                                    "Page: List of presidents of the institutions of the European Union\n",
-                                    "Summary: This is a list of presidents of the institutions of the European Union (EU). Each of the institutions is headed by a president or a presidency, with some being more prominent than others. Both the President of the European Council and the President of the European Commission are sometimes wrongly termed the President of the European Union. Most go back to 1957 but others, such as the President of the Auditors Court or of the European Central Bank, have been created recently. Currently (2025), the President of the European Commission is Ursula von der Leyen and the President of the European Council is António Costa.\n",
-                                    "Agent(thought) 🤖 :  The current president of the European Commission is Ursula von der Leyen, as per the information retrieved from Wikipedia.\n",
-                                    "Agent(final_answer) 🤖 :  The current president of the European Commission is Ursula von der Leyen.\n"
-                              ]
-                        }
-                  ],
-                  "source": [
-                        "from typing import Any\n",
-                        "\n",
-                        "from langchain_community.tools import WikipediaQueryRun\n",
-                        "from langchain_community.utilities import WikipediaAPIWrapper\n",
-                        "from pydantic import BaseModel, Field\n",
-                        "\n",
-                        "from beeai_framework.agents.bee.agent import BeeAgent\n",
-                        "from beeai_framework.context import RunContext\n",
-                        "from beeai_framework.tools import Tool\n",
-                        "from beeai_framework.tools.tool import StringToolOutput, ToolRunOptions\n",
-                        "\n",
-                        "\n",
-                        "class LangChainWikipediaToolInput(BaseModel):\n",
-                        "    query: str = Field(description=\"The topic or question to search for on Wikipedia.\")\n",
-                        "\n",
-                        "\n",
-                        "class LangChainWikipediaTool(Tool[LangChainWikipediaToolInput, ToolRunOptions]):\n",
-                        "    \"\"\"Adapter class to integrate LangChain's Wikipedia tool with our framework\"\"\"\n",
-                        "\n",
-                        "    name = \"Wikipedia\"\n",
-                        "    description = \"Search factual and historical information from Wikipedia about given topics.\"\n",
-                        "    input_schema = LangChainWikipediaToolInput\n",
-                        "\n",
-                        "    def __init__(self) -> None:\n",
-                        "        super().__init__()\n",
-                        "        self._wikipedia = WikipediaQueryRun(api_wrapper=WikipediaAPIWrapper())\n",
-                        "\n",
-                        "    def _create_emitter(self) -> Emitter:\n",
-                        "        return Emitter.root().child(\n",
-                        "            namespace=[\"tool\", \"search\", \"langchain_wikipedia\"],\n",
-                        "            creator=self,\n",
-                        "        )\n",
-                        "\n",
-                        "    async def _run(self, input: LangChainWikipediaToolInput, options: ToolRunOptions | None, context: RunContext) -> StringToolOutput:\n",
-                        "        query = input.query\n",
-                        "        try:\n",
-                        "            result = self._wikipedia.run(query)\n",
-                        "            return StringToolOutput(result=result)\n",
-                        "        except Exception as e:\n",
-                        "            print(f\"Wikipedia search error: {e!s}\")\n",
-                        "            return f\"Error searching Wikipedia: {e!s}\"\n",
-                        "\n",
-                        "\n",
-                        "chat_model: ChatModel = ChatModel.from_name(\"ollama:granite3.1-dense:8b\")\n",
-                        "agent = BeeAgent(llm=chat_model, tools=[LangChainWikipediaTool()], memory=UnconstrainedMemory())\n",
-                        "\n",
-                        "result: BeeRunOutput = await agent.run(\"Who is the current president of the European Commission?\").observe(observer)"
-                  ]
-            },
-            {
-                  "cell_type": "markdown",
-                  "metadata": {},
-                  "source": [
-                        "The previous example can be re-written in a shorter form by adding the @tool decorator, which simplifies the tool definition. Here's how you can do it:"
-                  ]
-            },
-            {
-                  "cell_type": "code",
-                  "execution_count": 4,
-                  "metadata": {},
-                  "outputs": [
-                        {
-                              "name": "stdout",
-                              "output_type": "stream",
-                              "text": [
-                                    "Agent(thought) 🤖 :  I need to use the langchain_wikipedia_tool to find the longest living vertebrate.\n",
-                                    "Agent(tool_name) 🤖 :  langchain_wikipedia_tool\n",
-                                    "Agent(tool_input) 🤖 :  {'query': 'longest living vertebrate'}\n",
-                                    "Agent(tool_output) 🤖 :  Page: Hákarl\n",
-                                    "Summary: Hákarl (an abbreviation of kæstur hákarl [ˈcʰaistʏr ˈhauːˌkʰa(r)tl̥]), referred to as fermented shark in English, is a national dish of Iceland consisting of Greenland shark or other sleeper shark that has been cured with a particular fermentation process and hung to dry for four to five months. It has a strong ammonia-rich smell and fishy taste, making hákarl an acquired taste.\n",
-                                    "Fermented shark is readily available in Icelandic stores and may be eaten year-round, but is most often served as part of a Þorramatur, a selection of traditional Icelandic food served at the midwinter festival þorrablót.\n",
-                                    "\n",
-                                    "Page: List of longest-living organisms\n",
-                                    "Summary: This is a list of the longest-living biological organisms: the individual(s) (or in some instances, clones) of a species with the longest natural maximum life spans. For a given species, such a designation may include:\n",
-                                    "\n",
-                                    "The oldest known individual(s) that are currently alive, with verified ages.\n",
-                                    "Verified individual record holders, such as the longest-lived human, Jeanne Calment, or the longest-lived domestic cat, Creme Puff.\n",
-                                    "The definition of \"longest-living\" used in this article considers only the observed or estimated length of an individual organism's natural lifespan – that is, the duration of time between its birth or conception, or the earliest emergence of its identity as an individual organism, and its death – and does not consider other conceivable interpretations of \"longest-living\", such as the length of time between the earliest appearance of a species in the fossil record and the present (the historical \"age\" of the species as a whole), the time between a species' first speciation and its extinction (the phylogenetic \"lifespan\" of the species), or the range of possible lifespans of a species' individuals. This list includes long-lived organisms that are currently still alive as well as those that are dead.\n",
-                                    "Determining the length of an organism's natural lifespan is complicated by many problems of definition and interpretation, as well as by practical difficulties in reliably measuring age, particularly for extremely old organisms and for those that reproduce by asexual cloning. In many cases the ages listed below are estimates based on observed present-day growth rates, which may differ significantly from the growth rates experienced thousands of years ago. Identifying the longest-living organisms also depends on defining what constitutes an \"individual\" organism, which can be problematic, since many asexual organisms and clonal colonies defy one or both of the traditional colloquial definitions of individuality (having a distinct genotype and having an independent, physically separate body). Additionally, some organisms maintain the capability to reproduce through very long periods of metabolic dormancy, during which they may not be considered \"alive\" by certain definitions but nonetheless can resume normal metabolism afterward; it is unclear whether the dormant periods should be counted as part of the organism's lifespan.\n",
-                                    "\n",
-                                    "Page: Greenland shark\n",
-                                    "Summary: The Greenland shark (Somniosus microcephalus), also known as the gurry shark or grey shark, is a large shark of the family Somniosidae (\"sleeper sharks\"), closely related to the Pacific and southern sleeper sharks. Inhabiting the North Atlantic and Arctic Oceans, they are notable for their exceptional longevity, although they are poorly studied due to the depth and remoteness of their natural habitat.\n",
-                                    "Greenland sharks have the longest lifespan of any known vertebrate, estimated to be between 250 and 500 years. They are among the largest extant species of shark, reaching a maximum confirmed length of 6.4 m (21 ft) long and weighing over 1,000 kg (2,200 lb). They reach sexual maturity at about 150 years of age, and their pups are born alive after an estimated gestation period of 8 to 18 years.\n",
-                                    "The shark is a generalist feeder, consuming a variety of available foods, including carrion.\n",
-                                    "Greenland shark me\n",
-                                    "Agent(thought) 🤖 :  The information provided indicates that the Greenland shark has the longest lifespan among vertebrates, estimated to be between 250 and 500 years.\n",
-                                    "Agent(final_answer) 🤖 :  The Greenland shark is the longest living vertebrate, with an estimated lifespan of 250 to 500 years.\n"
-                              ]
-                        }
-                  ],
-                  "source": [
-                        "from langchain_community.tools import WikipediaQueryRun  # noqa: F811\n",
-                        "from langchain_community.utilities import WikipediaAPIWrapper  # noqa: F811\n",
-                        "\n",
-                        "from beeai_framework.agents.bee.agent import BeeAgent\n",
-                        "from beeai_framework.tools import Tool, tool\n",
-                        "\n",
-                        "\n",
-                        "# defining a tool using the `tool` decorator\n",
-                        "# Note: the pydoc is important as it serves as the tool description to the agent\n",
-                        "@tool\n",
-                        "def langchain_wikipedia_tool(query: str) -> str:\n",
-                        "    \"\"\"\n",
-                        "    Search factual and historical information, including biography, history, politics, geography, society, culture,\n",
-                        "    science, technology, people, animal species, mathematics, and other subjects.\n",
-                        "\n",
-                        "    Args:\n",
-                        "        query: The topic or question to search for on Wikipedia.\n",
-                        "\n",
-                        "    Returns:\n",
-                        "        The information found via searching Wikipedia.\n",
-                        "    \"\"\"\n",
-                        "    wikipedia = WikipediaQueryRun(api_wrapper=WikipediaAPIWrapper())\n",
-                        "    return wikipedia.run(query)\n",
-                        "\n",
-                        "\n",
-                        "# using the tool in an agent\n",
-                        "chat_model: ChatModel = ChatModel.from_name(\"ollama:granite3.1-dense:8b\")\n",
-                        "agent = BeeAgent(llm=chat_model, tools=[langchain_wikipedia_tool], memory=UnconstrainedMemory())\n",
-                        "\n",
-                        "result: BeeRunOutput = await agent.run(\"What is the longest living vertebrate?\").observe(observer)"
-                  ]
-            }
-      ],
-      "metadata": {
-            "kernelspec": {
-                  "display_name": "beeai-framework-IVd76ig_-py3.12",
-                  "language": "python",
-                  "name": "python3"
-            },
-            "language_info": {
-                  "codemirror_mode": {
-                        "name": "ipython",
-                        "version": 3
-                  },
-                  "file_extension": ".py",
-                  "mimetype": "text/x-python",
-                  "name": "python",
-                  "nbconvert_exporter": "python",
-                  "pygments_lexer": "ipython3",
-                  "version": "3.12.6"
-            }
-      },
-      "nbformat": 4,
-      "nbformat_minor": 4
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# BeeAI ReAct agents\n",
+    "\n",
+    "The BeeAI ReAct agent is a pre-configured implementation of the ReAct (Reasoning and Acting) pattern. It can be customized with tools and instructions to suit different tasks.\n",
+    "\n",
+    "The ReAct pattern is a framework used in AI models, particularly language models, to separate the reasoning process from the action-taking process. This pattern enhances the model's ability to handle complex queries by enabling it to:\n",
+    "\n",
+    "- Reason about the problem.\n",
+    "- Decide on an action to take.\n",
+    "- Observe the result of that action to inform further reasoning and actions.\n",
+    "\n",
+    "The ReAct agent provides a convenient out-of-the-box agent implementation that makes it easier to build agents using this pattern."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Basic ReAct Agent\n",
+    "\n",
+    "To configure a ReAct agent, you need to define a ChatModel and construct a BeeAgent.\n",
+    "\n",
+    "In this example, we won't provide any external tools to the agent. It will rely solely on its own memory to provide answers. This is a basic setup where the agent tries to reason and act based on the context it has built internally.\n",
+    "\n",
+    "Try modifying the input text in the call to agent.run() to experiment with obtaining different answers. This will help you see how the agent's reasoning and response vary with different prompts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Agent(thought) 🤖 :  The user wants to know the chemical composition of a water molecule. A water molecule is composed of two hydrogen atoms and one oxygen atom, represented as H2O.\n",
+      "\n",
+      "Agent(final_answer) 🤖 :  A water molecule consists of two hydrogen atoms and one oxygen atom, chemically represented as H2O.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from typing import Any\n",
+    "\n",
+    "from beeai_framework.agents.bee.agent import BeeAgent\n",
+    "from beeai_framework.agents.types import BeeRunOutput\n",
+    "from beeai_framework.backend.chat import ChatModel\n",
+    "from beeai_framework.emitter.emitter import Emitter, EventMeta\n",
+    "from beeai_framework.emitter.types import EmitterOptions\n",
+    "from beeai_framework.memory.unconstrained_memory import UnconstrainedMemory\n",
+    "\n",
+    "# Construct ChatModel\n",
+    "chat_model: ChatModel = ChatModel.from_name(\"ollama:granite3.1-dense:8b\")\n",
+    "\n",
+    "# Construct Agent instance with the chat model\n",
+    "agent = BeeAgent(llm=chat_model, tools=[], memory=UnconstrainedMemory())\n",
+    "\n",
+    "\n",
+    "async def process_agent_events(event_data: dict[str, Any], event_meta: EventMeta) -> None:\n",
+    "    \"\"\"Process agent events and log appropriately\"\"\"\n",
+    "\n",
+    "    if event_meta.name == \"error\":\n",
+    "        print(\"Agent 🤖 : \", event_data[\"error\"])\n",
+    "    elif event_meta.name == \"retry\":\n",
+    "        print(\"Agent 🤖 : \", \"retrying the action...\")\n",
+    "    elif event_meta.name == \"update\":\n",
+    "        print(f\"Agent({event_data['update']['key']}) 🤖 : \", event_data[\"update\"][\"parsedValue\"])\n",
+    "\n",
+    "\n",
+    "# Observe the agent\n",
+    "async def observer(emitter: Emitter) -> None:\n",
+    "    emitter.on(\"*.*\", process_agent_events, EmitterOptions(match_nested=True))\n",
+    "\n",
+    "\n",
+    "# Run the agent\n",
+    "result: BeeRunOutput = await agent.run(\"What chemical elements make up a water molecule?\").observe(observer)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using Tools\n",
+    "\n",
+    "To go beyond just chatting with an LLM, you can provide tools to the agent. This enables the agent to perform specific tasks and interact with external systems, enhancing its functionality. There are different ways to add tools to the agent:\n",
+    "\n",
+    "- Built-in tools from the framework: BeeAI provides several built-in tools that you can easily integrate with your agent.\n",
+    "- Importing tools from other libraries: You can bring in external tools or APIs to extend your agent's capabilities.\n",
+    "- Custom tooling: You can also write your own custom tools tailored to your specific use case.\n",
+    "\n",
+    "By equipping the agent with these tools, you allow it to perform more complex actions, such as querying databases, interacting with APIs, or manipulating data.\n",
+    "\n",
+    "## Built-in tools\n",
+    "\n",
+    "BeeAI comes with several built-in tools that are part of the library, which can be easily imported and added to your agent.\n",
+    "\n",
+    "In this example, we provide the agent with a weather forecast lookup tool called OpenMeteoTool. With this tool, the agent can retrieve real-time weather data, enabling it to answer weather-related queries with more accuracy.\n",
+    "\n",
+    "Follow the agent's thoughts and actions to understand how it approaches and solves the problem."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Agent(thought) 🤖 :  I need to use the OpenMeteoTool to get the current weather information for London.\n",
+      "\n",
+      "Agent(tool_name) 🤖 :  OpenMeteoTool\n",
+      "Agent(tool_input) 🤖 :  {'location_name': 'London', 'temperature_unit': 'celsius'}\n",
+      "Agent(tool_output) 🤖 :  {\"latitude\": 51.5, \"longitude\": -0.120000124, \"generationtime_ms\": 0.06449222564697266, \"utc_offset_seconds\": 0, \"timezone\": \"GMT\", \"timezone_abbreviation\": \"GMT\", \"elevation\": 23.0, \"current_units\": {\"time\": \"iso8601\", \"interval\": \"seconds\", \"temperature_2m\": \"\\u00b0C\", \"rain\": \"mm\", \"relative_humidity_2m\": \"%\", \"wind_speed_10m\": \"km/h\"}, \"current\": {\"time\": \"2025-03-06T04:00\", \"interval\": 900, \"temperature_2m\": 6.7, \"rain\": 0.0, \"relative_humidity_2m\": 63, \"wind_speed_10m\": 3.3}, \"daily_units\": {\"time\": \"iso8601\", \"temperature_2m_max\": \"\\u00b0C\", \"temperature_2m_min\": \"\\u00b0C\", \"rain_sum\": \"mm\"}, \"daily\": {\"time\": [\"2025-03-06\"], \"temperature_2m_max\": [15.1], \"temperature_2m_min\": [5.1], \"rain_sum\": [0.0]}}\n",
+      "Agent(thought) 🤖 :  The OpenMeteoTool returned the current weather information for London. The temperature is 6.7°C, with no rain and a wind speed of 3.3 km/h.\n",
+      "\n",
+      "Agent(final_answer) 🤖 :  The current weather in London is 6.7°C with no rain and a wind speed of 3.3 km/h.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from beeai_framework.backend.chat import ChatModel\n",
+    "from beeai_framework.tools.weather.openmeteo import OpenMeteoTool\n",
+    "\n",
+    "chat_model: ChatModel = ChatModel.from_name(\"ollama:granite3.1-dense:8b\")\n",
+    "\n",
+    "# create an agent using the default LLM and add the OpenMeteoTool that is capable of fetching weather-based information\n",
+    "agent = BeeAgent(llm=chat_model, tools=[OpenMeteoTool()], memory=UnconstrainedMemory())\n",
+    "\n",
+    "\n",
+    "# Run the agent\n",
+    "result: BeeRunOutput = await agent.run(\"What's the current weather in London?\").observe(observer)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Imported Tools\n",
+    "\n",
+    "Tools can also be imported from other libraries to extend the functionality of your agent. For example, you can integrate tools from libraries like LangChain to give your agent access to even more capabilities.\n",
+    "\n",
+    "Here’s an example showing how to integrate the Wikipedia tool from LangChain, written in long form (without using the @tool decorator):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Agent(thought) 🤖 :  I can find this information using the Wikipedia tool.\n",
+      "Agent(tool_name) 🤖 :  Wikipedia\n",
+      "Agent(tool_input) 🤖 :  {'query': 'Current President of the European Commission'}\n",
+      "Agent(tool_output) 🤖 :  Page: Vice-President of the European Commission\n",
+      "Summary: A Vice-President of the European Commission is a member of the European Commission who leads the commission's work in particular focus areas in which multiple European Commissioners participate.\n",
+      "Currently, the European Commission has a total of six Vice-Presidents: five Executive-Vice Presidents, and the High Representative who is ex officio one of the Vice-Presidents as well.\n",
+      "\n",
+      "Page: European Commission\n",
+      "Summary: The European Commission (EC) is the primary executive arm of the European Union (EU). It operates as a cabinet government, with a number of members of the Commission (directorial system, informally known as \"Commissioners\") corresponding to two thirds of the number of member states, unless the European Council, acting unanimously, decides to alter this number. The current number of Commissioners is 27, including the President. It includes an administrative body of about 32,000 European civil servants. The commission is divided into departments known as Directorates-General (DGs) that can be likened to departments or ministries each headed by a Director-General who is responsible to a Commissioner.\n",
+      "Currently, there is one member per member state, but members are bound by their oath of office to represent the general interest of the EU as a whole rather than their home state. The Commission President (currently Ursula von der Leyen) is proposed by the European Council (the 27 heads of state/governments) and elected by the European Parliament. The Council of the European Union then nominates the other members of the Commission in agreement with the nominated President, and the 27 members as a team are then subject to a vote of approval by the European Parliament. The current Commission is the Von der Leyen Commission II, which took office in December 2024, following the European Parliament elections in June of the same year.\n",
+      "\n",
+      "Page: List of presidents of the institutions of the European Union\n",
+      "Summary: This is a list of presidents of the institutions of the European Union (EU). Each of the institutions is headed by a president or a presidency, with some being more prominent than others. Both the President of the European Council and the President of the European Commission are sometimes wrongly termed the President of the European Union. Most go back to 1957 but others, such as the President of the Auditors Court or of the European Central Bank, have been created recently. Currently (2025), the President of the European Commission is Ursula von der Leyen and the President of the European Council is António Costa.\n",
+      "Agent(thought) 🤖 :  The current president of the European Commission is Ursula von der Leyen, as per the information retrieved from Wikipedia.\n",
+      "Agent(final_answer) 🤖 :  The current president of the European Commission is Ursula von der Leyen.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from typing import Any\n",
+    "\n",
+    "from langchain_community.tools import WikipediaQueryRun\n",
+    "from langchain_community.utilities import WikipediaAPIWrapper\n",
+    "from pydantic import BaseModel, Field\n",
+    "\n",
+    "from beeai_framework.agents.bee.agent import BeeAgent\n",
+    "from beeai_framework.context import RunContext\n",
+    "from beeai_framework.tools import Tool\n",
+    "from beeai_framework.tools.tool import StringToolOutput, ToolRunOptions\n",
+    "\n",
+    "\n",
+    "class LangChainWikipediaToolInput(BaseModel):\n",
+    "    query: str = Field(description=\"The topic or question to search for on Wikipedia.\")\n",
+    "\n",
+    "\n",
+    "class LangChainWikipediaTool(Tool[LangChainWikipediaToolInput, ToolRunOptions]):\n",
+    "    \"\"\"Adapter class to integrate LangChain's Wikipedia tool with our framework\"\"\"\n",
+    "\n",
+    "    name = \"Wikipedia\"\n",
+    "    description = \"Search factual and historical information from Wikipedia about given topics.\"\n",
+    "    input_schema = LangChainWikipediaToolInput\n",
+    "\n",
+    "    def __init__(self) -> None:\n",
+    "        super().__init__()\n",
+    "        self._wikipedia = WikipediaQueryRun(api_wrapper=WikipediaAPIWrapper())\n",
+    "\n",
+    "    def _create_emitter(self) -> Emitter:\n",
+    "        return Emitter.root().child(\n",
+    "            namespace=[\"tool\", \"search\", \"langchain_wikipedia\"],\n",
+    "            creator=self,\n",
+    "        )\n",
+    "\n",
+    "    async def _run(\n",
+    "        self, input: LangChainWikipediaToolInput, options: ToolRunOptions | None, context: RunContext\n",
+    "    ) -> StringToolOutput:\n",
+    "        query = input.query\n",
+    "        try:\n",
+    "            result = self._wikipedia.run(query)\n",
+    "            return StringToolOutput(result=result)\n",
+    "        except Exception as e:\n",
+    "            print(f\"Wikipedia search error: {e!s}\")\n",
+    "            return f\"Error searching Wikipedia: {e!s}\"\n",
+    "\n",
+    "\n",
+    "chat_model: ChatModel = ChatModel.from_name(\"ollama:granite3.1-dense:8b\")\n",
+    "agent = BeeAgent(llm=chat_model, tools=[LangChainWikipediaTool()], memory=UnconstrainedMemory())\n",
+    "\n",
+    "result: BeeRunOutput = await agent.run(\"Who is the current president of the European Commission?\").observe(observer)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The previous example can be re-written in a shorter form by adding the @tool decorator, which simplifies the tool definition. Here's how you can do it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Agent(thought) 🤖 :  I need to use the langchain_wikipedia_tool to find the longest living vertebrate.\n",
+      "Agent(tool_name) 🤖 :  langchain_wikipedia_tool\n",
+      "Agent(tool_input) 🤖 :  {'query': 'longest living vertebrate'}\n",
+      "Agent(tool_output) 🤖 :  Page: Hákarl\n",
+      "Summary: Hákarl (an abbreviation of kæstur hákarl [ˈcʰaistʏr ˈhauːˌkʰa(r)tl̥]), referred to as fermented shark in English, is a national dish of Iceland consisting of Greenland shark or other sleeper shark that has been cured with a particular fermentation process and hung to dry for four to five months. It has a strong ammonia-rich smell and fishy taste, making hákarl an acquired taste.\n",
+      "Fermented shark is readily available in Icelandic stores and may be eaten year-round, but is most often served as part of a Þorramatur, a selection of traditional Icelandic food served at the midwinter festival þorrablót.\n",
+      "\n",
+      "Page: List of longest-living organisms\n",
+      "Summary: This is a list of the longest-living biological organisms: the individual(s) (or in some instances, clones) of a species with the longest natural maximum life spans. For a given species, such a designation may include:\n",
+      "\n",
+      "The oldest known individual(s) that are currently alive, with verified ages.\n",
+      "Verified individual record holders, such as the longest-lived human, Jeanne Calment, or the longest-lived domestic cat, Creme Puff.\n",
+      "The definition of \"longest-living\" used in this article considers only the observed or estimated length of an individual organism's natural lifespan – that is, the duration of time between its birth or conception, or the earliest emergence of its identity as an individual organism, and its death – and does not consider other conceivable interpretations of \"longest-living\", such as the length of time between the earliest appearance of a species in the fossil record and the present (the historical \"age\" of the species as a whole), the time between a species' first speciation and its extinction (the phylogenetic \"lifespan\" of the species), or the range of possible lifespans of a species' individuals. This list includes long-lived organisms that are currently still alive as well as those that are dead.\n",
+      "Determining the length of an organism's natural lifespan is complicated by many problems of definition and interpretation, as well as by practical difficulties in reliably measuring age, particularly for extremely old organisms and for those that reproduce by asexual cloning. In many cases the ages listed below are estimates based on observed present-day growth rates, which may differ significantly from the growth rates experienced thousands of years ago. Identifying the longest-living organisms also depends on defining what constitutes an \"individual\" organism, which can be problematic, since many asexual organisms and clonal colonies defy one or both of the traditional colloquial definitions of individuality (having a distinct genotype and having an independent, physically separate body). Additionally, some organisms maintain the capability to reproduce through very long periods of metabolic dormancy, during which they may not be considered \"alive\" by certain definitions but nonetheless can resume normal metabolism afterward; it is unclear whether the dormant periods should be counted as part of the organism's lifespan.\n",
+      "\n",
+      "Page: Greenland shark\n",
+      "Summary: The Greenland shark (Somniosus microcephalus), also known as the gurry shark or grey shark, is a large shark of the family Somniosidae (\"sleeper sharks\"), closely related to the Pacific and southern sleeper sharks. Inhabiting the North Atlantic and Arctic Oceans, they are notable for their exceptional longevity, although they are poorly studied due to the depth and remoteness of their natural habitat.\n",
+      "Greenland sharks have the longest lifespan of any known vertebrate, estimated to be between 250 and 500 years. They are among the largest extant species of shark, reaching a maximum confirmed length of 6.4 m (21 ft) long and weighing over 1,000 kg (2,200 lb). They reach sexual maturity at about 150 years of age, and their pups are born alive after an estimated gestation period of 8 to 18 years.\n",
+      "The shark is a generalist feeder, consuming a variety of available foods, including carrion.\n",
+      "Greenland shark me\n",
+      "Agent(thought) 🤖 :  The information provided indicates that the Greenland shark has the longest lifespan among vertebrates, estimated to be between 250 and 500 years.\n",
+      "Agent(final_answer) 🤖 :  The Greenland shark is the longest living vertebrate, with an estimated lifespan of 250 to 500 years.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from langchain_community.tools import WikipediaQueryRun  # noqa: F811\n",
+    "from langchain_community.utilities import WikipediaAPIWrapper  # noqa: F811\n",
+    "\n",
+    "from beeai_framework.agents.bee.agent import BeeAgent\n",
+    "from beeai_framework.tools import Tool, tool\n",
+    "\n",
+    "\n",
+    "# defining a tool using the `tool` decorator\n",
+    "# Note: the pydoc is important as it serves as the tool description to the agent\n",
+    "@tool\n",
+    "def langchain_wikipedia_tool(query: str) -> str:\n",
+    "    \"\"\"\n",
+    "    Search factual and historical information, including biography, history, politics, geography, society, culture,\n",
+    "    science, technology, people, animal species, mathematics, and other subjects.\n",
+    "\n",
+    "    Args:\n",
+    "        query: The topic or question to search for on Wikipedia.\n",
+    "\n",
+    "    Returns:\n",
+    "        The information found via searching Wikipedia.\n",
+    "    \"\"\"\n",
+    "    wikipedia = WikipediaQueryRun(api_wrapper=WikipediaAPIWrapper())\n",
+    "    return wikipedia.run(query)\n",
+    "\n",
+    "\n",
+    "# using the tool in an agent\n",
+    "chat_model: ChatModel = ChatModel.from_name(\"ollama:granite3.1-dense:8b\")\n",
+    "agent = BeeAgent(llm=chat_model, tools=[langchain_wikipedia_tool], memory=UnconstrainedMemory())\n",
+    "\n",
+    "result: BeeRunOutput = await agent.run(\"What is the longest living vertebrate?\").observe(observer)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "beeai-framework-IVd76ig_-py3.12",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/python/examples/notebooks/agents.ipynb
+++ b/python/examples/notebooks/agents.ipynb
@@ -1,306 +1,326 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# BeeAI ReAct agents\n",
-    "\n",
-    "The BeeAI ReAct agent is a pre-configured implementation of the ReAct (Reasoning and Acting) pattern. It can be customized with tools and instructions to suit different tasks.\n",
-    "\n",
-    "The ReAct pattern is a framework used in AI models, particularly language models, to separate the reasoning process from the action-taking process. This pattern enhances the model's ability to handle complex queries by enabling it to:\n",
-    "\n",
-    "- Reason about the problem.\n",
-    "- Decide on an action to take.\n",
-    "- Observe the result of that action to inform further reasoning and actions.\n",
-    "\n",
-    "The ReAct agent provides a convenient out-of-the-box agent implementation that makes it easier to build agents using this pattern."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Basic ReAct Agent\n",
-    "\n",
-    "To configure a ReAct agent, you need to define a ChatModel and construct a BeeAgent.\n",
-    "\n",
-    "In this example, we won't provide any external tools to the agent. It will rely solely on its own memory to provide answers. This is a basic setup where the agent tries to reason and act based on the context it has built internally.\n",
-    "\n",
-    "Try modifying the input text in the call to agent.run() to experiment with obtaining different answers. This will help you see how the agent's reasoning and response vary with different prompts."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Agent(thought) 🤖 :  The user wants to know the chemical composition of a water molecule. A water molecule is composed of two hydrogen atoms and one oxygen atom, represented as H2O.\n",
-      "\n",
-      "Agent(final_answer) 🤖 :  A water molecule consists of two hydrogen atoms and one oxygen atom, chemically represented as H2O.\n"
-     ]
-    }
-   ],
-   "source": [
-    "from typing import Any\n",
-    "\n",
-    "from beeai_framework.agents.bee.agent import BeeAgent\n",
-    "from beeai_framework.agents.types import BeeRunOutput\n",
-    "from beeai_framework.backend.chat import ChatModel\n",
-    "from beeai_framework.emitter.emitter import Emitter, EventMeta\n",
-    "from beeai_framework.emitter.types import EmitterOptions\n",
-    "from beeai_framework.memory.unconstrained_memory import UnconstrainedMemory\n",
-    "\n",
-    "# Construct ChatModel\n",
-    "chat_model: ChatModel = ChatModel.from_name(\"ollama:granite3.1-dense:8b\")\n",
-    "\n",
-    "# Construct Agent instance with the chat model\n",
-    "agent = BeeAgent(llm=chat_model, tools=[], memory=UnconstrainedMemory())\n",
-    "\n",
-    "\n",
-    "async def process_agent_events(event_data: dict[str, Any], event_meta: EventMeta) -> None:\n",
-    "    \"\"\"Process agent events and log appropriately\"\"\"\n",
-    "\n",
-    "    if event_meta.name == \"error\":\n",
-    "        print(\"Agent 🤖 : \", event_data[\"error\"])\n",
-    "    elif event_meta.name == \"retry\":\n",
-    "        print(\"Agent 🤖 : \", \"retrying the action...\")\n",
-    "    elif event_meta.name == \"update\":\n",
-    "        print(f\"Agent({event_data['update']['key']}) 🤖 : \", event_data[\"update\"][\"parsedValue\"])\n",
-    "\n",
-    "\n",
-    "# Observe the agent\n",
-    "async def observer(emitter: Emitter) -> None:\n",
-    "    emitter.on(\"*.*\", process_agent_events, EmitterOptions(match_nested=True))\n",
-    "\n",
-    "\n",
-    "# Run the agent\n",
-    "result: BeeRunOutput = await agent.run(\"What chemical elements make up a water molecule?\").observe(observer)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Using Tools\n",
-    "\n",
-    "To go beyond just chatting with an LLM, you can provide tools to the agent. This enables the agent to perform specific tasks and interact with external systems, enhancing its functionality. There are different ways to add tools to the agent:\n",
-    "\n",
-    "- Built-in tools from the framework: BeeAI provides several built-in tools that you can easily integrate with your agent.\n",
-    "- Importing tools from other libraries: You can bring in external tools or APIs to extend your agent's capabilities.\n",
-    "- Custom tooling: You can also write your own custom tools tailored to your specific use case.\n",
-    "\n",
-    "By equipping the agent with these tools, you allow it to perform more complex actions, such as querying databases, interacting with APIs, or manipulating data.\n",
-    "\n",
-    "## Built-in tools\n",
-    "\n",
-    "BeeAI comes with several built-in tools that are part of the library, which can be easily imported and added to your agent.\n",
-    "\n",
-    "In this example, we provide the agent with a weather forecast lookup tool called OpenMeteoTool. With this tool, the agent can retrieve real-time weather data, enabling it to answer weather-related queries with more accuracy.\n",
-    "\n",
-    "Follow the agent's thoughts and actions to understand how it approaches and solves the problem."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Agent(thought) 🤖 :  I need to use the OpenMeteoTool to get the current weather information for London.\n",
-      "\n",
-      "Agent(tool_name) 🤖 :  OpenMeteoTool\n",
-      "Agent(tool_input) 🤖 :  {'location_name': 'London', 'temperature_unit': 'celsius'}\n",
-      "Agent(tool_output) 🤖 :  <beeai_framework.tools.tool.StringToolOutput object at 0x117cd2bd0>\n",
-      "Agent(thought) 🤖 :  The OpenMeteoTool returned the current weather information for London. The temperature is 7.3°C, with no rain and a relative humidity of 60%. The wind speed is 4.2 km/h.\n",
-      "\n",
-      "Agent(final_answer) 🤖 :  The current weather in London is 7.3°C with no rain and a relative humidity of 60%, and the wind speed is 4.2 km/h.\n"
-     ]
-    }
-   ],
-   "source": [
-    "from beeai_framework.backend.chat import ChatModel\n",
-    "from beeai_framework.tools.weather.openmeteo import OpenMeteoTool\n",
-    "\n",
-    "chat_model: ChatModel = ChatModel.from_name(\"ollama:granite3.1-dense:8b\")\n",
-    "\n",
-    "# create an agent using the default LLM and add the OpenMeteoTool that is capable of fetching weather-based information\n",
-    "agent = BeeAgent(llm=chat_model, tools=[OpenMeteoTool()], memory=UnconstrainedMemory())\n",
-    "\n",
-    "\n",
-    "# Run the agent\n",
-    "result: BeeRunOutput = await agent.run(\"What's the current weather in London?\").observe(observer)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Imported Tools\n",
-    "\n",
-    "Tools can also be imported from other libraries to extend the functionality of your agent. For example, you can integrate tools from libraries like LangChain to give your agent access to even more capabilities.\n",
-    "\n",
-    "Here’s an example showing how to integrate the Wikipedia tool from LangChain, written in long form (without using the @tool decorator):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Agent(thought) 🤖 :  I can find this information using the Wikipedia tool.\n",
-      "Agent(tool_name) 🤖 :  Wikipedia\n",
-      "Agent(tool_input) 🤖 :  {'query': 'Current President of the European Commission'}\n",
-      "Agent(tool_output) 🤖 :  <beeai_framework.tools.tool.StringToolOutput object at 0x11777f440>\n",
-      "Agent(thought) 🤖 :  The current president of the European Commission is Ursula von der Leyen, as per the information retrieved from Wikipedia.\n",
-      "Agent(final_answer) 🤖 :  The current president of the European Commission is Ursula von der Leyen.\n"
-     ]
-    }
-   ],
-   "source": [
-    "from typing import Any\n",
-    "\n",
-    "from langchain_community.tools import WikipediaQueryRun\n",
-    "from langchain_community.utilities import WikipediaAPIWrapper\n",
-    "from pydantic import BaseModel, Field\n",
-    "\n",
-    "from beeai_framework.agents.bee.agent import BeeAgent\n",
-    "from beeai_framework.context import RunContext\n",
-    "from beeai_framework.tools import Tool\n",
-    "from beeai_framework.tools.tool import StringToolOutput, ToolRunOptions\n",
-    "\n",
-    "\n",
-    "class LangChainWikipediaToolInput(BaseModel):\n",
-    "    query: str = Field(description=\"The topic or question to search for on Wikipedia.\")\n",
-    "\n",
-    "\n",
-    "class LangChainWikipediaTool(Tool[LangChainWikipediaToolInput, ToolRunOptions]):\n",
-    "    \"\"\"Adapter class to integrate LangChain's Wikipedia tool with our framework\"\"\"\n",
-    "\n",
-    "    name = \"Wikipedia\"\n",
-    "    description = \"Search factual and historical information from Wikipedia about given topics.\"\n",
-    "    input_schema = LangChainWikipediaToolInput\n",
-    "\n",
-    "    def __init__(self) -> None:\n",
-    "        super().__init__()\n",
-    "        self._wikipedia = WikipediaQueryRun(api_wrapper=WikipediaAPIWrapper())\n",
-    "\n",
-    "    def _create_emitter(self) -> Emitter:\n",
-    "        return Emitter.root().child(\n",
-    "            namespace=[\"tool\", \"search\", \"langchain_wikipedia\"],\n",
-    "            creator=self,\n",
-    "        )\n",
-    "\n",
-    "    async def _run(\n",
-    "        self,\n",
-    "        input: LangChainWikipediaToolInput,\n",
-    "        options: ToolRunOptions | None = None,\n",
-    "        context: RunContext | None = None,\n",
-    "    ) -> StringToolOutput:\n",
-    "        query = input.query\n",
-    "        try:\n",
-    "            result = self._wikipedia.run(query)\n",
-    "            return StringToolOutput(result=result)\n",
-    "        except Exception as e:\n",
-    "            print(f\"Wikipedia search error: {e!s}\")\n",
-    "            return f\"Error searching Wikipedia: {e!s}\"\n",
-    "\n",
-    "\n",
-    "chat_model: ChatModel = ChatModel.from_name(\"ollama:granite3.1-dense:8b\")\n",
-    "agent = BeeAgent(llm=chat_model, tools=[LangChainWikipediaTool()], memory=UnconstrainedMemory())\n",
-    "\n",
-    "result: BeeRunOutput = await agent.run(\"Who is the current president of the European Commission?\").observe(observer)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The previous example can be re-written in a shorter form by adding the @tool decorator, which simplifies the tool definition. Here's how you can do it:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Agent(thought) 🤖 :  I need to use the langchain_wikipedia_tool to find the longest living vertebrate.\n",
-      "Agent(tool_name) 🤖 :  langchain_wikipedia_tool\n",
-      "Agent(tool_input) 🤖 :  {'query': 'longest living vertebrate'}\n",
-      "Agent(tool_output) 🤖 :  <beeai_framework.tools.tool.StringToolOutput object at 0x120ba0980>\n",
-      "Agent(thought) 🤖 :  The information provided indicates that the Greenland shark has the longest lifespan among vertebrates, estimated to be between 250 and 500 years.\n",
-      "Agent(final_answer) 🤖 :  The Greenland shark is the longest living vertebrate, with an estimated lifespan of 250 to 500 years.\n"
-     ]
-    }
-   ],
-   "source": [
-    "from langchain_community.tools import WikipediaQueryRun  # noqa: F811\n",
-    "from langchain_community.utilities import WikipediaAPIWrapper  # noqa: F811\n",
-    "\n",
-    "from beeai_framework.agents.bee.agent import BeeAgent\n",
-    "from beeai_framework.tools import Tool, tool\n",
-    "\n",
-    "\n",
-    "# defining a tool using the `tool` decorator\n",
-    "# Note: the pydoc is important as it serves as the tool description to the agent\n",
-    "@tool\n",
-    "def langchain_wikipedia_tool(query: str) -> str:\n",
-    "    \"\"\"\n",
-    "    Search factual and historical information, including biography, history, politics, geography, society, culture,\n",
-    "    science, technology, people, animal species, mathematics, and other subjects.\n",
-    "\n",
-    "    Args:\n",
-    "        query: The topic or question to search for on Wikipedia.\n",
-    "\n",
-    "    Returns:\n",
-    "        The information found via searching Wikipedia.\n",
-    "    \"\"\"\n",
-    "    wikipedia = WikipediaQueryRun(api_wrapper=WikipediaAPIWrapper())\n",
-    "    return StringToolOutput(wikipedia.run(query))\n",
-    "\n",
-    "\n",
-    "# using the tool in an agent\n",
-    "chat_model: ChatModel = ChatModel.from_name(\"ollama:granite3.1-dense:8b\")\n",
-    "agent = BeeAgent(llm=chat_model, tools=[langchain_wikipedia_tool], memory=UnconstrainedMemory())\n",
-    "\n",
-    "result: BeeRunOutput = await agent.run(\"What is the longest living vertebrate?\").observe(observer)"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "beeai-framework-IVd76ig_-py3.12",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.6"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+      "cells": [
+            {
+                  "cell_type": "markdown",
+                  "metadata": {},
+                  "source": [
+                        "# BeeAI ReAct agents\n",
+                        "\n",
+                        "The BeeAI ReAct agent is a pre-configured implementation of the ReAct (Reasoning and Acting) pattern. It can be customized with tools and instructions to suit different tasks.\n",
+                        "\n",
+                        "The ReAct pattern is a framework used in AI models, particularly language models, to separate the reasoning process from the action-taking process. This pattern enhances the model's ability to handle complex queries by enabling it to:\n",
+                        "\n",
+                        "- Reason about the problem.\n",
+                        "- Decide on an action to take.\n",
+                        "- Observe the result of that action to inform further reasoning and actions.\n",
+                        "\n",
+                        "The ReAct agent provides a convenient out-of-the-box agent implementation that makes it easier to build agents using this pattern."
+                  ]
+            },
+            {
+                  "cell_type": "markdown",
+                  "metadata": {},
+                  "source": [
+                        "## Basic ReAct Agent\n",
+                        "\n",
+                        "To configure a ReAct agent, you need to define a ChatModel and construct a BeeAgent.\n",
+                        "\n",
+                        "In this example, we won't provide any external tools to the agent. It will rely solely on its own memory to provide answers. This is a basic setup where the agent tries to reason and act based on the context it has built internally.\n",
+                        "\n",
+                        "Try modifying the input text in the call to agent.run() to experiment with obtaining different answers. This will help you see how the agent's reasoning and response vary with different prompts."
+                  ]
+            },
+            {
+                  "cell_type": "code",
+                  "execution_count": 1,
+                  "metadata": {},
+                  "outputs": [
+                        {
+                              "name": "stdout",
+                              "output_type": "stream",
+                              "text": [
+                                    "Agent(thought) 🤖 :  The user wants to know the chemical composition of a water molecule. A water molecule is composed of two hydrogen atoms and one oxygen atom, represented as H2O.\n",
+                                    "\n",
+                                    "Agent(final_answer) 🤖 :  A water molecule consists of two hydrogen atoms and one oxygen atom, chemically represented as H2O.\n"
+                              ]
+                        }
+                  ],
+                  "source": [
+                        "from typing import Any\n",
+                        "\n",
+                        "from beeai_framework.agents.bee.agent import BeeAgent\n",
+                        "from beeai_framework.agents.types import BeeRunOutput\n",
+                        "from beeai_framework.backend.chat import ChatModel\n",
+                        "from beeai_framework.emitter.emitter import Emitter, EventMeta\n",
+                        "from beeai_framework.emitter.types import EmitterOptions\n",
+                        "from beeai_framework.memory.unconstrained_memory import UnconstrainedMemory\n",
+                        "\n",
+                        "# Construct ChatModel\n",
+                        "chat_model: ChatModel = ChatModel.from_name(\"ollama:granite3.1-dense:8b\")\n",
+                        "\n",
+                        "# Construct Agent instance with the chat model\n",
+                        "agent = BeeAgent(llm=chat_model, tools=[], memory=UnconstrainedMemory())\n",
+                        "\n",
+                        "\n",
+                        "async def process_agent_events(event_data: dict[str, Any], event_meta: EventMeta) -> None:\n",
+                        "    \"\"\"Process agent events and log appropriately\"\"\"\n",
+                        "\n",
+                        "    if event_meta.name == \"error\":\n",
+                        "        print(\"Agent 🤖 : \", event_data[\"error\"])\n",
+                        "    elif event_meta.name == \"retry\":\n",
+                        "        print(\"Agent 🤖 : \", \"retrying the action...\")\n",
+                        "    elif event_meta.name == \"update\":\n",
+                        "        print(f\"Agent({event_data['update']['key']}) 🤖 : \", event_data[\"update\"][\"parsedValue\"])\n",
+                        "\n",
+                        "\n",
+                        "# Observe the agent\n",
+                        "async def observer(emitter: Emitter) -> None:\n",
+                        "    emitter.on(\"*.*\", process_agent_events, EmitterOptions(match_nested=True))\n",
+                        "\n",
+                        "\n",
+                        "# Run the agent\n",
+                        "result: BeeRunOutput = await agent.run(\"What chemical elements make up a water molecule?\").observe(observer)"
+                  ]
+            },
+            {
+                  "cell_type": "markdown",
+                  "metadata": {},
+                  "source": [
+                        "## Using Tools\n",
+                        "\n",
+                        "To go beyond just chatting with an LLM, you can provide tools to the agent. This enables the agent to perform specific tasks and interact with external systems, enhancing its functionality. There are different ways to add tools to the agent:\n",
+                        "\n",
+                        "- Built-in tools from the framework: BeeAI provides several built-in tools that you can easily integrate with your agent.\n",
+                        "- Importing tools from other libraries: You can bring in external tools or APIs to extend your agent's capabilities.\n",
+                        "- Custom tooling: You can also write your own custom tools tailored to your specific use case.\n",
+                        "\n",
+                        "By equipping the agent with these tools, you allow it to perform more complex actions, such as querying databases, interacting with APIs, or manipulating data.\n",
+                        "\n",
+                        "## Built-in tools\n",
+                        "\n",
+                        "BeeAI comes with several built-in tools that are part of the library, which can be easily imported and added to your agent.\n",
+                        "\n",
+                        "In this example, we provide the agent with a weather forecast lookup tool called OpenMeteoTool. With this tool, the agent can retrieve real-time weather data, enabling it to answer weather-related queries with more accuracy.\n",
+                        "\n",
+                        "Follow the agent's thoughts and actions to understand how it approaches and solves the problem."
+                  ]
+            },
+            {
+                  "cell_type": "code",
+                  "execution_count": 2,
+                  "metadata": {},
+                  "outputs": [
+                        {
+                              "name": "stdout",
+                              "output_type": "stream",
+                              "text": [
+                                    "Agent(thought) 🤖 :  I need to use the OpenMeteoTool to get the current weather information for London.\n",
+                                    "\n",
+                                    "Agent(tool_name) 🤖 :  OpenMeteoTool\n",
+                                    "Agent(tool_input) 🤖 :  {'location_name': 'London', 'temperature_unit': 'celsius'}\n",
+                                    "Agent(tool_output) 🤖 :  {\"latitude\": 51.5, \"longitude\": -0.120000124, \"generationtime_ms\": 0.06449222564697266, \"utc_offset_seconds\": 0, \"timezone\": \"GMT\", \"timezone_abbreviation\": \"GMT\", \"elevation\": 23.0, \"current_units\": {\"time\": \"iso8601\", \"interval\": \"seconds\", \"temperature_2m\": \"\\u00b0C\", \"rain\": \"mm\", \"relative_humidity_2m\": \"%\", \"wind_speed_10m\": \"km/h\"}, \"current\": {\"time\": \"2025-03-06T04:00\", \"interval\": 900, \"temperature_2m\": 6.7, \"rain\": 0.0, \"relative_humidity_2m\": 63, \"wind_speed_10m\": 3.3}, \"daily_units\": {\"time\": \"iso8601\", \"temperature_2m_max\": \"\\u00b0C\", \"temperature_2m_min\": \"\\u00b0C\", \"rain_sum\": \"mm\"}, \"daily\": {\"time\": [\"2025-03-06\"], \"temperature_2m_max\": [15.1], \"temperature_2m_min\": [5.1], \"rain_sum\": [0.0]}}\n",
+                                    "Agent(thought) 🤖 :  The OpenMeteoTool returned the current weather information for London. The temperature is 6.7°C, with no rain and a wind speed of 3.3 km/h.\n",
+                                    "\n",
+                                    "Agent(final_answer) 🤖 :  The current weather in London is 6.7°C with no rain and a wind speed of 3.3 km/h.\n"
+                              ]
+                        }
+                  ],
+                  "source": [
+                        "from beeai_framework.backend.chat import ChatModel\n",
+                        "from beeai_framework.tools.weather.openmeteo import OpenMeteoTool\n",
+                        "\n",
+                        "chat_model: ChatModel = ChatModel.from_name(\"ollama:granite3.1-dense:8b\")\n",
+                        "\n",
+                        "# create an agent using the default LLM and add the OpenMeteoTool that is capable of fetching weather-based information\n",
+                        "agent = BeeAgent(llm=chat_model, tools=[OpenMeteoTool()], memory=UnconstrainedMemory())\n",
+                        "\n",
+                        "\n",
+                        "# Run the agent\n",
+                        "result: BeeRunOutput = await agent.run(\"What's the current weather in London?\").observe(observer)"
+                  ]
+            },
+            {
+                  "cell_type": "markdown",
+                  "metadata": {},
+                  "source": [
+                        "### Imported Tools\n",
+                        "\n",
+                        "Tools can also be imported from other libraries to extend the functionality of your agent. For example, you can integrate tools from libraries like LangChain to give your agent access to even more capabilities.\n",
+                        "\n",
+                        "Here’s an example showing how to integrate the Wikipedia tool from LangChain, written in long form (without using the @tool decorator):"
+                  ]
+            },
+            {
+                  "cell_type": "code",
+                  "execution_count": 3,
+                  "metadata": {},
+                  "outputs": [
+                        {
+                              "name": "stdout",
+                              "output_type": "stream",
+                              "text": [
+                                    "Agent(thought) 🤖 :  I can find this information using the Wikipedia tool.\n",
+                                    "Agent(tool_name) 🤖 :  Wikipedia\n",
+                                    "Agent(tool_input) 🤖 :  {'query': 'Current President of the European Commission'}\n",
+                                    "Agent(tool_output) 🤖 :  Page: Vice-President of the European Commission\n",
+                                    "Summary: A Vice-President of the European Commission is a member of the European Commission who leads the commission's work in particular focus areas in which multiple European Commissioners participate.\n",
+                                    "Currently, the European Commission has a total of six Vice-Presidents: five Executive-Vice Presidents, and the High Representative who is ex officio one of the Vice-Presidents as well.\n",
+                                    "\n",
+                                    "Page: European Commission\n",
+                                    "Summary: The European Commission (EC) is the primary executive arm of the European Union (EU). It operates as a cabinet government, with a number of members of the Commission (directorial system, informally known as \"Commissioners\") corresponding to two thirds of the number of member states, unless the European Council, acting unanimously, decides to alter this number. The current number of Commissioners is 27, including the President. It includes an administrative body of about 32,000 European civil servants. The commission is divided into departments known as Directorates-General (DGs) that can be likened to departments or ministries each headed by a Director-General who is responsible to a Commissioner.\n",
+                                    "Currently, there is one member per member state, but members are bound by their oath of office to represent the general interest of the EU as a whole rather than their home state. The Commission President (currently Ursula von der Leyen) is proposed by the European Council (the 27 heads of state/governments) and elected by the European Parliament. The Council of the European Union then nominates the other members of the Commission in agreement with the nominated President, and the 27 members as a team are then subject to a vote of approval by the European Parliament. The current Commission is the Von der Leyen Commission II, which took office in December 2024, following the European Parliament elections in June of the same year.\n",
+                                    "\n",
+                                    "Page: List of presidents of the institutions of the European Union\n",
+                                    "Summary: This is a list of presidents of the institutions of the European Union (EU). Each of the institutions is headed by a president or a presidency, with some being more prominent than others. Both the President of the European Council and the President of the European Commission are sometimes wrongly termed the President of the European Union. Most go back to 1957 but others, such as the President of the Auditors Court or of the European Central Bank, have been created recently. Currently (2025), the President of the European Commission is Ursula von der Leyen and the President of the European Council is António Costa.\n",
+                                    "Agent(thought) 🤖 :  The current president of the European Commission is Ursula von der Leyen, as per the information retrieved from Wikipedia.\n",
+                                    "Agent(final_answer) 🤖 :  The current president of the European Commission is Ursula von der Leyen.\n"
+                              ]
+                        }
+                  ],
+                  "source": [
+                        "from typing import Any\n",
+                        "\n",
+                        "from langchain_community.tools import WikipediaQueryRun\n",
+                        "from langchain_community.utilities import WikipediaAPIWrapper\n",
+                        "from pydantic import BaseModel, Field\n",
+                        "\n",
+                        "from beeai_framework.agents.bee.agent import BeeAgent\n",
+                        "from beeai_framework.context import RunContext\n",
+                        "from beeai_framework.tools import Tool\n",
+                        "from beeai_framework.tools.tool import StringToolOutput, ToolRunOptions\n",
+                        "\n",
+                        "\n",
+                        "class LangChainWikipediaToolInput(BaseModel):\n",
+                        "    query: str = Field(description=\"The topic or question to search for on Wikipedia.\")\n",
+                        "\n",
+                        "\n",
+                        "class LangChainWikipediaTool(Tool[LangChainWikipediaToolInput, ToolRunOptions]):\n",
+                        "    \"\"\"Adapter class to integrate LangChain's Wikipedia tool with our framework\"\"\"\n",
+                        "\n",
+                        "    name = \"Wikipedia\"\n",
+                        "    description = \"Search factual and historical information from Wikipedia about given topics.\"\n",
+                        "    input_schema = LangChainWikipediaToolInput\n",
+                        "\n",
+                        "    def __init__(self) -> None:\n",
+                        "        super().__init__()\n",
+                        "        self._wikipedia = WikipediaQueryRun(api_wrapper=WikipediaAPIWrapper())\n",
+                        "\n",
+                        "    def _create_emitter(self) -> Emitter:\n",
+                        "        return Emitter.root().child(\n",
+                        "            namespace=[\"tool\", \"search\", \"langchain_wikipedia\"],\n",
+                        "            creator=self,\n",
+                        "        )\n",
+                        "\n",
+                        "    async def _run(self, input: LangChainWikipediaToolInput, options: ToolRunOptions | None, context: RunContext) -> StringToolOutput:\n",
+                        "        query = input.query\n",
+                        "        try:\n",
+                        "            result = self._wikipedia.run(query)\n",
+                        "            return StringToolOutput(result=result)\n",
+                        "        except Exception as e:\n",
+                        "            print(f\"Wikipedia search error: {e!s}\")\n",
+                        "            return f\"Error searching Wikipedia: {e!s}\"\n",
+                        "\n",
+                        "\n",
+                        "chat_model: ChatModel = ChatModel.from_name(\"ollama:granite3.1-dense:8b\")\n",
+                        "agent = BeeAgent(llm=chat_model, tools=[LangChainWikipediaTool()], memory=UnconstrainedMemory())\n",
+                        "\n",
+                        "result: BeeRunOutput = await agent.run(\"Who is the current president of the European Commission?\").observe(observer)"
+                  ]
+            },
+            {
+                  "cell_type": "markdown",
+                  "metadata": {},
+                  "source": [
+                        "The previous example can be re-written in a shorter form by adding the @tool decorator, which simplifies the tool definition. Here's how you can do it:"
+                  ]
+            },
+            {
+                  "cell_type": "code",
+                  "execution_count": 4,
+                  "metadata": {},
+                  "outputs": [
+                        {
+                              "name": "stdout",
+                              "output_type": "stream",
+                              "text": [
+                                    "Agent(thought) 🤖 :  I need to use the langchain_wikipedia_tool to find the longest living vertebrate.\n",
+                                    "Agent(tool_name) 🤖 :  langchain_wikipedia_tool\n",
+                                    "Agent(tool_input) 🤖 :  {'query': 'longest living vertebrate'}\n",
+                                    "Agent(tool_output) 🤖 :  Page: Hákarl\n",
+                                    "Summary: Hákarl (an abbreviation of kæstur hákarl [ˈcʰaistʏr ˈhauːˌkʰa(r)tl̥]), referred to as fermented shark in English, is a national dish of Iceland consisting of Greenland shark or other sleeper shark that has been cured with a particular fermentation process and hung to dry for four to five months. It has a strong ammonia-rich smell and fishy taste, making hákarl an acquired taste.\n",
+                                    "Fermented shark is readily available in Icelandic stores and may be eaten year-round, but is most often served as part of a Þorramatur, a selection of traditional Icelandic food served at the midwinter festival þorrablót.\n",
+                                    "\n",
+                                    "Page: List of longest-living organisms\n",
+                                    "Summary: This is a list of the longest-living biological organisms: the individual(s) (or in some instances, clones) of a species with the longest natural maximum life spans. For a given species, such a designation may include:\n",
+                                    "\n",
+                                    "The oldest known individual(s) that are currently alive, with verified ages.\n",
+                                    "Verified individual record holders, such as the longest-lived human, Jeanne Calment, or the longest-lived domestic cat, Creme Puff.\n",
+                                    "The definition of \"longest-living\" used in this article considers only the observed or estimated length of an individual organism's natural lifespan – that is, the duration of time between its birth or conception, or the earliest emergence of its identity as an individual organism, and its death – and does not consider other conceivable interpretations of \"longest-living\", such as the length of time between the earliest appearance of a species in the fossil record and the present (the historical \"age\" of the species as a whole), the time between a species' first speciation and its extinction (the phylogenetic \"lifespan\" of the species), or the range of possible lifespans of a species' individuals. This list includes long-lived organisms that are currently still alive as well as those that are dead.\n",
+                                    "Determining the length of an organism's natural lifespan is complicated by many problems of definition and interpretation, as well as by practical difficulties in reliably measuring age, particularly for extremely old organisms and for those that reproduce by asexual cloning. In many cases the ages listed below are estimates based on observed present-day growth rates, which may differ significantly from the growth rates experienced thousands of years ago. Identifying the longest-living organisms also depends on defining what constitutes an \"individual\" organism, which can be problematic, since many asexual organisms and clonal colonies defy one or both of the traditional colloquial definitions of individuality (having a distinct genotype and having an independent, physically separate body). Additionally, some organisms maintain the capability to reproduce through very long periods of metabolic dormancy, during which they may not be considered \"alive\" by certain definitions but nonetheless can resume normal metabolism afterward; it is unclear whether the dormant periods should be counted as part of the organism's lifespan.\n",
+                                    "\n",
+                                    "Page: Greenland shark\n",
+                                    "Summary: The Greenland shark (Somniosus microcephalus), also known as the gurry shark or grey shark, is a large shark of the family Somniosidae (\"sleeper sharks\"), closely related to the Pacific and southern sleeper sharks. Inhabiting the North Atlantic and Arctic Oceans, they are notable for their exceptional longevity, although they are poorly studied due to the depth and remoteness of their natural habitat.\n",
+                                    "Greenland sharks have the longest lifespan of any known vertebrate, estimated to be between 250 and 500 years. They are among the largest extant species of shark, reaching a maximum confirmed length of 6.4 m (21 ft) long and weighing over 1,000 kg (2,200 lb). They reach sexual maturity at about 150 years of age, and their pups are born alive after an estimated gestation period of 8 to 18 years.\n",
+                                    "The shark is a generalist feeder, consuming a variety of available foods, including carrion.\n",
+                                    "Greenland shark me\n",
+                                    "Agent(thought) 🤖 :  The information provided indicates that the Greenland shark has the longest lifespan among vertebrates, estimated to be between 250 and 500 years.\n",
+                                    "Agent(final_answer) 🤖 :  The Greenland shark is the longest living vertebrate, with an estimated lifespan of 250 to 500 years.\n"
+                              ]
+                        }
+                  ],
+                  "source": [
+                        "from langchain_community.tools import WikipediaQueryRun  # noqa: F811\n",
+                        "from langchain_community.utilities import WikipediaAPIWrapper  # noqa: F811\n",
+                        "\n",
+                        "from beeai_framework.agents.bee.agent import BeeAgent\n",
+                        "from beeai_framework.tools import Tool, tool\n",
+                        "\n",
+                        "\n",
+                        "# defining a tool using the `tool` decorator\n",
+                        "# Note: the pydoc is important as it serves as the tool description to the agent\n",
+                        "@tool\n",
+                        "def langchain_wikipedia_tool(query: str) -> str:\n",
+                        "    \"\"\"\n",
+                        "    Search factual and historical information, including biography, history, politics, geography, society, culture,\n",
+                        "    science, technology, people, animal species, mathematics, and other subjects.\n",
+                        "\n",
+                        "    Args:\n",
+                        "        query: The topic or question to search for on Wikipedia.\n",
+                        "\n",
+                        "    Returns:\n",
+                        "        The information found via searching Wikipedia.\n",
+                        "    \"\"\"\n",
+                        "    wikipedia = WikipediaQueryRun(api_wrapper=WikipediaAPIWrapper())\n",
+                        "    return wikipedia.run(query)\n",
+                        "\n",
+                        "\n",
+                        "# using the tool in an agent\n",
+                        "chat_model: ChatModel = ChatModel.from_name(\"ollama:granite3.1-dense:8b\")\n",
+                        "agent = BeeAgent(llm=chat_model, tools=[langchain_wikipedia_tool], memory=UnconstrainedMemory())\n",
+                        "\n",
+                        "result: BeeRunOutput = await agent.run(\"What is the longest living vertebrate?\").observe(observer)"
+                  ]
+            }
+      ],
+      "metadata": {
+            "kernelspec": {
+                  "display_name": "beeai-framework-IVd76ig_-py3.12",
+                  "language": "python",
+                  "name": "python3"
+            },
+            "language_info": {
+                  "codemirror_mode": {
+                        "name": "ipython",
+                        "version": 3
+                  },
+                  "file_extension": ".py",
+                  "mimetype": "text/x-python",
+                  "name": "python",
+                  "nbconvert_exporter": "python",
+                  "pygments_lexer": "ipython3",
+                  "version": "3.12.6"
+            }
+      },
+      "nbformat": 4,
+      "nbformat_minor": 4
 }

--- a/python/examples/notebooks/workflows.ipynb
+++ b/python/examples/notebooks/workflows.ipynb
@@ -99,7 +99,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -182,7 +182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -249,8 +249,14 @@
     "    response: ChatModelStructureOutput = await model.create_structure(\n",
     "        schema=WebSearchQuery, messages=[UserMessage(prompt)]\n",
     "    )\n",
+    "\n",
     "    # Run search and store results in state\n",
-    "    state.search_results = str(search_tool.run(response.object[\"query\"]))\n",
+    "    try:\n",
+    "        state.search_results = str(search_tool.run(response.object[\"query\"]))\n",
+    "    except Exception:\n",
+    "        print(\"Search tool failed! Agent will answer from memory.\")\n",
+    "        state.search_results = \"No search results available.\"\n",
+    "\n",
     "    return \"generate_answer\""
    ]
   },
@@ -304,10 +310,11 @@
      "output_type": "stream",
      "text": [
       "Step:  web_search\n",
+      "Search tool failed!\n",
       "Step:  generate_answer\n",
       "*****\n",
       "Question:  What is the term for a baby hedgehog?\n",
-      "Answer:  The term for a baby hedgehog is hoglet. This information is consistent across multiple search results. Hoglets are born in litters and are covered with a layer of skin and fluid to prevent injury during birth. It's generally recommended to leave hoglets alone if found, as their parent is usually nearby. Rearing hoglets requires constant warmth, regular feeding, and toileting.\n"
+      "Answer:  The term for a baby hedgehog is \"hoglet.\"\n"
      ]
     }
    ],
@@ -346,7 +353,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/python/examples/tools/custom/base.py
+++ b/python/examples/tools/custom/base.py
@@ -15,7 +15,7 @@ class RiddleToolInput(BaseModel):
     riddle_number: int = Field(description="Index of riddle to retrieve.")
 
 
-class RiddleTool(Tool[RiddleToolInput, ToolRunOptions]):
+class RiddleTool(Tool[RiddleToolInput, ToolRunOptions, StringToolOutput]):
     name = "Riddle"
     description = "It selects a riddle to test your knowledge."
     input_schema = RiddleToolInput

--- a/python/examples/tools/custom/openlibrary.py
+++ b/python/examples/tools/custom/openlibrary.py
@@ -9,7 +9,7 @@ from beeai_framework.context import RunContext
 from beeai_framework.emitter.emitter import Emitter
 from beeai_framework.errors import FrameworkError
 from beeai_framework.tools import ToolInputValidationError
-from beeai_framework.tools.tool import Tool, ToolRunOptions
+from beeai_framework.tools.tool import JSONToolOutput, Tool, ToolRunOptions
 
 
 class OpenLibraryToolInput(BaseModel):
@@ -24,7 +24,7 @@ class OpenLibraryToolResult(BaseModel):
     bib_key: str
 
 
-class OpenLibraryTool(Tool[OpenLibraryToolInput, ToolRunOptions]):
+class OpenLibraryTool(Tool[OpenLibraryToolInput, ToolRunOptions, JSONToolOutput]):
     name = "OpenLibrary"
     description = """Provides access to a library of books with information about book titles,
         authors, contributors, publication dates, publisher and isbn."""
@@ -41,7 +41,7 @@ class OpenLibraryTool(Tool[OpenLibraryToolInput, ToolRunOptions]):
 
     async def _run(
         self, tool_input: OpenLibraryToolInput, options: ToolRunOptions | None, context: RunContext
-    ) -> OpenLibraryToolResult:
+    ) -> JSONToolOutput:
         key = ""
         value = ""
         input_vars = vars(tool_input)
@@ -63,10 +63,12 @@ class OpenLibraryTool(Tool[OpenLibraryToolInput, ToolRunOptions]):
 
             json_output = response.json()[f"{key}:{value}"]
 
-        return OpenLibraryToolResult(
-            preview_url=json_output.get("preview_url", ""),
-            info_url=json_output.get("info_url", ""),
-            bib_key=json_output.get("bib_key", ""),
+        return JSONToolOutput(
+            result={
+                "preview_url": json_output.get("preview_url", ""),
+                "info_url": json_output.get("info_url", ""),
+                "bib_key": json_output.get("bib_key", ""),
+            }
         )
 
 

--- a/python/tests/tools/test_decorator.py
+++ b/python/tests/tools/test_decorator.py
@@ -15,7 +15,7 @@
 
 import pytest
 
-from beeai_framework.tools import tool
+from beeai_framework.tools import StringToolOutput, tool
 
 """
 Unit Tests
@@ -40,8 +40,8 @@ async def test_tool_annotation() -> None:
         return query
 
     query = "Hello!"
-    result = await test_tool.run({"query": query})
-    assert result == query
+    result: StringToolOutput = await test_tool.run({"query": query})
+    assert result.get_text_content() == query
 
 
 @pytest.mark.unit
@@ -55,8 +55,8 @@ async def test_tool_annotation_no_params() -> None:
         """
         return "Hello!"
 
-    result = await test_tool.run({})
-    assert result == "Hello!"
+    result: StringToolOutput = await test_tool.run({})
+    assert result.get_text_content() == "Hello!"
 
 
 @pytest.mark.unit
@@ -67,8 +67,8 @@ async def test_tool_annotation_empty_desc() -> None:
         """"""
         return "Hello!"
 
-    result = await test_tool.run({})
-    assert result == "Hello!"
+    result: StringToolOutput = await test_tool.run({})
+    assert result.get_text_content() == "Hello!"
 
 
 @pytest.mark.unit

--- a/python/tests/tools/test_emitter.py
+++ b/python/tests/tools/test_emitter.py
@@ -19,7 +19,7 @@ import pytest
 
 from beeai_framework.emitter.emitter import Emitter, EventMeta
 from beeai_framework.emitter.types import EmitterOptions
-from beeai_framework.tools import tool
+from beeai_framework.tools import StringToolOutput, tool
 
 """
 Unit Tests
@@ -51,5 +51,5 @@ async def test_tool_emitter() -> None:
         return query
 
     query = "Hello!"
-    result = await test_tool.run({"query": query}).observe(observer)
-    assert result == query
+    result: StringToolOutput = await test_tool.run({"query": query}).observe(observer)
+    assert result.get_text_content() == query


### PR DESCRIPTION
1. Replaces to_string on tool output with python __str__ override
2. Tool results are now printed in agents notebook
3. Decorated tools that return str can now work with Agent (output is wrapped as StringToolOutput)
4. Error checking in notebooks for search tool failures

### Checklist

<!-- For completed items, change [ ] to [x]. -->

- [x] I have read the [contributor guide](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have [signed off](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-dco) on my commit
- [x] Linting passes: `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: `yarn format` or `yarn format:fix`
- [x] Unit tests pass: `yarn test:unit`
- [ ] E2E tests pass: `yarn test:e2e`
- [ ] Tests are included <!-- Bug fixes and new features should include tests -->
- [ ] Documentation is changed or added
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
