### PR TITLE
feat(adapters): Support additional headers for OpenAI backend

### DIFF
--- a/python/beeai_framework/adapters/litellm/chat.py
+++ b/python/beeai_framework/adapters/litellm/chat.py
@@ -78,6 +78,11 @@ class LiteLLMChatModel(ChatModel, ABC):
                 if isinstance(parsed_headers, dict):
                     extra_headers = parsed_headers
             except json.JSONDecodeError:
+                logger.error(
+                    f"Error decoding LITELLM_EXTRA_HEADERS: {extra_headers_json}. "
+                    + "This must be a valid JSON string. No extra headers will be set."
+                )
+                # consider raising an exception.            except json.JSONDecodeError:
                 pass
 
         if extra_headers:

--- a/python/beeai_framework/adapters/litellm/chat.py
+++ b/python/beeai_framework/adapters/litellm/chat.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import logging
-import os
 from abc import ABC
 from collections.abc import AsyncGenerator
 from typing import Any
@@ -66,37 +65,11 @@ class LiteLLMChatModel(ChatModel, ABC):
         litellm.drop_params = True
         self._settings = settings.copy() if settings is not None else {}
 
-        # Extra headers logic
-        extra_headers = None
-        extra_headers_str = self._settings.get("extra_headers", os.getenv("LITELLM_EXTRA_HEADERS"))
-
-        if extra_headers_str:
-            try:
-                parsed_headers = {}
-                for pair in extra_headers_str.split(","):
-                    pair = pair.strip()
-                    if "=" in pair:
-                        key, value = pair.split("=", 1)
-                        parsed_headers[key.strip()] = value.strip()
-
-                if parsed_headers:
-                    extra_headers = parsed_headers
-
-            except Exception as e:
-                logger.error(
-                    f"Error parsing LITELLM_EXTRA_HEADERS: {extra_headers_str}. "
-                    f"Error: {e}. "
-                    "This must be a comma-separated list of key=value pairs. No extra headers will be set."
-                )
-                # consider raising an exception.            except json.JSONDecodeError:
-                pass
-
-        if extra_headers:
-            self._settings["extra_headers"] = extra_headers
-
     @staticmethod
     def litellm_debug(enable: bool = True) -> None:
         litellm.set_verbose = enable  # type: ignore
+        litellm.suppress_debug_info = not enable
+
         litellm.suppress_debug_info = not enable
         litellm.logging = enable
 

--- a/python/beeai_framework/adapters/litellm/chat.py
+++ b/python/beeai_framework/adapters/litellm/chat.py
@@ -32,7 +32,6 @@ from beeai_framework.adapters.litellm._patch import _patch_litellm_cache
 from beeai_framework.backend.chat import (
     ChatModel,
 )
