### PR TITLE
docs: fix remaining broken links for both typescript and python   @bhargavyagnik

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,7 +41,6 @@ jobs:
             .
             --verbose
             --no-progress
-            --include-fragments
             --exclude-path docs/typescript/CHANGELOG.md
             './docs/**/*.md'
             './docs/**/*.html'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,6 +41,7 @@ jobs:
             .
             --verbose
             --no-progress
+            --include-fragments
             --exclude-path docs/typescript/CHANGELOG.md
             './docs/**/*.md'
             './docs/**/*.html'

--- a/python/docs/cache.md
+++ b/python/docs/cache.md
@@ -200,4 +200,5 @@ _Source: /examples/cache/custom.py_
 
 ## Examples
 
-- All cache examples can be found in [here](/python/examples/cache).
+- All cache examples are coming soon in python.
+<!-- - All cache examples can be found in [here](/python/examples/cache). -->

--- a/python/docs/serialization.md
+++ b/python/docs/serialization.md
@@ -36,7 +36,7 @@ BeeAI framework provides robust serialization capabilities through its built-in 
 Coming soon
 ```
 
-_Source: [examples/serialization/base.py](/python/examples/serialization/base.py)_
+<!-- _Source: [examples/serialization/base.py](/python/examples/serialization/base.py)_ -->
 
 ---
 
@@ -74,7 +74,7 @@ Most BeeAI components can be serialized out of the box. Here's an example using 
 Coming soon
 ```
 
-_Source: [examples/serialization/memory.py](/python/examples/serialization/memory.py)_
+<!-- _Source: [examples/serialization/memory.py](/python/examples/serialization/memory.py)_ -->
 
 > [TIP!]
 > Most framework components are `Serializable`.
@@ -93,7 +93,7 @@ You can register external classes with the serializer:
 Coming soon
 ```
 
-_Source: [examples/serialization/customExternal.py](/python/examples/serialization/customExternal.py)_
+<!-- _Source: [examples/serialization/customExternal.py](/python/examples/serialization/customExternal.py)_ -->
 
 **2. Implement the `Serializable` Interface**
 
@@ -103,7 +103,7 @@ For deeper integration, extend the Serializable class:
 Coming soon
 ```
 
-_Source: [examples/serialization/customInternal.py](/python/examples/serialization/customInternal.py)_
+<!-- _Source: [examples/serialization/customInternal.py](/python/examples/serialization/customInternal.py)_ -->
 
 > [NOTE!]
 > Failure to register a class that the `Serializer` does not know will result in the `SerializerError` error. BeeAI framework avoids importing all potential classes automatically to prevent increased application size and unnecessary dependencies.
