### PR TITLE
test(examples): Add missing examples

### DIFF
--- a/python/docs/backend.md
+++ b/python/docs/backend.md
@@ -162,6 +162,23 @@ async def watson_tool_calling() -> None:
     print(final_response.get_text_content())
 
 
+async def watsonx_debug() -> None:
+    # Log every request
+    llm.emitter.match(
+        "*",
+        lambda data, event: print(
+            f"Time: {event.created_at.time().isoformat()}",
+            f"Event: {event.name}",
+            f"Data: {str(data)[:90]}...",
+        ),
+    )
+
+    response = await llm.create(
+        messages=[UserMessage("Hello world!")],
+    )
+    print(response.messages[0].to_plain())
+
+
 async def main() -> None:
     print("*" * 10, "watsonx_from_name")
     await watsonx_from_name()
@@ -175,6 +192,8 @@ async def main() -> None:
     await watson_structure()
     print("*" * 10, "watson_tool_calling")
     await watson_tool_calling()
+    print("*" * 10, "watsonx_debug")
+    await watsonx_debug()
 
 
 if __name__ == "__main__":

--- a/python/examples/agents/experimental/human.py
+++ b/python/examples/agents/experimental/human.py
@@ -1,0 +1,68 @@
+import asyncio
+import sys
+import traceback
+
+from beeai_framework import ReActAgent, TokenMemory
+from beeai_framework.adapters.ollama.backend.chat import OllamaChatModel
+from beeai_framework.agents import AgentExecutionConfig
+from beeai_framework.errors import FrameworkError
+from beeai_framework.tools.weather.openmeteo import OpenMeteoTool
+from examples.helpers.io import ConsoleReader
+from examples.tools.experimental.human import HumanTool, HumanToolInput
+
+
+async def main() -> None:
+    # Initialize LLM (test against llama as requested)
+    llm = OllamaChatModel("llama3.1")
+
+    # Create the console reader once, share it with HumanTool
+    reader = ConsoleReader()
+
+    # Initialize ReActAgent with shared reader for HumanTool
+    agent = ReActAgent(
+        llm=llm,
+        memory=TokenMemory(llm),
+        tools=[
+            OpenMeteoTool(),
+            HumanTool(
+                HumanToolInput(
+                    reader=reader,
+                )
+            ),
+        ],
+    )
+
+    # Main loop
+    for prompt in reader:
+        # Run the agent and observe events
+        response = (
+            await agent.run(
+                prompt=prompt,
+                execution=AgentExecutionConfig(max_retries_per_step=3, total_max_retries=10, max_iterations=20),
+            )
+            .on(
+                "update",  # Show only final answers
+                lambda data, event: reader.write("Agent 🤖 : ", data["update"]["value"])
+                if data["update"]["key"] == "final_answer"
+                else None,
+            )
+            .on(
+                "error",  # Log errors
+                lambda data, event: reader.write("Agent 🤖 : ", FrameworkError.ensure(data["error"]).explain()),
+            )
+            .on(
+                "retry",  # Retry notifications
+                lambda data, event: reader.write("Agent 🤖 : ", "Retrying the action..."),
+            )
+        )
+
+        # Print the final response
+        reader.write("Agent 🤖 : ", response.result.text)
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except FrameworkError as e:
+        traceback.print_exc()
+        sys.exit(e.explain())

--- a/python/examples/backend/providers/watsonx.py
+++ b/python/examples/backend/providers/watsonx.py
@@ -93,6 +93,23 @@ async def watson_tool_calling() -> None:
     print(final_response.get_text_content())
 
 
+async def watsonx_debug() -> None:
+    # Log every request
+    llm.emitter.match(
+        "*",
+        lambda data, event: print(
+            f"Time: {event.created_at.time().isoformat()}",
+            f"Event: {event.name}",
+            f"Data: {str(data)[:90]}...",
+        ),
+    )
+
+    response = await llm.create(
+        messages=[UserMessage("Hello world!")],
+    )
+    print(response.messages[0].to_plain())
+
+
 async def main() -> None:
     print("*" * 10, "watsonx_from_name")
     await watsonx_from_name()
@@ -106,6 +123,8 @@ async def main() -> None:
     await watson_structure()
     print("*" * 10, "watson_tool_calling")
     await watson_tool_calling()
+    print("*" * 10, "watsonx_debug")
+    await watsonx_debug()
 
 
 if __name__ == "__main__":

--- a/python/examples/tools/experimental/human.py
+++ b/python/examples/tools/experimental/human.py
@@ -73,8 +73,6 @@ class HumanTool(Tool[InputSchema, ToolRunOptions, JSONToolOutput]):
     async def _run(self, tool_input: InputSchema, options: ToolRunOptions | None, run: RunContext) -> JSONToolOutput:
         # Use the reader from input
         self.tool_input.reader.write("HumanTool", tool_input.message)