-from beeai_framework.backend.constants import ProviderName
 from beeai_framework.backend.errors import ChatModelError
 from beeai_framework.backend.message import (
     AssistantMessage,

--- a/python/beeai_framework/adapters/litellm/utils.py
+++ b/python/beeai_framework/adapters/litellm/utils.py
@@ -1,0 +1,69 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Any
+
+from beeai_framework.logger import Logger
+
+logger = Logger(__name__)
+
+
+def parse_extra_headers(
+    settings_headers: dict[str, Any] | None = None,
+    env_headers: str | None = None,
+) -> dict[str, str]:
+    """
+    Parses extra headers from settings and/or environment variables.
+
+    Args:
+        settings_headers: Extra headers provided in settings.
+        env_headers: Extra headers from the environment variable.
+
+    Returns:
+        A dictionary of extra headers or {} if no headers are found.
+
+    """
+    extra_headers: dict[str, str] = {}
+
+    # Priority 2: Environment variable (provider-specific)
+    if env_headers:
+        extra_headers = _parse_header_string(env_headers)
+
+    # Priority 1: Settings (highest priority)
+    if settings_headers is None:
+        pass
+    elif isinstance(settings_headers, dict):
+        extra_headers = settings_headers
+    else:
+        # Should be unreachable. protect against not passing dict/None
+        raise ValueError(
+            f"Invalid settings_headers format. Expected a dictionary or None, received {type(settings_headers)}"
+        )
+
+    return extra_headers
+
+
+def _parse_header_string(header_string: str) -> dict[str, str]:
+    """Parses a comma-separated string of headers into a dictionary."""
+    headers: dict[str, str] = {}
+    if not header_string:
+        return headers
+    header_string = header_string.strip()
+    for pair in header_string.split(","):
+        pair = pair.strip()
+        if "=" in pair:
+            key, value = pair.split("=", 1)
+            headers[key.strip()] = value.strip()
+        else:
+            logger.warning(f"Malformed header string detected. Will ignore it: {pair}")
+    return headers

--- a/python/beeai_framework/adapters/litellm/utils.py
+++ b/python/beeai_framework/adapters/litellm/utils.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from typing import Any
 
 from beeai_framework.logger import Logger

--- a/python/beeai_framework/adapters/openai/backend/chat.py
+++ b/python/beeai_framework/adapters/openai/backend/chat.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+import json
 import os
 from typing import Any
 
@@ -30,6 +31,21 @@ class OpenAIChatModel(LiteLLMChatModel):
 
     def __init__(self, model_id: str | None = None, settings: dict[str, Any] | None = None) -> None:
         _settings = settings.copy() if settings is not None else {}
+
+        # Extra headers -- ignored if invalid
+        extra_headers = None
+        extra_headers_json = _settings.get("extra_headers", os.getenv("OPENAI_EXTRA_HEADERS"))
+
+        if extra_headers_json:
+            try:
+                parsed_headers = json.loads(extra_headers_json)
+                if isinstance(parsed_headers, dict):
+                    extra_headers = parsed_headers
+            except json.JSONDecodeError:
+                pass
+
+        if extra_headers:
+            _settings["headers"] = extra_headers
 
         super().__init__(
             model_id if model_id else os.getenv("OPENAI_CHAT_MODEL", "gpt-4o"),

--- a/python/beeai_framework/adapters/openai/backend/chat.py
+++ b/python/beeai_framework/adapters/openai/backend/chat.py
@@ -16,6 +16,7 @@
 import os
 from typing import Any
 
+from beeai_framework.adapters.litellm import utils
 from beeai_framework.adapters.litellm.chat import LiteLLMChatModel
 from beeai_framework.backend.constants import ProviderName
 from beeai_framework.logger import Logger
@@ -51,3 +52,8 @@ class OpenAIChatModel(LiteLLMChatModel):
             provider_id="openai",
             settings=_settings,
         )
+        self._settings["extra_headers"] = utils.parse_extra_headers(
+            self._settings.get("extra_headers"), os.getenv("OPENAI_EXTRA_HEADERS")
+        )
+
+        pass

--- a/python/beeai_framework/adapters/openai/backend/chat.py
+++ b/python/beeai_framework/adapters/openai/backend/chat.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-import json
 import os
 from typing import Any
 
@@ -31,21 +30,6 @@ class OpenAIChatModel(LiteLLMChatModel):
 
     def __init__(self, model_id: str | None = None, settings: dict[str, Any] | None = None) -> None:
         _settings = settings.copy() if settings is not None else {}
-
-        # Extra headers -- ignored if invalid
-        extra_headers = None
-        extra_headers_json = _settings.get("extra_headers", os.getenv("OPENAI_EXTRA_HEADERS"))
-
-        if extra_headers_json:
-            try:
-                parsed_headers = json.loads(extra_headers_json)
-                if isinstance(parsed_headers, dict):
-                    extra_headers = parsed_headers
-            except json.JSONDecodeError:
-                pass
-
-        if extra_headers:
-            _settings["headers"] = extra_headers
 
         super().__init__(
             model_id if model_id else os.getenv("OPENAI_CHAT_MODEL", "gpt-4o"),

--- a/python/beeai_framework/adapters/openai/backend/chat.py
+++ b/python/beeai_framework/adapters/openai/backend/chat.py
@@ -24,11 +24,26 @@ logger = Logger(__name__)
 
 
 class OpenAIChatModel(LiteLLMChatModel):
+    """
+    A chat model implementation for the OpenAI provider, leveraging LiteLLM.
+    """
+
     @property
     def provider_id(self) -> ProviderName:
+        """The provider ID for OpenAI."""
         return "openai"
 
     def __init__(self, model_id: str | None = None, settings: dict[str, Any] | None = None) -> None:
+        """
+        Initializes the OpenAIChatModel.
+
+        Args:
+            model_id: The ID of the OpenAI model to use. If not provided,
+                it falls back to the OPENAI_CHAT_MODEL environment variable,
+                and then defaults to 'gpt-4o'.
+            settings: A dictionary of settings to configure the model.
+                These settings will take precedence over environment variables.
+        """
         _settings = settings.copy() if settings is not None else {}
 
         super().__init__(

--- a/python/docs/backend.md
+++ b/python/docs/backend.md
@@ -44,7 +44,7 @@ The following table depicts supported providers. Each provider requires specific
 | Name             | Chat | Embedding | Dependency               | Environment Variables                                                                                                                                                 |
 | ---------------- | :--: | :-------: | ------------------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Ollama`         |  ✅  |          | `ollama-ai-provider`     | OLLAMA_CHAT_MODEL<br/>OLLAMA_BASE_URL                                                                                                       |
-| `OpenAI`         |  ✅  |          | `openai`     | OPENAI_CHAT_MODEL<br/>OPENAI_API_BASE<br/>OPENAI_API_KEY<br/>OPENAI_ORGANIZATION                                                                                                       |
+| `OpenAI`         |  ✅  |          | `openai`     | OPENAI_CHAT_MODEL<br/>OPENAI_API_BASE<br/>OPENAI_API_KEY<br/>OPENAI_ORGANIZATION<br>OPENAI_EXTRA_HEADERS                                                                                                       |
 | `Watsonx`        |  ✅  |          | `@ibm-cloud/watsonx-ai`  | WATSONX_CHAT_MODEL<br/>WATSONX_EMBEDDING_MODEL<br>WATSONX_API_KEY<br/>WATSONX_PROJECT_ID<br/>WATSONX_SPACE_ID<br>WATSONX_VERSION<br>WATSONX_REGION                    |
 | `Groq`           |  ✅  |         | | GROQ_CHAT_MODEL<br>GROQ_API_KEY |
 | `Amazon Bedrock` |  ✅  |         |  `boto3`| AWS_CHAT_MODEL<br>AWS_ACCESS_KEY_ID<br>AWS_SECRET_ACCESS_KEY<br>AWS_REGION_NAME |

--- a/python/docs/backend.md
+++ b/python/docs/backend.md
@@ -56,7 +56,7 @@ The following table depicts supported providers. Each provider requires specific
 In addition to the variables listed above, the following apply across all existing providers which use LitelLM.
 | Environment variable | Description | Example |
 | -- | -- | -- |
-| `LITELLM_EXTRA_HEADERS` | JSON string of headers to be sent with the request | {"secret-key": "a764e90bac"}
+| `LITELLM_EXTRA_HEADERS` | Command seperated list of key value pairs for extra headers to be sent with the request | secret-key=a764e90bac
 > [!TIP]
 >
 > If you don't see your provider raise an issue [here](https://github.com/i-am-bee/beeai-framework/discussions). Meanwhile, you can use [Ollama adapter](/python/examples/backend/providers/ollama.py).

--- a/python/docs/backend.md
+++ b/python/docs/backend.md
@@ -53,7 +53,10 @@ The following table depicts supported providers. Each provider requires specific
 | `Anthropic`      |  ✅  |         |  | ANTHROPIC_CHAT_MODEL<br>ANTHROPIC_API_KEY |
 | `xAI`           |  ✅  |         | | XAI_CHAT_MODEL<br>XAI_API_KEY |
 
-
+In addition to the variables listed above, the following apply across all existing providers which use LitelLM.
+| Environment variable | Description | Example |
+| -- | -- | -- |
+| `LITELLM_EXTRA_HEADERS` | JSON string of headers to be sent with the request | {"secret-key": "a764e90bac"}
 > [!TIP]
 >
 > If you don't see your provider raise an issue [here](https://github.com/i-am-bee/beeai-framework/discussions). Meanwhile, you can use [Ollama adapter](/python/examples/backend/providers/ollama.py).

--- a/python/docs/backend.md
+++ b/python/docs/backend.md
@@ -53,10 +53,6 @@ The following table depicts supported providers. Each provider requires specific
 | `Anthropic`      |  ✅  |         |  | ANTHROPIC_CHAT_MODEL<br>ANTHROPIC_API_KEY |
 | `xAI`           |  ✅  |         | | XAI_CHAT_MODEL<br>XAI_API_KEY |
 
-In addition to the variables listed above, the following apply across all existing providers which use LitelLM.
-| Environment variable | Description | Example |
-| -- | -- | -- |
-| `LITELLM_EXTRA_HEADERS` | Command seperated list of key value pairs for extra headers to be sent with the request | secret-key=a764e90bac
 > [!TIP]
 >
 > If you don't see your provider raise an issue [here](https://github.com/i-am-bee/beeai-framework/discussions). Meanwhile, you can use [Ollama adapter](/python/examples/backend/providers/ollama.py).

--- a/python/tests/backend/providers/test_litellm_utils.py
+++ b/python/tests/backend/providers/test_litellm_utils.py
@@ -9,6 +9,8 @@
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import os
 from unittest.mock import patch

--- a/python/tests/backend/providers/test_litellm_utils.py
+++ b/python/tests/backend/providers/test_litellm_utils.py
@@ -1,0 +1,101 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from beeai_framework.adapters.litellm import utils
+
+
+class TestParseExtraHeaders:
+    """
+    Test cases for the parse_extra_headers function.
+    This is used by adapters to send extra headers to the model.
+    This can be useful for proxy servers and gateways
+    """
+
+    @pytest.mark.unit
+    def test_settings_headers_dict(self) -> None:
+        """
+
+        Extra headers are provided in settings (dict).
+        Typically when client app passes setting on ChatModel constructor
+        """
+        settings_headers = {"header1": "value1", "header2": "value2"}
+        result = utils.parse_extra_headers(settings_headers, None)
+        assert result == settings_headers
+
+    @pytest.mark.unit
+    def test_no_headers(self) -> None:
+        """
+        Test when no headers are provided, it should return {}
+        The most regular case - no extra headers needed
+        """
+        result = utils.parse_extra_headers(None, None)
+        assert result == {}
+
+    @pytest.mark.unit
+    def test_env_headers(self) -> None:
+        """
+        Test when extra headers are provided as an environment variable.
+        Simple usage, avoiding any code change
+        """
+        with patch.dict(os.environ, {"LITELLM_EXTRA_HEADERS": "header1=value1, header2=value2"}):
+            result = utils.parse_extra_headers(None, os.environ.get("LITELLM_EXTRA_HEADERS"))
+            assert result == {"header1": "value1", "header2": "value2"}
+
+    @pytest.mark.unit
+    def test_settings_override_env(self) -> None:
+        """
+        Test that existing settings override the environment variables.
+        """
+        settings_headers = {"header1": "new_value1", "header3": "value3"}
+        with patch.dict(os.environ, {"ENV_VAR": "header1=value1, header2=value2"}):
+            result = utils.parse_extra_headers(settings_headers, os.environ.get("ENV_VAR"))
+            assert result == {"header1": "new_value1", "header3": "value3"}
+
+    @pytest.mark.unit
+    def test_env_headers_with_spaces(self) -> None:
+        """Test when environment variable has extra spaces."""
+        with patch.dict(os.environ, {"ENV_VAR": " header1 = value1 , header2= value2 "}):
+            result = utils.parse_extra_headers(None, os.environ.get("ENV_VAR"))
+            assert result == {"header1": "value1", "header2": "value2"}
+
+    @pytest.mark.unit
+    def test_invalid_headers_string_format(self) -> None:
+        """
+        Test when a malformed header string is passed.
+        Expected behaviour is that only correct key=value pairs are parsed.
+        """
+        with patch.dict(os.environ, {"ENV_VAR": "header1=value1,header2value2"}):
+            result = utils.parse_extra_headers(None, os.environ.get("ENV_VAR"))
+            assert result == {"header1": "value1"}
+
+    @pytest.mark.unit
+    def test_empty_header_string(self) -> None:
+        """Test when environment variable is empty or whitespace."""
+
+        with patch.dict(os.environ, {"ENV_VAR": ""}):
+            result = utils.parse_extra_headers(None, os.environ.get("ENV_VAR"))
+            assert result == {}
+
+        with patch.dict(os.environ, {"ENV_VAR": "    "}):
+            result = utils.parse_extra_headers(None, os.environ.get("ENV_VAR"))
+            assert result == {}
+
+    @pytest.mark.unit
+    def test_settings_headers_none(self) -> None:
+        """Test when settings headers are explicitly set to None."""
+        result = utils.parse_extra_headers(None, None)
+        assert result == {}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review and complete the sections below.
-->

### Which issue(s) does this pull-request address?

<!--
Please include a link to an issue in the tracker.  The issue describes the problem to be solved.  If there is no issue raised for this PR then either raise one with a summary and description of the problem or add a summary and description of the problem here
-->

Closes: #532

### Description

[ Updated with revised format / variable ]

<!-- Provide a description of the change, pay special attention to describing any breaking changes.  The description describes the resolution to the problem described in the linked issue (or to the problem outlined in this PR). -->

Adds support for LiteLLM provider to add additional headers
```
export OPENAI_EXTRA_HEADERS="MY_API_KEY=ab592c9f3e001b"
```

To test (for example, with OpenAI, also set:
```
OPENAI_API_KEY=my-api-key
OPENAI_CHAT_MODEL=my-model
OPENAI_API_BASE=https://my-endpoint/
```

Tested ok

### Checklist

<!-- For completed items, change [ ] to [x]. -->

- [x] I have read the [contributor guide](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have [signed off](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-dco) on my commit
- [x] Linting passes: `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: `yarn format` or `yarn format:fix`
- [x] Unit tests pass: `yarn test:unit`
- [ ] E2E tests pass: `yarn test:e2e`
- [ ] Tests are included <!-- Bug fixes and new features should include tests -->
- [x] Documentation is changed or added
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
