### PR TITLE
feat: Add Run.on API to directly add an event callback

### DIFF
--- a/python/beeai_framework/context.py
+++ b/python/beeai_framework/context.py
@@ -74,10 +74,12 @@ class Run(Generic[R]):
         return self
 
     async def _run_tasks(self) -> R:
-        for fn, params in self.tasks:
+        tasks = self.tasks[:]
+        self.tasks.clear()
+
+        for fn, params in tasks:
             await ensure_async(fn)(*params)
 
-        self.tasks.clear()
         return await self.handler()
 
     def _set_context(self, context: dict) -> None:

--- a/python/examples/agents/granite.py
+++ b/python/examples/agents/granite.py
@@ -6,7 +6,6 @@ from beeai_framework.agents.react.agent import ReActAgent
 from beeai_framework.agents.react.types import ReActAgentRunOutput
 from beeai_framework.agents.types import AgentExecutionConfig
 from beeai_framework.backend.chat import ChatModel
-from beeai_framework.emitter import Emitter, EventMeta
 from beeai_framework.errors import FrameworkError
 from beeai_framework.memory.unconstrained_memory import UnconstrainedMemory
 from beeai_framework.tools.search import DuckDuckGoSearchTool
@@ -25,15 +24,12 @@ async def main() -> None:
 
     prompt = reader.prompt()
 
-    def update_callback(data: dict, event: EventMeta) -> None:
-        reader.write(f"Agent({data['update']['key']}) 🤖 : ", data["update"]["parsedValue"])
-
-    def on_update(emitter: Emitter) -> None:
-        emitter.on("update", update_callback)
-
     output: ReActAgentRunOutput = await agent.run(
         prompt=prompt, execution=AgentExecutionConfig(total_max_retries=2, max_retries_per_step=3, max_iterations=8)
-    ).observe(on_update)
+    ).on(
+        "update",
+        lambda data, event: reader.write(f"Agent({data['update']['key']}) 🤖 : ", data["update"]["parsedValue"]),
+    )
 
     reader.write("Agent 🤖 : ", output.result.text)
 

--- a/python/examples/agents/react.py
+++ b/python/examples/agents/react.py
@@ -11,7 +11,7 @@ from beeai_framework import Tool
 from beeai_framework.agents.react.agent import ReActAgent
 from beeai_framework.agents.types import AgentExecutionConfig
 from beeai_framework.backend.chat import ChatModel, ChatModelParameters
-from beeai_framework.emitter.emitter import Emitter, EventMeta
+from beeai_framework.emitter.emitter import EventMeta
 from beeai_framework.emitter.types import EmitterOptions
 from beeai_framework.errors import FrameworkError
 from beeai_framework.logger import Logger
@@ -76,10 +76,6 @@ def process_agent_events(data: dict[str, Any], event: EventMeta) -> None:
         reader.write("Agent 🤖 : ", "success")
 
 
-def observer(emitter: Emitter) -> None:
-    emitter.on("*", process_agent_events, EmitterOptions(match_nested=False))
-
-
 async def main() -> None:
     """Main application loop"""
 
@@ -102,7 +98,7 @@ async def main() -> None:
         response = await agent.run(
             prompt=prompt,
             execution=AgentExecutionConfig(max_retries_per_step=3, total_max_retries=10, max_iterations=20),
-        ).observe(observer)
+        ).on("*", process_agent_events, EmitterOptions(match_nested=False))
 
         reader.write("Agent 🤖 : ", response.result.text)
 

--- a/python/examples/agents/simple.py
+++ b/python/examples/agents/simple.py
@@ -5,7 +5,6 @@ import traceback
 from beeai_framework.agents.react.agent import ReActAgent
 from beeai_framework.agents.react.types import ReActAgentRunOutput
 from beeai_framework.backend.chat import ChatModel
-from beeai_framework.emitter.emitter import Emitter, EventMeta
 from beeai_framework.errors import FrameworkError
 from beeai_framework.memory.unconstrained_memory import UnconstrainedMemory
 from beeai_framework.tools.search.duckduckgo import DuckDuckGoSearchTool
@@ -16,13 +15,9 @@ async def main() -> None:
     llm = ChatModel.from_name("ollama:granite3.1-dense:8b")
     agent = ReActAgent(llm=llm, tools=[DuckDuckGoSearchTool(), OpenMeteoTool()], memory=UnconstrainedMemory())
 
-    def update_callback(data: dict, event: EventMeta) -> None:
-        print(f"Agent({data['update']['key']}) 🤖 : ", data["update"]["parsedValue"])
-
-    def on_update(emitter: Emitter) -> None:
-        emitter.on("update", update_callback)
-
-    output: ReActAgentRunOutput = await agent.run("What's the current weather in Las Vegas?").observe(on_update)
+    output: ReActAgentRunOutput = await agent.run("What's the current weather in Las Vegas?").on(
+        "update", lambda data, event: print(f"Agent({data['update']['key']}) 🤖 : ", data["update"]["parsedValue"])
+    )
 
     print("Agent 🤖 : ", output.result.text)
 


### PR DESCRIPTION
### Which issue(s) does this pull-request address?

Closes: #471

### Description

This introduces the `Run.on` method that combines the `Run.observe` and `Emitter.match` calls into one more user friendly callback.

Included in this PR:
- The `Run.on` method and rework of `Run` internals to support it
- Updates to a few demos to leverage the new method
- Address mypy errors by moving the `ContextVar` storage to a global, as a `ContextVar` is intended to be

### Checklist

<!-- For completed items, change [ ] to [x]. -->

- [x] I have read the [contributor guide](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have [signed off](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-dco) on my commit
- [x] Tests are included <!-- Bug fixes and new features should include tests -->
- [ ] Documentation is changed or added
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
