### PR TITLE
fix: handle colon symbols in model id

### DIFF
--- a/typescript/examples/backend/chatFromName.ts
+++ b/typescript/examples/backend/chatFromName.ts
@@ -1,0 +1,16 @@
+import "dotenv/config.js";
+import { createConsoleReader } from "examples/helpers/io.js";
+import { UserMessage } from "beeai-framework/backend/message";
+import { ChatModel } from "beeai-framework/backend/chat";
+
+const llm = await ChatModel.fromName("ollama:granite3.2:8b");
+
+const reader = createConsoleReader();
+
+for await (const { prompt } of reader) {
+  const response = await llm.create({
+    messages: [new UserMessage(prompt)],
+  });
+  reader.write(`LLM 🤖 (txt) : `, response.getTextContent());
+  reader.write(`LLM 🤖 (raw) : `, JSON.stringify(response.messages));
+}

--- a/typescript/src/backend/utils.ts
+++ b/typescript/src/backend/utils.ts
@@ -33,7 +33,9 @@ export function parseModel(name: string) {
   if (!name) {
     throw new ValueError("Neither 'provider' nor 'provider:model' was specified.");
   }
-  const [providerId, modelId] = name.split(":") as [ProviderName, string];
+  const [providerId, ...rest] = name.split(":") as [ProviderName, ...string[]];
+  const modelId = rest.join(":");
+
   const providerDef = findProviderDef(providerId);
   if (!providerDef) {
     throw new ValueError("Model does not contain provider name!");


### PR DESCRIPTION
Fix that makes it possible to use model ids with colon symbols which is common in ollama.

For example: 

```
const llm = await ChatModel.fromName("ollama:granite3.2:8b");
```

The current implementation will identify `granite3.2` as the modelId and lead to an ollama error. 

This PR updates the model parsing code to correctly extract the model id `granite3.2:8b`

### Checklist

<!-- For completed items, change [ ] to [x]. -->

- [x] I have read the [contributor guide](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have [signed off](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-dco) on my commit
- [x] Linting passes: `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: `yarn format` or `yarn format:fix`
- [x] Unit tests pass: `yarn test:unit`
- [x] E2E tests pass: `yarn test:e2e`
- [x] Tests are included <!-- Bug fixes and new features should include tests -->
- [ ] Documentation is changed or added
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