-
-        # Use askSingleQuestion with the signal
         user_input = self.tool_input.reader.prompt()
 
         # Return JSONToolOutput with the clarification

--- a/python/examples/tools/experimental/human.py
+++ b/python/examples/tools/experimental/human.py
@@ -1,0 +1,85 @@
+from pydantic import BaseModel, Field, InstanceOf
+
+from beeai_framework.context import RunContext
+from beeai_framework.emitter import Emitter
+from beeai_framework.tools.tool import JSONToolOutput, Tool, ToolRunOptions
+from examples.helpers.io import ConsoleReader
+
+
+class HumanToolInput(BaseModel):
+    reader: InstanceOf[ConsoleReader]
+    name: str | None = None
+    description: str | None = None
+
+
+class InputSchema(BaseModel):
+    message: str = Field(min_length=1)
+
+
+class HumanTool(Tool[InputSchema, ToolRunOptions, JSONToolOutput]):
+    name = "HumanTool"
+    description = """
+    This tool is used whenever the user's input is unclear, ambiguous, or incomplete.
+    The agent MUST invoke this tool when additional clarification is required to proceed.
+    The output must adhere strictly to the following structure:
+        - Thought: A single-line description of the need for clarification.
+        - Function Name: HumanTool
+        - Function Input: { "message": "Your question to the user for clarification." }
+        - Function Output: The user's response in JSON format.
+    Examples:
+        - Example 1:
+          Input: "What is the weather?"
+          Thought: "The user's request lacks a location. I need to ask for clarification."
+          Function Name: HumanTool
+          Function Input: { "message": "Could you provide the location for which you would like to know the weather?" }
+          Function Output: { "clarification": "Santa Fe, Argentina" }
+          Final Answer: The current weather in Santa Fe, Argentina is 17.3°C with a relative humidity of 48% and a wind speed of 10.1 km/h.
+
+        - Example 2:
+          Input: "Can you help me?"
+          Thought: "The user's request is too vague. I need to ask for more details."
+          Function Name: HumanTool
+          Function Input: { "message": "Could you clarify what kind of help you need?" }
+          Function Output: { "clarification": "I need help understanding how to use the project management tool." }
+          Final Answer: Sure, I can help you with the project management tool. Let me know which feature you'd like to learn about or if you'd like a general overview.
+
+        - Example 3:
+          Input: "Translate this sentence."
+          Thought: "The user's request is incomplete. I need to ask for the sentence they want translated."
+          Function Name: HumanTool
+          Function Input: { "message": "Could you specify the sentence you would like me to translate?" }
+          Function Output: { "clarification": "Translate 'Hello, how are you?' to French." }
+          Final Answer: The French translation of 'Hello, how are you?' is 'Bonjour, comment vas-tu?'
+
+    Note: Do NOT attempt to guess or provide incomplete responses. Always use this tool when in doubt to ensure accurate and meaningful interactions.
+"""  # noqa: E501
+
+    def __init__(self, tool_input: HumanToolInput) -> None:
+        super().__init__()
+        self.tool_input = tool_input
+        self.name = tool_input.name or self.name
+        self.description = tool_input.description or self.description
+
+    def _create_emitter(self) -> Emitter:
+        return Emitter.root().child(
+            namespace=["tool", "human"],
+            creator=self,
+        )
+
+    @property
+    def input_schema(self) -> type[InputSchema]:
+        return InputSchema
+
+    async def _run(self, tool_input: InputSchema, options: ToolRunOptions | None, run: RunContext) -> JSONToolOutput:
+        # Use the reader from input
+        self.tool_input.reader.write("HumanTool", tool_input.message)
+
+        # Use askSingleQuestion with the signal
+        user_input = self.tool_input.reader.prompt()
+
+        # Return JSONToolOutput with the clarification
+        return JSONToolOutput(
+            {
+                "clarification": user_input.strip(),
+            }
+        )


### PR DESCRIPTION
### Which issue(s) does this pull-request address?

Ref #336 

### Description

This adds the remaining examples that aren't blocked by a missing feature, Tool, or Agent

Examples added:
- `watsonx_debug` added to `backend/providers/watsonx.py` instead of it's own file
- `tools/experimental/human.py` and `agents/experimental/human.py` added as a pair

### Checklist

<!-- For completed items, change [ ] to [x]. -->

- [x] I have read the [contributor guide](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have [signed off](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-dco) on my commit
- [x] Tests are included <!-- Bug fixes and new features should include tests -->
- [x] Documentation is changed or added
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
