### PR TITLE
fix(emitter): The "match all nested" matcher should match all nested

### DIFF
--- a/python/beeai_framework/emitter/emitter.py
+++ b/python/beeai_framework/emitter/emitter.py
@@ -132,7 +132,7 @@ class Emitter(Generic[T]):
     def match(self, matcher: Matcher, callback: Callback, options: EmitterOptions | None = None) -> CleanupFn:
         def create_matcher() -> MatcherFn:
             matchers: list[MatcherFn] = []
-            match_nested = options.match_nested if options else False
+            match_nested = options.match_nested if options else None
 
             if matcher == "*":
                 match_nested = False if match_nested is None else match_nested

--- a/python/examples/tools/mcp_agent.py
+++ b/python/examples/tools/mcp_agent.py
@@ -14,7 +14,6 @@ from beeai_framework.agents.react.agent import ReActAgent
 from beeai_framework.agents.types import AgentExecutionConfig
 from beeai_framework.backend.chat import ChatModel, ChatModelParameters
 from beeai_framework.emitter.emitter import Emitter, EventMeta
-from beeai_framework.emitter.types import EmitterOptions
 from beeai_framework.errors import FrameworkError
 from beeai_framework.logger import Logger
 from beeai_framework.memory.token_memory import TokenMemory
@@ -90,7 +89,7 @@ def process_agent_events(data: dict[str, Any], event: EventMeta) -> None:
 
 
 def observer(emitter: Emitter) -> None:
-    emitter.on("*.*", process_agent_events, EmitterOptions(match_nested=True))
+    emitter.on("*.*", process_agent_events)
 
 
 async def main() -> None:

--- a/python/examples/workflows/emitter.py
+++ b/python/examples/workflows/emitter.py
@@ -6,7 +6,6 @@ from typing import Literal, TypeAlias
 from pydantic import BaseModel
 
 from beeai_framework.emitter.emitter import Emitter, EventMeta
-from beeai_framework.emitter.types import EmitterOptions
 from beeai_framework.errors import FrameworkError
 from beeai_framework.workflows.workflow import Workflow, WorkflowReservedStepName
 
@@ -48,7 +47,7 @@ async def main() -> None:
 
     # Observe the agent
     async def observer(emitter: Emitter) -> None:
-        emitter.on("*.*", print_event, EmitterOptions(match_nested=True))
+        emitter.on("*.*", print_event)
 
     def pre_process(state: State) -> WorkflowStep:
         state.abs_repetitions = abs(state.y)

--- a/python/tests/tools/test_emitter.py
+++ b/python/tests/tools/test_emitter.py
@@ -18,7 +18,6 @@ from typing import Any
 import pytest
 
 from beeai_framework.emitter.emitter import Emitter, EventMeta
-from beeai_framework.emitter.types import EmitterOptions
 from beeai_framework.tools import StringToolOutput, tool
 
 """
@@ -34,7 +33,7 @@ async def test_tool_emitter() -> None:
 
     # Observe the agent
     async def observer(emitter: Emitter) -> None:
-        emitter.on("*.*", process_agent_events, EmitterOptions(match_nested=True))
+        emitter.on("*.*", process_agent_events)
 
     @tool
     def test_tool(query: str) -> str:


### PR DESCRIPTION
### Which issue(s) does this pull-request address?

Addresses user feedback from slack

### Description

The `"*.*"` matcher should set `match_nested=True` by default, it was not

### Checklist

<!-- For completed items, change [ ] to [x]. -->

- [x] I have read the [contributor guide](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have [signed off](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-dco) on my commit
- [x] Tests are included <!-- Bug fixes and new features should include tests -->
- [ ] Documentation is changed or added
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