@@ -114,10 +114,10 @@ _Source: [examples/serialization/customInternal.py](/python/examples/serializati
 Coming soon
 ```
 
-_Source: [examples/serialization/context.py](/python/examples/serialization/context.py)_
+<!-- _Source: [examples/serialization/context.py](/python/examples/serialization/context.py)_ -->
 
 ---
 
 ## Examples
-
-- All serialization examples can be found in [here](/python/examples/serialization).
+- All serialization examples are coming soon in python.
+<!-- - All serialization examples can be found in [here](/python/examples/serialization). -->

--- a/typescript/CONTRIBUTING.md
+++ b/typescript/CONTRIBUTING.md
@@ -8,7 +8,7 @@ community in this goal.
 
 If you are new to Bee contributing, we recommend you do the following before diving into the code:
 
-- Read [Bee Overview](/docs/overview.md) to understand core concepts.
+- Read [Bee Overview](/typescript/docs/overview.md) to understand core concepts.
 - Read [Code of Conduct](./CODE_OF_CONDUCT.md).
 
 ## Style and lint
@@ -68,7 +68,7 @@ yarn prepare
 ```
 
 - Type: feat, fix, chore, docs, style, refactor, perf, test, etc.
-- Scope: The area of the codebase your changes affect (optional). The allowed values are: adapters, agents, llms, tools, cache, emitter, internals, logger, memory, serializer, infra, deps, instrumentation. The latest values are listed in [package.json](/package.json)
+- Scope: The area of the codebase your changes affect (optional). The allowed values are: adapters, agents, llms, tools, cache, emitter, internals, logger, memory, serializer, infra, deps, instrumentation. The latest values are listed in [package.json](/typescript/package.json)
 - Subject: A short description of the changes (required).
 
 _Example:_

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -120,7 +120,7 @@ npm run start [project_name].ts
 
 The BeeAI Framework is an open-source project and we ❤️ contributions.<br>
 
-If you'd like to help build BeeAI, take a look at our [contribution guidelines](/typescript/docs/CONTRIBUTING.md).
+If you'd like to help build BeeAI, take a look at our [contribution guidelines](/typescript/CONTRIBUTING.md).
 
 ## Bugs
 

--- a/typescript/docs/cache.md
+++ b/typescript/docs/cache.md
@@ -320,7 +320,7 @@ await setTimeout(150);
 console.info(token === (await getSecret())); // false
 ```
 
-_Source: [examples/cache/cacheFn.ts](/typescriptexamples/cache/cacheFn.ts)_
+_Source: [examples/cache/cacheFn.ts](/typescript/examples/cache/cacheFn.ts)_
 
 > [!NOTE]
 >
@@ -373,4 +373,4 @@ export class CustomCache<T> extends BaseCache<T> {
 
 _Source: [examples/cache/custom.ts](/typescript/examples/cache/custom.ts)_
 
-The simplest implementation is `UnconstrainedCache`, which can be found [here](/src/cache/unconstrainedCache.ts).
+The simplest implementation is `UnconstrainedCache`, which can be found [here](/typescript/src/cache/unconstrainedCache.ts).

--- a/typescript/docs/overview.md
+++ b/typescript/docs/overview.md
@@ -7,7 +7,7 @@ The source directory (`src`) provides numerous modules that one can use.
 | Name                                        | Description                                                                                 |
 | ------------------------------------------- | ------------------------------------------------------------------------------------------- |
 | [**agents**](./agents.md)                   | Base classes defining the common interface for agent.                                       |
-| [**backend**](/docs/backend.md)             | Functionalities that relates to AI models (chat, embedding, image, tool calling, ...)       |
+| [**backend**](./backend.md)                 | Functionalities that relates to AI models (chat, embedding, image, tool calling, ...)       |
 | [**template**](./templates.md)              | Prompt Templating system based on `Mustache` with various improvements.                     |
 | [**memory**](./memory.md)                   | Various types of memories to use with agent.                                                |
 | [**tools**](./tools.md)                     | Tools that an agent can use.                                                                |

--- a/typescript/docs/serialization.md
+++ b/typescript/docs/serialization.md
@@ -20,7 +20,7 @@ console.info(deserialized instanceof Date); // true
 console.info(original.toISOString() === deserialized.toISOString()); // true
 ```
 
-_Source: [examples/serialization/base.ts](/examples/tools/base.ts)_
+_Source: [examples/serialization/base.ts](/typescript/examples/tools/base.ts)_
 
 > [!NOTE]
 >
@@ -28,7 +28,7 @@ _Source: [examples/serialization/base.ts](/examples/tools/base.ts)_
 
 ## Being Serializable
 
-Most parts of the framework implement the internal [`Serializable`](/src/internals/serializable.ts) class, which exposes the following methods.
+Most parts of the framework implement the internal [`Serializable`](/typescript/src/internals/serializable.ts) class, which exposes the following methods.
 
 - `createSnapshot` (returns an object that "snapshots" the current state)
 - `loadSnapshot` (applies the provided snapshot to the current instance)
@@ -53,7 +53,7 @@ const deserialized = await TokenMemory.fromSerialized(serialized);
 await deserialized.add(new AssistantMessage("Bee"));
 ```
 
-_Source: [examples/serialization/memory.ts](/examples/serialization/memory.ts)_
+_Source: [examples/serialization/memory.ts](/typescript/examples/serialization/memory.ts)_
 
 ### Serializing unknowns
 
@@ -90,7 +90,7 @@ console.info(instance);
 console.info(deserialized);
 ```
 
-_Source: [examples/serialization/customExternal.ts](/examples/serialization/customExternal.ts)_
+_Source: [examples/serialization/customExternal.ts](/typescript/examples/serialization/customExternal.ts)_
 
 or you can extend the `Serializable` class.
 
@@ -128,7 +128,7 @@ console.info(instance);
 console.info(deserialized);
 ```
 
-_Source: [examples/serialization/customInternal.ts](/examples/serialization/customInternal.ts)_
+_Source: [examples/serialization/customInternal.ts](/typescript/examples/serialization/customInternal.ts)_
 
 > [!TIP]
 >
@@ -153,7 +153,7 @@ const memory = await UnconstrainedMemory.fromSerialized(serialized, {
 console.info(memory.messages);
 ```
 
-_Source: [examples/serialization/context.ts](/examples/serialization/context.ts)_
+_Source: [examples/serialization/context.ts](/typescript/examples/serialization/context.ts)_
 
 > [!IMPORTANT]
 >

--- a/typescript/docs/tools.md
+++ b/typescript/docs/tools.md
@@ -110,7 +110,7 @@ const agent = new BeeAgent({
 });
 ```
 
-_Source: [examples/tools/agent.ts](/typescriptexamples/tools/agent.ts)_
+_Source: [examples/tools/agent.ts](/typescript/examples/tools/agent.ts)_
 
 ## Writing a new tool
 
@@ -337,7 +337,7 @@ _Source: [examples/tools/custom/openLibrary.ts](/typescript/examples/tools/custo
 
 - **Declare an input schema:**
 
-  This is used to define the format of the input to your tool. The agent will formalise the natural language input(s) it has received and structure them into the fields described in the tool's input. The input schema can be specified using [Zod](https://github.com/colinhacks/zod) (recommended) or JSONSchema. It must be a function (either sync or async). Zod effects (e.g. `z.object().transform(...)`) are not supported. The return value of `inputSchema` must always be an object and pass validation by the `validateSchema()` function defined in [schema.ts](/src/internals/helpers/schema.ts). Keep your tool input schema simple and provide schema descriptions to help the agent to interpret fields.
+  This is used to define the format of the input to your tool. The agent will formalise the natural language input(s) it has received and structure them into the fields described in the tool's input. The input schema can be specified using [Zod](https://github.com/colinhacks/zod) (recommended) or JSONSchema. It must be a function (either sync or async). Zod effects (e.g. `z.object().transform(...)`) are not supported. The return value of `inputSchema` must always be an object and pass validation by the `validateSchema()` function defined in [schema.ts](/typescript/src/internals/helpers/schema.ts). Keep your tool input schema simple and provide schema descriptions to help the agent to interpret fields.
 
   <!-- eslint-skip -->
 


### PR DESCRIPTION
### Which issue(s) does this pull-request address?
Solved https://github.com/i-am-bee/beeai-framework/issues/543.

Updated links to existing docs. 

Now, as per link checker, the missing links are only 
Errors in docs/README.md
- [ ] [ERROR] file:///typescript/docs/backend.md%23providers-implementations | Cannot find file
- [ ] [ERROR] file:///typescript/docs/tools.md%23using-the-mcptool-class | Cannot find file
- [ ] [ERROR] file:///python/tools.md%23using-the-customtool-python-functions | Cannot find file
- [ ] [ERROR] file:///python/tools.md%23mcp-tool | Cannot find file
- [ ] [ERROR] file:///python/docs/agents.md%23creating-your-own-agent | Cannot find file
- [ ] [ERROR] file:///python/backend.md%23supported-providers | Cannot find file

But, this is an issue with fragments. The links are working fine with readme, IDE and website. The link-checker has an issue with finding anchor links in the code. So I will mention this in the PR submitted https://github.com/i-am-bee/beeai-framework/pull/542
<!--
Please include a link to an issue in the tracker.  The issue describes the problem to be solved.  If there is no issue raised for this PR then either raise one with a summary and description of the problem or add a summary and description of the problem here
-->

Closes: #543 

### Description

<!-- Provide a description of the change, pay special attention to describing any breaking changes.  The description describes the resolution to the problem described in the linked issue (or to the problem outlined in this PR). -->

### Checklist

#### General
- [x] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [x] Linting passes: Python `poe lint` or `poe lint --fix` / TypeScript `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: Python `poe format` or `poe format --fix` / TypeScript: `yarn format` or `yarn format:fix`
- [x] Static type checks pass: Python `poe type-check`

#### Testing
- [ ] Unit tests pass: Python `poe test --type unit` / TypeScript `yarn test:unit`
- [ ] E2E tests pass: Python `poe test --type e2e` / TypeScript: `yarn test:e2e`
- [ ] Integration tests pass: Python `poe test --type integration`
- [ ] Tests are included (for bug fixes or new features)

#### Documentation
- [x] Documentation is updated
- [x] Embedme embeds code examples in docs. To update after edits, run: Python `poe docs --type build`
