### PR TITLE
refactor: Add emitter event types and fix mypy

### DIFF
--- a/python/beeai_framework/adapters/langchain/tools.py
+++ b/python/beeai_framework/adapters/langchain/tools.py
@@ -23,7 +23,8 @@ from pydantic import BaseModel, ConfigDict
 
 from beeai_framework.context import RunContext
 from beeai_framework.emitter.emitter import Emitter
-from beeai_framework.tools.tool import StringToolOutput, Tool, ToolRunOptions
+from beeai_framework.tools.tool import StringToolOutput, Tool
+from beeai_framework.tools.types import ToolRunOptions
 from beeai_framework.utils.strings import to_safe_word
 
 

--- a/python/beeai_framework/adapters/litellm/chat.py
+++ b/python/beeai_framework/adapters/litellm/chat.py
@@ -15,6 +15,7 @@
 import logging
 from abc import ABC
 from collections.abc import AsyncGenerator
+from typing import Any
 
 import litellm
 from litellm import (
@@ -96,7 +97,7 @@ class LiteLLMChatModel(ChatModel, ABC):
             # TODO: issue https://github.com/BerriAI/litellm/issues/8868
             raise ChatModelError("Stream response is empty.")
 
-    async def _create_structure(self, input: ChatModelStructureInput, run: RunContext) -> ChatModelStructureOutput:
+    async def _create_structure(self, input: ChatModelStructureInput[Any], run: RunContext) -> ChatModelStructureOutput:
         if "response_format" not in self.supported_params:
             logger.warning(f"{self.provider_id} model {self.model_id} does not support structured data.")
             return await super()._create_structure(input, run)

--- a/python/beeai_framework/adapters/litellm/chat.py
+++ b/python/beeai_framework/adapters/litellm/chat.py
@@ -29,16 +29,18 @@ from litellm.types.utils import StreamingChoices
 from beeai_framework.adapters.litellm._patch import _patch_litellm_cache
 from beeai_framework.backend.chat import (
     ChatModel,
-    ChatModelInput,
-    ChatModelOutput,
-    ChatModelStructureInput,
-    ChatModelStructureOutput,
 )
 from beeai_framework.backend.errors import ChatModelError
 from beeai_framework.backend.message import (
     AssistantMessage,
     MessageToolCallContent,
     ToolMessage,
+)
+from beeai_framework.backend.types import (
+    ChatModelInput,
+    ChatModelOutput,
+    ChatModelStructureInput,
+    ChatModelStructureOutput,
 )
 from beeai_framework.backend.utils import parse_broken_json
 from beeai_framework.context import RunContext

--- a/python/beeai_framework/agents/base.py
+++ b/python/beeai_framework/agents/base.py
@@ -14,7 +14,7 @@
 
 
 from abc import ABC, abstractmethod
-from typing import Generic, TypeVar
+from typing import Any, Generic, TypeVar
 
 from pydantic import BaseModel
 
@@ -86,3 +86,6 @@ class BaseAgent(ABC, Generic[TInput, TOptions, TOutput]):
             description="",
             tools=[],
         )
+
+
+AnyAgent = BaseAgent[Any, Any, Any]

--- a/python/beeai_framework/agents/react/__init__.py
+++ b/python/beeai_framework/agents/react/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
-from beeai_framework.agents.react.agent import ReActAgent, ReActAgentInput, ReActAgentRunInput
+from beeai_framework.agents.react.agent import ReActAgent
+from beeai_framework.agents.react.types import ReActAgentInput, ReActAgentRunInput
 
 __all__ = ["ReActAgent", "ReActAgentInput", "ReActAgentRunInput"]

--- a/python/beeai_framework/agents/react/agent.py
+++ b/python/beeai_framework/agents/react/agent.py
@@ -15,6 +15,7 @@
 
 from collections.abc import Callable
 from datetime import UTC, datetime
+from typing import Any
 
 from beeai_framework.agents.base import BaseAgent
 from beeai_framework.agents.react.runners.base import (
@@ -37,7 +38,6 @@ from beeai_framework.agents.types import (
     AgentExecutionConfig,
     AgentMeta,
 )
-from beeai_framework.backend import Message
 from beeai_framework.backend.chat import ChatModel
 from beeai_framework.backend.message import AssistantMessage, MessageMeta, UserMessage
 from beeai_framework.context import RunContext
@@ -54,10 +54,10 @@ class ReActAgent(BaseAgent[ReActAgentRunInput, ReActAgentRunOptions, ReActAgentR
     def __init__(
         self,
         llm: ChatModel,
-        tools: list[Tool],
+        tools: list[Tool[Any, Any, Any]],
         memory: BaseMemory,
         meta: AgentMeta | None = None,
-        templates: dict[ModelKeysType, PromptTemplate | ReActAgentTemplateFactory] | None = None,
+        templates: dict[ModelKeysType, PromptTemplate[Any] | ReActAgentTemplateFactory] | None = None,
         execution: AgentExecutionConfig | None = None,
         stream: bool | None = None,
     ) -> None:
@@ -134,7 +134,7 @@ class ReActAgent(BaseAgent[ReActAgentRunInput, ReActAgentRunOptions, ReActAgentR
         )
         await runner.init(run_input)
 
-        final_message: Message | None = None
+        final_message: AssistantMessage | None = None
         while not final_message:
             iteration: ReActAgentRunnerIteration = await runner.create_iteration()
 
@@ -158,7 +158,7 @@ class ReActAgent(BaseAgent[ReActAgentRunInput, ReActAgentRunOptions, ReActAgentR
                     )
                 )
 
-                for key in ["partialUpdate", "update"]:
+                for key in ["partial_update", "update"]:
                     await iteration.emitter.emit(
                         key,
                         {

--- a/python/beeai_framework/agents/react/agent.py
+++ b/python/beeai_framework/agents/react/agent.py
@@ -44,7 +44,7 @@ from beeai_framework.context import RunContext
 from beeai_framework.emitter import Emitter
 from beeai_framework.memory import BaseMemory
 from beeai_framework.template import PromptTemplate
-from beeai_framework.tools.tool import Tool
+from beeai_framework.tools.tool import AnyTool
 from beeai_framework.utils.models import ModelLike, to_model, to_model_optional
 
 
@@ -54,7 +54,7 @@ class ReActAgent(BaseAgent[ReActAgentRunInput, ReActAgentRunOptions, ReActAgentR
     def __init__(
         self,
         llm: ChatModel,
-        tools: list[Tool[Any, Any, Any]],
+        tools: list[AnyTool],
         memory: BaseMemory,
         meta: AgentMeta | None = None,
         templates: dict[ModelKeysType, PromptTemplate[Any] | ReActAgentTemplateFactory] | None = None,

--- a/python/beeai_framework/agents/react/events.py
+++ b/python/beeai_framework/agents/react/events.py
@@ -25,7 +25,8 @@ from beeai_framework.agents.react.types import (
 from beeai_framework.backend.message import AnyMessage
 from beeai_framework.errors import FrameworkError
 from beeai_framework.memory.base_memory import BaseMemory
-from beeai_framework.tools.tool import AnyTool, ToolOutput
+from beeai_framework.tools import ToolOutput
+from beeai_framework.tools.tool import AnyTool
 
 
 class ReActAgentStartEvent(BaseModel):

--- a/python/beeai_framework/agents/react/events.py
+++ b/python/beeai_framework/agents/react/events.py
@@ -69,7 +69,7 @@ class ReActAgentUpdateEvent(BaseModel):
     memory: InstanceOf[BaseMemory] | None = None
 
 
-class ToolEventData(BaseModel):
+class ReActAgentToolEventData(BaseModel):
     tool: InstanceOf[AnyTool]
     input: Any
     options: ReActAgentRunOptions
@@ -79,7 +79,7 @@ class ToolEventData(BaseModel):
 
 
 class ReActAgentToolEvent(BaseModel):
-    data: ToolEventData
+    data: ReActAgentToolEventData
     meta: ReActAgentIterationMeta
 
 

--- a/python/beeai_framework/agents/react/events.py
+++ b/python/beeai_framework/agents/react/events.py
@@ -1,0 +1,95 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+
+from pydantic import BaseModel, InstanceOf
+
+from beeai_framework.agents.react.types import (
+    ReActAgentIterationMeta,
+    ReActAgentIterationResult,
+    ReActAgentRunIteration,
+    ReActAgentRunOptions,
+)
+from beeai_framework.backend.message import AnyMessage
+from beeai_framework.errors import FrameworkError
+from beeai_framework.memory.base_memory import BaseMemory
+from beeai_framework.tools.tool import AnyTool, ToolOutput
+
+
+class ReActAgentStartEvent(BaseModel):
+    meta: ReActAgentIterationMeta
+    tools: list[InstanceOf[AnyTool]]
+    memory: InstanceOf[BaseMemory]
+
+
+class ReActAgentErrorEvent(BaseModel):
+    error: InstanceOf[FrameworkError]
+    meta: ReActAgentIterationMeta
+
+
+class ReActAgentRetryEvent(BaseModel):
+    meta: ReActAgentIterationMeta
+
+
+class ReActAgentSuccessEvent(BaseModel):
+    data: InstanceOf[AnyMessage]
+    iterations: list[ReActAgentRunIteration]
+    memory: InstanceOf[BaseMemory]
+    meta: ReActAgentIterationMeta
+
+
+class ReActAgentUpdate(BaseModel):
+    key: str
+    value: Any
+    parsed_value: Any
+
+
+class ReActAgentUpdateMeta(ReActAgentIterationMeta):
+    success: bool
+
+
+class ReActAgentUpdateEvent(BaseModel):
+    data: ReActAgentIterationResult | dict[str, Any]
+    update: ReActAgentUpdate
+    meta: ReActAgentUpdateMeta
+    tools: list[InstanceOf[AnyTool]] | None = None
+    memory: InstanceOf[BaseMemory] | None = None
+
+
+class ToolEventData(BaseModel):
+    tool: InstanceOf[AnyTool]
+    input: Any
+    options: ReActAgentRunOptions
+    iteration: ReActAgentIterationResult
+    result: InstanceOf[ToolOutput] | None = None
+    error: InstanceOf[FrameworkError] | None = None
+
+
+class ReActAgentToolEvent(BaseModel):
+    data: ToolEventData
+    meta: ReActAgentIterationMeta
+
+
+react_agent_event_types: dict[str, Any] = {
+    "start": ReActAgentStartEvent,
+    "error": ReActAgentErrorEvent,
+    "retry": ReActAgentRetryEvent,
+    "success": ReActAgentSuccessEvent,
+    "update": ReActAgentUpdateEvent,
+    "partial_update": ReActAgentUpdateEvent,
+    "tool_start": ReActAgentToolEvent,
+    "tool_success": ReActAgentToolEvent,
+    "tool_error": ReActAgentToolEvent,
+}

--- a/python/beeai_framework/agents/react/runners/base.py
+++ b/python/beeai_framework/agents/react/runners/base.py
@@ -19,6 +19,7 @@ from typing import Any
 from pydantic import BaseModel, InstanceOf
 
 from beeai_framework.agents import AgentError
+from beeai_framework.agents.react.events import react_agent_event_types
 from beeai_framework.agents.react.types import (
     ReActAgentInput,
     ReActAgentIterationMeta,
@@ -28,7 +29,6 @@ from beeai_framework.agents.react.types import (
     ReActAgentRunOptions,
     ReActAgentTemplateFactory,
     ReActAgentTemplates,
-    react_agent_event_types,
 )
 from beeai_framework.cancellation import AbortSignal
 from beeai_framework.context import RunContext

--- a/python/beeai_framework/agents/react/runners/base.py
+++ b/python/beeai_framework/agents/react/runners/base.py
@@ -14,6 +14,7 @@
 
 import math
 from abc import ABC, abstractmethod
+from typing import Any
 
 from pydantic import BaseModel, InstanceOf
 
@@ -27,6 +28,7 @@ from beeai_framework.agents.react.types import (
     ReActAgentRunOptions,
     ReActAgentTemplateFactory,
     ReActAgentTemplates,
+    react_agent_event_types,
 )
 from beeai_framework.cancellation import AbortSignal
 from beeai_framework.context import RunContext
@@ -102,7 +104,10 @@ class BaseRunner(ABC):
         if meta.iteration > max_iterations:
             raise AgentError(f"Agent was not able to resolve the task in {max_iterations} iterations.")
 
-        emitter = self._run.emitter.child(group_id=f"`iteration-{meta.iteration}")
+        emitter = self._run.emitter.child(
+            group_id=f"`iteration-{meta.iteration}",
+            events=react_agent_event_types,
+        )
         iteration = await self.llm(ReActAgentRunnerLLMInput(emitter=emitter, signal=self._run.signal, meta=meta))
         self._iterations.append(iteration)
         return ReActAgentRunnerIteration(emitter=emitter, state=iteration.state, meta=meta, signal=self._run.signal)
@@ -132,7 +137,7 @@ class BaseRunner(ABC):
         templates = {}
 
         for key, default_template in self.default_templates().model_dump().items():
-            override: PromptTemplate | ReActAgentTemplateFactory = overrides.get(key) or default_template
+            override: PromptTemplate[Any] | ReActAgentTemplateFactory = overrides.get(key) or default_template
             if isinstance(override, PromptTemplate):
                 templates[key] = override
                 continue

--- a/python/beeai_framework/agents/react/runners/default/runner.py
+++ b/python/beeai_framework/agents/react/runners/default/runner.py
@@ -61,7 +61,7 @@ from beeai_framework.parsers.line_prefix import (
 )
 from beeai_framework.retryable import Retryable, RetryableConfig, RetryableContext, RetryableInput
 from beeai_framework.tools import ToolError, ToolInputValidationError
-from beeai_framework.tools.tool import StringToolOutput, Tool, ToolOutput, ToolRunOptions
+from beeai_framework.tools.tool import AnyTool, StringToolOutput, ToolOutput, ToolRunOptions
 from beeai_framework.utils.strings import create_strenum, to_json
 
 
@@ -224,7 +224,7 @@ class DefaultRunner(BaseRunner):
         ).get()
 
     async def tool(self, input: ReActAgentRunnerToolInput) -> ReActAgentRunnerToolResult:
-        tool: Tool[Any, Any, Any] | None = next(
+        tool: AnyTool | None = next(
             (
                 tool
                 for tool in self._input.tools

--- a/python/beeai_framework/agents/react/runners/default/runner.py
+++ b/python/beeai_framework/agents/react/runners/default/runner.py
@@ -45,8 +45,8 @@ from beeai_framework.agents.react.types import (
     ReActAgentRunIteration,
     ReActAgentTemplates,
 )
-from beeai_framework.backend.chat import ChatModelOutput
 from beeai_framework.backend.message import AssistantMessage, SystemMessage, UserMessage
+from beeai_framework.backend.types import ChatModelOutput
 from beeai_framework.emitter.emitter import EventMeta
 from beeai_framework.errors import FrameworkError
 from beeai_framework.memory.base_memory import BaseMemory
@@ -60,8 +60,9 @@ from beeai_framework.parsers.line_prefix import (
     LinePrefixParserUpdate,
 )
 from beeai_framework.retryable import Retryable, RetryableConfig, RetryableContext, RetryableInput
-from beeai_framework.tools import ToolError, ToolInputValidationError
-from beeai_framework.tools.tool import AnyTool, StringToolOutput, ToolOutput, ToolRunOptions
+from beeai_framework.tools import StringToolOutput, ToolError, ToolInputValidationError, ToolOutput
+from beeai_framework.tools.tool import AnyTool
+from beeai_framework.tools.types import ToolRunOptions
 from beeai_framework.utils.strings import create_strenum, to_json
 
 

--- a/python/beeai_framework/agents/react/runners/default/runner.py
+++ b/python/beeai_framework/agents/react/runners/default/runner.py
@@ -157,7 +157,7 @@ class DefaultRunner(BaseRunner):
 
             async def on_partial_update(data: LinePrefixParserUpdate, event: EventMeta) -> None:
                 await input.emitter.emit(
-                    "partialUpdate",
+                    "partial_update",
                     {
                         "data": parser.final_state,
                         "update": {
@@ -192,7 +192,7 @@ class DefaultRunner(BaseRunner):
                 messages=self.memory.messages[:],
                 stream=True,
                 tools=self._input.tools if self.use_native_tool_calling else None,
-            ).observe(lambda llm_emitter: llm_emitter.on("newToken", on_new_token))
+            ).observe(lambda llm_emitter: llm_emitter.on("new_token", on_new_token))
 
             await parser.end()
 
@@ -224,7 +224,7 @@ class DefaultRunner(BaseRunner):
         ).get()
 
     async def tool(self, input: ReActAgentRunnerToolInput) -> ReActAgentRunnerToolResult:
-        tool: Tool | None = next(
+        tool: Tool[Any, Any, Any] | None = next(
             (
                 tool
                 for tool in self._input.tools

--- a/python/beeai_framework/agents/react/runners/granite/runner.py
+++ b/python/beeai_framework/agents/react/runners/granite/runner.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any
+
 from beeai_framework.agents.react.runners.default.prompts import ToolNoResultsTemplate, UserEmptyPromptTemplate
 from beeai_framework.agents.react.runners.default.runner import DefaultRunner
 from beeai_framework.agents.react.runners.granite.prompts import (
@@ -40,7 +42,7 @@ class GraniteRunner(DefaultRunner):
     def __init__(self, input: ReActAgentInput, options: ReActAgentRunOptions, run: RunContext) -> None:
         super().__init__(input, options, run)
 
-        async def on_update(data: dict, event: EventMeta) -> None:
+        async def on_update(data: dict[str, Any], event: EventMeta) -> None:
             update = data.get("update")
             assert update is not None
             if update.get("key") == "tool_output":

--- a/python/beeai_framework/agents/react/types.py
+++ b/python/beeai_framework/agents/react/types.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from collections.abc import Callable
-from typing import Annotated
+from typing import Annotated, Any
 
 from pydantic import BaseModel, InstanceOf
 
@@ -21,9 +21,10 @@ from beeai_framework.agents.types import AgentExecutionConfig, AgentMeta
 from beeai_framework.backend.chat import ChatModel, ChatModelOutput
 from beeai_framework.backend.message import Message
 from beeai_framework.cancellation import AbortSignal
+from beeai_framework.errors import FrameworkError
 from beeai_framework.memory.base_memory import BaseMemory
 from beeai_framework.template import PromptTemplate
-from beeai_framework.tools.tool import AnyTool
+from beeai_framework.tools.tool import AnyTool, Tool, ToolOutput
 from beeai_framework.utils.strings import to_json
 
 
@@ -43,11 +44,11 @@ class ReActAgentRunOptions(BaseModel):
 class ReActAgentIterationResult(BaseModel):
     thought: str | None = None
     tool_name: str | None = None
-    tool_input: dict | None = None
+    tool_input: dict[str, Any] | None = None
     tool_output: str | None = None
     final_answer: str | None = None
 
-    def to_template(self) -> dict:
+    def to_template(self) -> dict[str, str]:
         return {
             "thought": self.thought or "",
             "tool_name": self.tool_name or "",
@@ -63,24 +64,24 @@ class ReActAgentRunIteration(BaseModel):
 
 
 class ReActAgentRunOutput(BaseModel):
-    result: InstanceOf[Message]
+    result: InstanceOf[Message[Any]]
     iterations: list[ReActAgentRunIteration]
     memory: InstanceOf[BaseMemory]
 
 
 class ReActAgentTemplates(BaseModel):
-    system: InstanceOf[PromptTemplate]  # TODO proper template subtypes
-    assistant: InstanceOf[PromptTemplate]
-    user: InstanceOf[PromptTemplate]
-    user_empty: InstanceOf[PromptTemplate]
-    tool_error: InstanceOf[PromptTemplate]
-    tool_input_error: InstanceOf[PromptTemplate]
-    tool_no_result_error: InstanceOf[PromptTemplate]
-    tool_not_found_error: InstanceOf[PromptTemplate]
-    schema_error: InstanceOf[PromptTemplate]
+    system: InstanceOf[PromptTemplate[Any]]  # TODO proper template subtypes
+    assistant: InstanceOf[PromptTemplate[Any]]
+    user: InstanceOf[PromptTemplate[Any]]
+    user_empty: InstanceOf[PromptTemplate[Any]]
+    tool_error: InstanceOf[PromptTemplate[Any]]
+    tool_input_error: InstanceOf[PromptTemplate[Any]]
+    tool_no_result_error: InstanceOf[PromptTemplate[Any]]
+    tool_not_found_error: InstanceOf[PromptTemplate[Any]]
+    schema_error: InstanceOf[PromptTemplate[Any]]
 
 
-ReActAgentTemplateFactory = Callable[[InstanceOf[PromptTemplate]], InstanceOf[PromptTemplate]]
+ReActAgentTemplateFactory = Callable[[InstanceOf[PromptTemplate[Any]]], InstanceOf[PromptTemplate[Any]]]
 ModelKeysType = Annotated[str, lambda v: v in ReActAgentTemplates.model_fields]
 
 
@@ -89,6 +90,73 @@ class ReActAgentInput(BaseModel):
     tools: list[InstanceOf[AnyTool]]
     memory: InstanceOf[BaseMemory]
     meta: InstanceOf[AgentMeta] | None = None
-    templates: dict[ModelKeysType, InstanceOf[PromptTemplate] | ReActAgentTemplateFactory] | None = None
+    templates: dict[ModelKeysType, InstanceOf[PromptTemplate[Any]] | ReActAgentTemplateFactory] | None = None
     execution: AgentExecutionConfig | None = None
     stream: bool | None = None
+
+
+class ReActAgentStartEvent(BaseModel):
+    meta: ReActAgentIterationMeta
+    tools: list[InstanceOf[Tool[Any, Any, Any]]]
+    memory: InstanceOf[BaseMemory]
+
+
+class ReActAgentErrorEvent(BaseModel):
+    error: InstanceOf[FrameworkError]
+    meta: ReActAgentIterationMeta
+
+
+class ReActAgentRetryEvent(BaseModel):
+    meta: ReActAgentIterationMeta
+
+
+class ReActAgentSuccessEvent(BaseModel):
+    data: InstanceOf[Message[Any]]
+    iterations: list[ReActAgentRunIteration]
+    memory: InstanceOf[BaseMemory]
+    meta: ReActAgentIterationMeta
+
+
+class ReActAgentUpdate(BaseModel):
+    key: str
+    value: Any
+    parsed_value: Any
+
+
+class ReActAgentUpdateMeta(ReActAgentIterationMeta):
+    success: bool
+
+
+class ReActAgentUpdateEvent(BaseModel):
+    data: ReActAgentIterationResult | dict[str, Any]
+    update: ReActAgentUpdate
+    meta: ReActAgentUpdateMeta
+    tools: list[InstanceOf[Tool[Any, Any, Any]]] | None = None
+    memory: InstanceOf[BaseMemory] | None = None
+
+
+class ToolEventData(BaseModel):
+    tool: InstanceOf[Tool[Any, Any, Any]]
+    input: Any
+    options: ReActAgentRunOptions
+    iteration: ReActAgentIterationResult
+    result: InstanceOf[ToolOutput] | None = None
+    error: InstanceOf[FrameworkError] | None = None
+
+
+class ReActAgentToolEvent(BaseModel):
+    data: ToolEventData
+    meta: ReActAgentIterationMeta
+
+
+react_agent_event_types: dict[str, Any] = {
+    "start": ReActAgentStartEvent,
+    "error": ReActAgentErrorEvent,
+    "retry": ReActAgentRetryEvent,
+    "success": ReActAgentSuccessEvent,
+    "update": ReActAgentUpdateEvent,
+    "partial_update": ReActAgentUpdateEvent,
+    "tool_start": ReActAgentToolEvent,
+    "tool_success": ReActAgentToolEvent,
+    "tool_error": ReActAgentToolEvent,
+}

--- a/python/beeai_framework/agents/react/types.py
+++ b/python/beeai_framework/agents/react/types.py
@@ -19,7 +19,7 @@ from pydantic import BaseModel, InstanceOf
 
 from beeai_framework.agents.types import AgentExecutionConfig, AgentMeta
 from beeai_framework.backend.chat import ChatModel, ChatModelOutput
-from beeai_framework.backend.message import Message
+from beeai_framework.backend.message import AnyMessage
 from beeai_framework.cancellation import AbortSignal
 from beeai_framework.errors import FrameworkError
 from beeai_framework.memory.base_memory import BaseMemory
@@ -64,7 +64,7 @@ class ReActAgentRunIteration(BaseModel):
 
 
 class ReActAgentRunOutput(BaseModel):
-    result: InstanceOf[Message[Any]]
+    result: InstanceOf[AnyMessage]
     iterations: list[ReActAgentRunIteration]
     memory: InstanceOf[BaseMemory]
 
@@ -111,7 +111,7 @@ class ReActAgentRetryEvent(BaseModel):
 
 
 class ReActAgentSuccessEvent(BaseModel):
-    data: InstanceOf[Message[Any]]
+    data: InstanceOf[AnyMessage]
     iterations: list[ReActAgentRunIteration]
     memory: InstanceOf[BaseMemory]
     meta: ReActAgentIterationMeta

--- a/python/beeai_framework/agents/react/types.py
+++ b/python/beeai_framework/agents/react/types.py
@@ -21,10 +21,9 @@ from beeai_framework.agents.types import AgentExecutionConfig, AgentMeta
 from beeai_framework.backend.chat import ChatModel, ChatModelOutput
 from beeai_framework.backend.message import AnyMessage
 from beeai_framework.cancellation import AbortSignal
-from beeai_framework.errors import FrameworkError
 from beeai_framework.memory.base_memory import BaseMemory
 from beeai_framework.template import PromptTemplate
-from beeai_framework.tools.tool import AnyTool, ToolOutput
+from beeai_framework.tools.tool import AnyTool
 from beeai_framework.utils.strings import to_json
 
 
@@ -93,70 +92,3 @@ class ReActAgentInput(BaseModel):
     templates: dict[ModelKeysType, InstanceOf[PromptTemplate[Any]] | ReActAgentTemplateFactory] | None = None
     execution: AgentExecutionConfig | None = None
     stream: bool | None = None
-
-
-class ReActAgentStartEvent(BaseModel):
-    meta: ReActAgentIterationMeta
-    tools: list[InstanceOf[AnyTool]]
-    memory: InstanceOf[BaseMemory]
-
-
-class ReActAgentErrorEvent(BaseModel):
-    error: InstanceOf[FrameworkError]
-    meta: ReActAgentIterationMeta
-
-
-class ReActAgentRetryEvent(BaseModel):
-    meta: ReActAgentIterationMeta
-
-
-class ReActAgentSuccessEvent(BaseModel):
-    data: InstanceOf[AnyMessage]
-    iterations: list[ReActAgentRunIteration]
-    memory: InstanceOf[BaseMemory]
-    meta: ReActAgentIterationMeta
-
-
-class ReActAgentUpdate(BaseModel):
-    key: str
-    value: Any
-    parsed_value: Any
-
-
-class ReActAgentUpdateMeta(ReActAgentIterationMeta):
-    success: bool
-
-
-class ReActAgentUpdateEvent(BaseModel):
-    data: ReActAgentIterationResult | dict[str, Any]
-    update: ReActAgentUpdate
-    meta: ReActAgentUpdateMeta
-    tools: list[InstanceOf[AnyTool]] | None = None
-    memory: InstanceOf[BaseMemory] | None = None
-
-
-class ToolEventData(BaseModel):
-    tool: InstanceOf[AnyTool]
-    input: Any
-    options: ReActAgentRunOptions
-    iteration: ReActAgentIterationResult
-    result: InstanceOf[ToolOutput] | None = None
-    error: InstanceOf[FrameworkError] | None = None
-
-
-class ReActAgentToolEvent(BaseModel):
-    data: ToolEventData
-    meta: ReActAgentIterationMeta
-
-
-react_agent_event_types: dict[str, Any] = {
-    "start": ReActAgentStartEvent,
-    "error": ReActAgentErrorEvent,
-    "retry": ReActAgentRetryEvent,
-    "success": ReActAgentSuccessEvent,
-    "update": ReActAgentUpdateEvent,
-    "partial_update": ReActAgentUpdateEvent,
-    "tool_start": ReActAgentToolEvent,
-    "tool_success": ReActAgentToolEvent,
-    "tool_error": ReActAgentToolEvent,
-}

--- a/python/beeai_framework/agents/react/types.py
+++ b/python/beeai_framework/agents/react/types.py
@@ -18,8 +18,9 @@ from typing import Annotated, Any
 from pydantic import BaseModel, InstanceOf
 
 from beeai_framework.agents.types import AgentExecutionConfig, AgentMeta
-from beeai_framework.backend.chat import ChatModel, ChatModelOutput
+from beeai_framework.backend.chat import ChatModel
 from beeai_framework.backend.message import AnyMessage
+from beeai_framework.backend.types import ChatModelOutput
 from beeai_framework.cancellation import AbortSignal
 from beeai_framework.memory.base_memory import BaseMemory
 from beeai_framework.template import PromptTemplate

--- a/python/beeai_framework/agents/react/types.py
+++ b/python/beeai_framework/agents/react/types.py
@@ -24,7 +24,7 @@ from beeai_framework.cancellation import AbortSignal
 from beeai_framework.errors import FrameworkError
 from beeai_framework.memory.base_memory import BaseMemory
 from beeai_framework.template import PromptTemplate
-from beeai_framework.tools.tool import AnyTool, Tool, ToolOutput
+from beeai_framework.tools.tool import AnyTool, ToolOutput
 from beeai_framework.utils.strings import to_json
 
 
@@ -97,7 +97,7 @@ class ReActAgentInput(BaseModel):
 
 class ReActAgentStartEvent(BaseModel):
     meta: ReActAgentIterationMeta
-    tools: list[InstanceOf[Tool[Any, Any, Any]]]
+    tools: list[InstanceOf[AnyTool]]
     memory: InstanceOf[BaseMemory]
 
 
@@ -131,12 +131,12 @@ class ReActAgentUpdateEvent(BaseModel):
     data: ReActAgentIterationResult | dict[str, Any]
     update: ReActAgentUpdate
     meta: ReActAgentUpdateMeta
-    tools: list[InstanceOf[Tool[Any, Any, Any]]] | None = None
+    tools: list[InstanceOf[AnyTool]] | None = None
     memory: InstanceOf[BaseMemory] | None = None
 
 
 class ToolEventData(BaseModel):
-    tool: InstanceOf[Tool[Any, Any, Any]]
+    tool: InstanceOf[AnyTool]
     input: Any
     options: ReActAgentRunOptions
     iteration: ReActAgentIterationResult

--- a/python/beeai_framework/agents/types.py
+++ b/python/beeai_framework/agents/types.py
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any
-
 from pydantic import BaseModel, InstanceOf
 
-from beeai_framework.tools.tool import Tool
+from beeai_framework.tools.tool import AnyTool
 
 
 class AgentExecutionConfig(BaseModel):
@@ -28,5 +26,5 @@ class AgentExecutionConfig(BaseModel):
 class AgentMeta(BaseModel):
     name: str
     description: str
-    tools: list[InstanceOf[Tool[Any, Any, Any]]]
+    tools: list[InstanceOf[AnyTool]]
     extra_description: str | None = None

--- a/python/beeai_framework/agents/types.py
+++ b/python/beeai_framework/agents/types.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any
 
 from pydantic import BaseModel, InstanceOf
 
@@ -27,5 +28,5 @@ class AgentExecutionConfig(BaseModel):
 class AgentMeta(BaseModel):
     name: str
     description: str
-    tools: list[InstanceOf[Tool]]
+    tools: list[InstanceOf[Tool[Any, Any, Any]]]
     extra_description: str | None = None

--- a/python/beeai_framework/backend/chat.py
+++ b/python/beeai_framework/backend/chat.py
@@ -16,7 +16,7 @@
 from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator, Callable
 from types import NoneType
-from typing import Any, Literal, Self, TypeVar
+from typing import Any, Generic, Literal, Self, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field, InstanceOf
 
@@ -58,7 +58,7 @@ class ChatConfig(BaseModel):
     parameters: ChatModelParameters | Callable[[ChatModelParameters], ChatModelParameters] | None = None
 
 
-class ChatModelStructureInput[T](ChatModelParameters):
+class ChatModelStructureInput(ChatModelParameters, Generic[T]):
     input_schema: type[T] = Field(..., alias="schema")
     messages: list[InstanceOf[Message[Any]]] = Field(..., min_length=1)
     abort_signal: AbortSignal | None = None

--- a/python/beeai_framework/backend/chat.py
+++ b/python/beeai_framework/backend/chat.py
@@ -30,7 +30,7 @@ from beeai_framework.emitter import Emitter
 from beeai_framework.logger import Logger
 from beeai_framework.retryable import Retryable, RetryableConfig, RetryableContext, RetryableInput
 from beeai_framework.template import PromptTemplate, PromptTemplateInput
-from beeai_framework.tools.tool import Tool
+from beeai_framework.tools.tool import AnyTool
 from beeai_framework.utils.lists import flatten
 from beeai_framework.utils.models import ModelLike
 from beeai_framework.utils.strings import to_json
@@ -70,7 +70,7 @@ class ChatModelStructureOutput(BaseModel):
 
 
 class ChatModelInput(ChatModelParameters):
-    tools: list[InstanceOf[Tool[Any, Any, Any]]] | None = None
+    tools: list[InstanceOf[AnyTool]] | None = None
     abort_signal: AbortSignal | None = None
     stop_sequences: list[str] | None = None
     response_format: dict[str, Any] | type[BaseModel] | None = None
@@ -252,7 +252,7 @@ IMPORTANT: You MUST answer with a JSON object that matches the JSON schema above
         self,
         *,
         messages: list[Message[Any]],
-        tools: list[Tool[Any, Any, Any]] | None = None,
+        tools: list[AnyTool] | None = None,
         abort_signal: AbortSignal | None = None,
         stop_sequences: list[str] | None = None,
         response_format: dict[str, Any] | type[BaseModel] | None = None,

--- a/python/beeai_framework/backend/events.py
+++ b/python/beeai_framework/backend/events.py
@@ -1,0 +1,49 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Callable
+from types import NoneType
+from typing import Any
+
+from pydantic import BaseModel, InstanceOf
+
+from beeai_framework.backend import ChatModelError
+from beeai_framework.backend.types import ChatModelInput, ChatModelOutput
+
+
+class ChatModelNewTokenEvent(BaseModel):
+    value: InstanceOf[ChatModelOutput]
+    abort: Callable[[], None]
+
+
+class ChatModelSuccessEvent(BaseModel):
+    value: InstanceOf[ChatModelOutput]
+
+
+class ChatModelStartEvent(BaseModel):
+    input: InstanceOf[ChatModelInput]
+
+
+class ChatModelErrorEvent(BaseModel):
+    input: InstanceOf[ChatModelInput]
+    error: InstanceOf[ChatModelError]
+
+
+chat_model_event_types: dict[str, Any] = {
+    "new_token": ChatModelNewTokenEvent,
+    "success": ChatModelSuccessEvent,
+    "start": ChatModelStartEvent,
+    "error": ChatModelErrorEvent,
+    "finish": NoneType,
+}

--- a/python/beeai_framework/backend/message.py
+++ b/python/beeai_framework/backend/message.py
@@ -18,7 +18,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from datetime import UTC, datetime
 from enum import Enum
-from typing import Any, Generic, Literal, TypeVar
+from typing import Any, Generic, Literal, TypeAlias, TypeVar
 
 from pydantic import BaseModel
 
@@ -173,3 +173,6 @@ class CustomMessage(Message[MessageTextContent]):
 
     def _models(self) -> Sequence[type[MessageTextContent]]:
         return [MessageTextContent]
+
+
+AnyMessage: TypeAlias = Message[Any]

--- a/python/beeai_framework/backend/types.py
+++ b/python/beeai_framework/backend/types.py
@@ -1,0 +1,108 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Callable
+from typing import Any, Generic, Self, TypeVar
+
+from pydantic import BaseModel, ConfigDict, Field, InstanceOf
+
+from beeai_framework.backend.message import AnyMessage, AssistantMessage, MessageToolCallContent
+from beeai_framework.cancellation import AbortSignal
+from beeai_framework.tools.tool import AnyTool
+from beeai_framework.utils.lists import flatten
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class ChatModelParameters(BaseModel):
+    max_tokens: int | None = None
+    top_p: int | None = None
+    frequency_penalty: int | None = None
+    temperature: int = 0
+    top_k: int | None = None
+    n: int | None = None
+    presence_penalty: int | None = None
+    seed: int | None = None
+    stop_sequences: list[str] | None = None
+    stream: bool | None = None
+
+
+class ChatConfig(BaseModel):
+    # TODO: cache: ChatModelCache | Callable[[ChatModelCache], ChatModelCache] | None = None
+    parameters: ChatModelParameters | Callable[[ChatModelParameters], ChatModelParameters] | None = None
+
+
+class ChatModelStructureInput(ChatModelParameters, Generic[T]):
+    input_schema: type[T] = Field(..., alias="schema")
+    messages: list[InstanceOf[AnyMessage]] = Field(..., min_length=1)
+    abort_signal: AbortSignal | None = None
+    max_retries: int | None = None
+
+
+class ChatModelStructureOutput(BaseModel):
+    object: type[BaseModel] | dict[str, Any]
+
+
+class ChatModelInput(ChatModelParameters):
+    tools: list[InstanceOf[AnyTool]] | None = None
+    abort_signal: AbortSignal | None = None
+    stop_sequences: list[str] | None = None
+    response_format: dict[str, Any] | type[BaseModel] | None = None
+    # tool_choice: NoneType # TODO
+    messages: list[InstanceOf[AnyMessage]] = Field(
+        ...,
+        min_length=1,
+        frozen=True,
+    )
+
+    model_config = ConfigDict(frozen=True)
+
+
+class ChatModelUsage(BaseModel):
+    prompt_tokens: int
+    completion_tokens: int
+    total_tokens: int
+
+
+class ChatModelOutput(BaseModel):
+    messages: list[InstanceOf[AnyMessage]]
+    usage: InstanceOf[ChatModelUsage] | None = None
+    finish_reason: str | None = None
+
+    @classmethod
+    def from_chunks(cls, chunks: list[Self]) -> Self:
+        final = cls(messages=[])
+        for cur in chunks:
+            final.merge(cur)
+        return final
+
+    def merge(self, other: Self) -> None:
+        self.messages.extend(other.messages)
+        self.finish_reason = other.finish_reason
+        if self.usage and other.usage:
+            merged_usage = self.usage.model_copy()
+            if other.usage.total_tokens:
+                merged_usage.total_tokens = max(self.usage.total_tokens, other.usage.total_tokens)
+                merged_usage.prompt_tokens = max(self.usage.prompt_tokens, other.usage.prompt_tokens)
+                merged_usage.completion_tokens = max(self.usage.completion_tokens, other.usage.completion_tokens)
+            self.usage = merged_usage
+        elif other.usage:
+            self.usage = other.usage.model_copy()
+
+    def get_tool_calls(self) -> list[MessageToolCallContent]:
+        assistant_message = [msg for msg in self.messages if isinstance(msg, AssistantMessage)]
+        return flatten([x.get_tool_calls() for x in assistant_message])
+
+    def get_text_content(self) -> str:
+        return "".join([x.text for x in list(filter(lambda x: isinstance(x, AssistantMessage), self.messages))])

--- a/python/beeai_framework/backend/utils.py
+++ b/python/beeai_framework/backend/utils.py
@@ -67,7 +67,7 @@ def load_model(name: ProviderName | str, model_type: Literal["embedding", "chat"
     module = import_module(module_path)
 
     class_name = f"{provider_def.name}{model_type.capitalize()}Model"
-    return getattr(module, class_name)
+    return getattr(module, class_name)  # type: ignore
 
 
 def parse_broken_json(input: str) -> Any:

--- a/python/beeai_framework/cancellation.py
+++ b/python/beeai_framework/cancellation.py
@@ -32,7 +32,7 @@ class AbortSignal(BaseModel):
         super().__init__()
         self._aborted = False
         self._reason: str | None = None
-        self._listeners: list[Callable] = []
+        self._listeners: list[Callable[[], None]] = []
 
     @property
     def aborted(self) -> bool:
@@ -66,7 +66,7 @@ class AbortSignal(BaseModel):
 
     def throw_if_aborted(self) -> None:
         if self._aborted:
-            raise AbortError(self._reason)
+            raise AbortError(self.reason)
 
 
 class AbortController:

--- a/python/beeai_framework/context.py
+++ b/python/beeai_framework/context.py
@@ -20,6 +20,7 @@ from collections.abc import Awaitable, Callable, Generator
 from contextvars import ContextVar
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from types import NoneType
 from typing import Any, Generic, Self, TypeVar
 
 from pydantic import BaseModel
@@ -51,13 +52,13 @@ class Run(Generic[R]):
     def __init__(self, handler: Callable[[], R | Awaitable[R]], context: "RunContext") -> None:
         super().__init__()
         self.handler = ensure_async(handler)
-        self.tasks: list[tuple[Callable, list]] = []
+        self.tasks: list[tuple[Callable[..., Any], list[Any]]] = []
         self.run_context = context
 
     def __await__(self) -> Generator[Any, None, R]:
         return self._run_tasks().__await__()
 
-    def observe(self, fn: Callable[[Emitter], None]) -> Self:
+    def observe(self, fn: Callable[[Emitter], Any]) -> Self:
         self.tasks.append((fn, [self.run_context.emitter]))
         return self
 
@@ -65,7 +66,7 @@ class Run(Generic[R]):
         self.tasks.append((self.run_context.emitter.match, [matcher, callback, options]))
         return self
 
-    def context(self, context: dict) -> Self:
+    def context(self, context: dict[str, Any]) -> Self:
         self.tasks.append((self._set_context, [context]))
         return self
 
@@ -82,7 +83,7 @@ class Run(Generic[R]):
 
         return await self.handler()
 
-    def _set_context(self, context: dict) -> None:
+    def _set_context(self, context: dict[str, Any]) -> None:
         self.run_context.context = context
         self.run_context.emitter.context = context
 
@@ -96,7 +97,9 @@ class RunContext(RunInstance):
         self.run_id = str(uuid.uuid4())
         self.parent_id = parent.run_id if parent else None
         self.group_id: str = parent.group_id if parent else str(uuid.uuid4())
-        self.context: dict = {k: v for k, v in parent.context.items() if k not in ["id", "parentId"]} if parent else {}
+        self.context: dict[str, Any] = (
+            {k: v for k, v in parent.context.items() if k not in ["id", "parentId"]} if parent else {}
+        )
 
         self.emitter = self.instance.emitter.child(
             context=self.context,
@@ -134,7 +137,17 @@ class RunContext(RunInstance):
         context = RunContext(instance=instance, context_input=context_input, parent=parent)
 
         async def handler() -> R:
-            emitter = context.emitter.child(namespace=["run"], creator=context, context={"internal": True})
+            emitter = context.emitter.child(
+                namespace=["run"],
+                creator=context,
+                context={"internal": True},
+                events={
+                    "start": NoneType,
+                    "success": type(any),
+                    "error": FrameworkError,
+                    "finish": NoneType,
+                },
+            )
 
             try:
                 await emitter.emit("start", None)

--- a/python/beeai_framework/emitter/emitter.py
+++ b/python/beeai_framework/emitter/emitter.py
@@ -12,15 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import asyncio
 import copy
 import functools
 import inspect
+import re
 import uuid
-from collections.abc import Callable
+from asyncio import Task
+from collections.abc import Callable, Coroutine
 from datetime import UTC, datetime
-from typing import Any, Generic, ParamSpec, TypeAlias, TypeVar
+from typing import Any, TypeAlias
 
 from pydantic import BaseModel, ConfigDict, InstanceOf
 
@@ -32,12 +33,9 @@ from beeai_framework.emitter.utils import (
 )
 from beeai_framework.utils.types import MaybeAsync
 
-T = TypeVar("T", bound=BaseModel)
-P = ParamSpec("P")
-
 MatcherFn: TypeAlias = Callable[["EventMeta"], bool]
-Matcher: TypeAlias = str | MatcherFn
-Callback: TypeAlias = MaybeAsync[[P, "EventMeta"], None]
+Matcher: TypeAlias = str | re.Pattern[str] | MatcherFn
+Callback: TypeAlias = MaybeAsync[[Any, "EventMeta"], None]
 CleanupFn: TypeAlias = Callable[[], None]
 
 
@@ -60,16 +58,18 @@ class EventMeta(BaseModel):
     context: object
     group_id: str | None = None
     trace: InstanceOf[EventTrace] | None = None
+    data_type: type
 
 
-class Emitter(Generic[T]):
+class Emitter:
     def __init__(
         self,
         group_id: str | None = None,
         namespace: list[str] | None = None,
         creator: object | None = None,
-        context: object | None = None,
+        context: dict[Any, Any] | None = None,
         trace: EventTrace | None = None,
+        events: dict[str, type] | None = None,
     ) -> None:
         super().__init__()
 
@@ -77,9 +77,10 @@ class Emitter(Generic[T]):
         self.group_id: str | None = group_id
         self.namespace: list[str] = namespace or []
         self.creator: object | None = creator
-        self.context: object = context or {}
+        self.context: dict[Any, Any] = context or {}
         self.trace: EventTrace | None = trace
         self.cleanups: list[CleanupFn] = []
+        self.events: dict[str, type] = events or {}
 
         assert_valid_namespace(self.namespace)
 
@@ -93,8 +94,9 @@ class Emitter(Generic[T]):
         group_id: str | None = None,
         namespace: list[str] | None = None,
         creator: object | None = None,
-        context: object | None = None,
+        context: dict[Any, Any] | None = None,
         trace: EventTrace | None = None,
+        events: dict[str, type] | None = None,
     ) -> "Emitter":
         child_emitter = Emitter(
             trace=trace or self.trace,
@@ -102,6 +104,7 @@ class Emitter(Generic[T]):
             context={**self.context, **(context or {})},
             creator=creator or self.creator,
             namespace=namespace + self.namespace if namespace else self.namespace[:],
+            events=events or self.events,
         )
 
         cleanup = child_emitter.pipe(self)
@@ -140,11 +143,10 @@ class Emitter(Generic[T]):
             elif matcher == "*.*":
                 match_nested = True if match_nested is None else match_nested
                 matchers.append(lambda _: True)
-            # TODO is_valid_regex matches on all strings, not just regex patterns
-            # elif is_valid_regex(matcher):
-            #     match_nested = True if match_nested is None else match_nested
-            #     matchers.append(lambda event: bool(re.search(matcher, event.path)))
-            elif isinstance(matcher, Callable):
+            elif isinstance(matcher, re.Pattern):
+                match_nested = True if match_nested is None else match_nested
+                matchers.append(lambda event: matcher.match(event.path) is not None)
+            elif callable(matcher):
                 match_nested = False if match_nested is None else match_nested
                 matchers.append(matcher)
             elif isinstance(matcher, str):
@@ -162,7 +164,7 @@ class Emitter(Generic[T]):
             if not match_nested:
 
                 def match_same_run(event: EventMeta) -> bool:
-                    return self.trace is None or self.trace.run_id == event.trace.run_id
+                    return self.trace is None or event.trace is None or self.trace.run_id == event.trace.run_id
 
                 matchers.insert(0, match_same_run)
 
@@ -180,7 +182,7 @@ class Emitter(Generic[T]):
         await self.invoke(value, event)
 
     async def invoke(self, data: Any, event: EventMeta) -> None:
-        executions = []
+        executions: list[Coroutine[Any, Any, Any] | Task[Any]] = []
         for listener in self.listeners:
             if not listener.match(event):
                 continue
@@ -212,4 +214,5 @@ class Emitter(Generic[T]):
             creator=self.creator,
             context={**self.context},
             trace=copy.copy(self.trace),
+            data_type=self.events.get(name) or type(Any),
         )

--- a/python/beeai_framework/emitter/emitter.py
+++ b/python/beeai_framework/emitter/emitter.py
@@ -80,9 +80,17 @@ class Emitter:
         self.context: dict[Any, Any] = context or {}
         self.trace: EventTrace | None = trace
         self.cleanups: list[CleanupFn] = []
-        self.events: dict[str, type] = events or {}
+        self._events: dict[str, type] = events or {}
 
         assert_valid_namespace(self.namespace)
+
+    @property
+    def events(self) -> dict[str, type]:
+        return self._events.copy()
+
+    @events.setter
+    def events(self, new_events: dict[str, type]) -> None:
+        self._events.update(new_events)
 
     @staticmethod
     @functools.cache

--- a/python/beeai_framework/emitter/emitter.py
+++ b/python/beeai_framework/emitter/emitter.py
@@ -164,7 +164,9 @@ class Emitter:
             if not match_nested:
 
                 def match_same_run(event: EventMeta) -> bool:
-                    return self.trace is None or event.trace is None or self.trace.run_id == event.trace.run_id
+                    return self.trace is None or (
+                        self.trace.run_id == event.trace.run_id if event.trace is not None else False
+                    )
 
                 matchers.insert(0, match_same_run)
 

--- a/python/beeai_framework/logger.py
+++ b/python/beeai_framework/logger.py
@@ -16,7 +16,7 @@
 import logging
 import sys
 from logging import Formatter
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from beeai_framework.errors import FrameworkError
 from beeai_framework.utils.config import CONFIG
@@ -102,11 +102,11 @@ class Logger(logging.Logger):
         # This method was inspired by the answers to Stack Overflow post
         # http://stackoverflow.com/q/2183233/2988730, especially
         # http://stackoverflow.com/a/13638084/2988730
-        def log_for_level(self: logging.Logger, message: str, *args: int, **kwargs: dict) -> None:  # pragma: no cover
+        def log_for_level(self: logging.Logger, message: str, *args: int, **kwargs: Any) -> None:  # pragma: no cover
             if self.isEnabledFor(level_num):
                 self._log(level_num, message, args, stacklevel=2, **kwargs)
 
-        def log_to_root(message: str, *args: int, **kwargs: dict) -> None:  # pragma: no cover
+        def log_to_root(message: str, *args: int, **kwargs: Any) -> None:  # pragma: no cover
             logging.log(level_num, message, *args, **kwargs)
 
         logging.addLevelName(level_num, level_name)

--- a/python/beeai_framework/retryable.py
+++ b/python/beeai_framework/retryable.py
@@ -59,10 +59,12 @@ class RetryableRunConfig:
 
 
 async def do_retry(fn: Callable[[int], Awaitable[T]], options: dict[str, Any] | None = None) -> T:
+    options = options or {}
+
     async def handler(attempt: int, remaining: int) -> T:
         logger.debug(f"Entering p_retry handler({attempt}, {remaining})")
         try:
-            factor = options["factor"] if options and options["factor"] is not None else 2
+            factor = options.get("factor", 2) or 2
 
             if attempt > 1:
                 await asyncio.sleep(factor ** (attempt - 1))

--- a/python/beeai_framework/retryable.py
+++ b/python/beeai_framework/retryable.py
@@ -25,7 +25,7 @@ from beeai_framework.errors import FrameworkError
 from beeai_framework.logger import Logger
 from beeai_framework.utils.models import ModelLike, to_model
 
-T = TypeVar("T", bound=BaseModel)
+T = TypeVar("T")
 logger = Logger(__name__)
 
 
@@ -62,7 +62,7 @@ async def do_retry(fn: Callable[[int], Awaitable[T]], options: dict[str, Any] | 
     async def handler(attempt: int, remaining: int) -> T:
         logger.debug(f"Entering p_retry handler({attempt}, {remaining})")
         try:
-            factor = options.get("factor", 2) if options else 2
+            factor = options["factor"] if options and options["factor"] is not None else 2
 
             if attempt > 1:
                 await asyncio.sleep(factor ** (attempt - 1))

--- a/python/beeai_framework/template.py
+++ b/python/beeai_framework/template.py
@@ -33,7 +33,7 @@ T = TypeVar("T", bound=BaseModel)
 class PromptTemplateInput(BaseModel, Generic[T]):
     input_schema: type[T] = Field(..., alias="schema")
     template: str
-    functions: dict[str, Callable[[dict], str]] | None = None
+    functions: dict[str, Callable[[dict[str, Any]], str]] | None = None
     defaults: dict[str, Any] = {}
 
 
@@ -59,7 +59,9 @@ class PromptTemplate(Generic[T]):
 
         return chevron.render(template=self._config.template, data=data)
 
-    def fork(self, customizer: Callable[[PromptTemplateInput], PromptTemplateInput] | None) -> "PromptTemplate":
+    def fork(
+        self, customizer: Callable[[PromptTemplateInput[Any]], PromptTemplateInput[Any]] | None
+    ) -> "PromptTemplate[Any]":
         new_config = customizer(self._config) if customizer else self._config
         if not isinstance(new_config, PromptTemplateInput):
             raise ValueError("Return type from customizer must be a PromptTemplateInput or nothing.")

--- a/python/beeai_framework/tools/__init__.py
+++ b/python/beeai_framework/tools/__init__.py
@@ -15,11 +15,10 @@
 
 from beeai_framework.tools.errors import ToolError, ToolInputValidationError
 from beeai_framework.tools.tool import (
-    StringToolOutput,
     Tool,
-    ToolOutput,
     tool,
 )
+from beeai_framework.tools.types import JSONToolOutput, StringToolOutput, ToolOutput
 
 __all__ = [
     "JSONToolOutput",

--- a/python/beeai_framework/tools/events.py
+++ b/python/beeai_framework/tools/events.py
@@ -1,0 +1,39 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Generic, TypeVar
+
+from pydantic import BaseModel, InstanceOf
+
+from beeai_framework.tools import ToolError
+from beeai_framework.tools.types import ToolOutput, ToolRunOptions
+
+TInput = TypeVar("TInput", bound=BaseModel)
+
+
+class ToolStartEvent(BaseModel, Generic[TInput]):
+    input: TInput
+    options: ToolRunOptions | None = None
+
+
+class ToolSuccessEvent(BaseModel, Generic[TInput]):
+    output: InstanceOf[ToolOutput]
+    input: TInput
+    options: ToolRunOptions | None = None
+
+
+class ToolErrorEvent(BaseModel, Generic[TInput]):
+    error: InstanceOf[ToolError]
+    input: TInput
+    options: ToolRunOptions | None = None

--- a/python/beeai_framework/tools/mcp_tools.py
+++ b/python/beeai_framework/tools/mcp_tools.py
@@ -23,8 +23,8 @@ from pydantic import BaseModel
 from beeai_framework.context import RunContext
 from beeai_framework.emitter import Emitter
 from beeai_framework.logger import Logger
-from beeai_framework.tools import Tool
-from beeai_framework.tools.tool import JSONToolOutput, ToolOutput, ToolRunOptions
+from beeai_framework.tools import Tool, ToolOutput
+from beeai_framework.tools.types import JSONToolOutput, ToolRunOptions
 from beeai_framework.utils.models import JSONSchemaModel
 from beeai_framework.utils.strings import to_safe_word
 

--- a/python/beeai_framework/tools/search/base.py
+++ b/python/beeai_framework/tools/search/base.py
@@ -15,7 +15,7 @@
 
 from pydantic import BaseModel
 
-from beeai_framework.tools.tool import ToolOutput
+from beeai_framework.tools import ToolOutput
 from beeai_framework.utils.strings import to_json
 
 

--- a/python/beeai_framework/tools/search/duckduckgo.py
+++ b/python/beeai_framework/tools/search/duckduckgo.py
@@ -21,7 +21,8 @@ from beeai_framework.emitter.emitter import Emitter
 from beeai_framework.logger import Logger
 from beeai_framework.tools import ToolError
 from beeai_framework.tools.search import SearchToolOutput, SearchToolResult
-from beeai_framework.tools.tool import Tool, ToolRunOptions
+from beeai_framework.tools.tool import Tool
+from beeai_framework.tools.types import ToolRunOptions
 
 logger = Logger(__name__)
 

--- a/python/beeai_framework/tools/search/wikipedia.py
+++ b/python/beeai_framework/tools/search/wikipedia.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-import wikipediaapi
+import wikipediaapi  # type: ignore
 from pydantic import BaseModel, Field
 
 from beeai_framework.context import RunContext

--- a/python/beeai_framework/tools/search/wikipedia.py
+++ b/python/beeai_framework/tools/search/wikipedia.py
@@ -19,7 +19,8 @@ from pydantic import BaseModel, Field
 from beeai_framework.context import RunContext
 from beeai_framework.emitter.emitter import Emitter
 from beeai_framework.tools.search import SearchToolOutput, SearchToolResult
-from beeai_framework.tools.tool import Tool, ToolRunOptions
+from beeai_framework.tools.tool import Tool
+from beeai_framework.tools.types import ToolRunOptions
 
 
 class WikipediaToolInput(BaseModel):

--- a/python/beeai_framework/tools/tool.py
+++ b/python/beeai_framework/tools/tool.py
@@ -90,18 +90,18 @@ class JSONToolOutput(ToolOutput):
         return not self.result
 
 
-class ToolStartEvent[TInput](BaseModel):
+class ToolStartEvent(BaseModel, Generic[TInput]):
     input: TInput
     options: ToolRunOptions | None = None
 
 
-class ToolSuccessEvent[TInput](BaseModel):
+class ToolSuccessEvent(BaseModel, Generic[TInput]):
     output: InstanceOf[ToolOutput]
     input: TInput
     options: ToolRunOptions | None = None
 
 
-class ToolErrorEvent[TInput](BaseModel):
+class ToolErrorEvent(BaseModel, Generic[TInput]):
     error: InstanceOf[ToolError]
     input: TInput
     options: ToolRunOptions | None = None

--- a/python/beeai_framework/tools/types.py
+++ b/python/beeai_framework/tools/types.py
@@ -1,0 +1,67 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from pydantic import BaseModel
+
+from beeai_framework.cancellation import AbortSignal
+from beeai_framework.utils.strings import to_json
+
+
+class RetryOptions(BaseModel):
+    max_retries: int | None = None
+    factor: int | None = None
+
+
+class ToolRunOptions(BaseModel):
+    retry_options: RetryOptions | None = None
+    signal: AbortSignal | None = None
+
+
+class ToolOutput(ABC):
+    @abstractmethod
+    def get_text_content(self) -> str:
+        pass
+
+    @abstractmethod
+    def is_empty(self) -> bool:
+        pass
+
+    def __str__(self) -> str:
+        return self.get_text_content()
+
+
+class StringToolOutput(ToolOutput):
+    def __init__(self, result: str = "") -> None:
+        super().__init__()
+        self.result = result
+
+    def is_empty(self) -> bool:
+        return len(self.result) == 0
+
+    def get_text_content(self) -> str:
+        return self.result
+
+
+class JSONToolOutput(ToolOutput):
+    def __init__(self, result: Any) -> None:
+        self.result = result
+
+    def get_text_content(self) -> str:
+        return to_json(self.result)
+
+    def is_empty(self) -> bool:
+        return not self.result

--- a/python/beeai_framework/tools/weather/openmeteo.py
+++ b/python/beeai_framework/tools/weather/openmeteo.py
@@ -26,8 +26,9 @@ from pydantic import BaseModel, Field
 from beeai_framework.context import RunContext
 from beeai_framework.emitter.emitter import Emitter
 from beeai_framework.logger import Logger
-from beeai_framework.tools import ToolError, ToolInputValidationError
-from beeai_framework.tools.tool import StringToolOutput, Tool, ToolRunOptions
+from beeai_framework.tools import StringToolOutput, ToolError, ToolInputValidationError
+from beeai_framework.tools.tool import Tool
+from beeai_framework.tools.types import ToolRunOptions
 
 logger = Logger(__name__)
 

--- a/python/beeai_framework/tools/weather/openmeteo.py
+++ b/python/beeai_framework/tools/weather/openmeteo.py
@@ -67,10 +67,10 @@ class OpenMeteoTool(Tool[OpenMeteoToolInput, ToolRunOptions, StringToolOutput]):
         if input.country:
             params["country"] = input.country
 
-        params = urlencode(params, doseq=True)
+        encoded_params = urlencode(params, doseq=True)
 
         response = requests.get(
-            f"https://geocoding-api.open-meteo.com/v1/search?{params}",
+            f"https://geocoding-api.open-meteo.com/v1/search?{encoded_params}",
             headers={"Content-Type": "application/json", "Accept": "application/json"},
         )
 
@@ -78,7 +78,8 @@ class OpenMeteoTool(Tool[OpenMeteoToolInput, ToolRunOptions, StringToolOutput]):
         results = response.json().get("results", [])
         if not results:
             raise ToolError(f"Location '{input.location_name}' was not found.")
-        return results[0]
+        geocode: dict[str, str] = results[0]
+        return geocode
 
     def get_params(self, input: OpenMeteoToolInput) -> dict[str, Any]:
         params = {

--- a/python/beeai_framework/utils/counter.py
+++ b/python/beeai_framework/utils/counter.py
@@ -37,7 +37,7 @@ class RetryCounter:
 
         # TODO: ifFatal, isRetryable etc
         if self.remaining < 0:
-            self._finalError = self._error_class(
+            self._finalError = self._error_class(  # type: ignore
                 f"Maximal amount of global retries ({self._max_retries}) has been reached.", cause=self._lastError
             )
             raise self._finalError

--- a/python/beeai_framework/utils/dicts.py
+++ b/python/beeai_framework/utils/dicts.py
@@ -12,15 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any
 
-def exclude_keys(input: dict, keys: set[str]) -> dict:
+
+def exclude_keys(input: dict[str, Any], keys: set[str]) -> dict[str, Any]:
     return {k: input[k] for k in input.keys() - keys}
 
 
-def include_keys(input: dict, keys: set[str]) -> dict:
+def include_keys(input: dict[str, Any], keys: set[str]) -> dict[str, Any]:
     valid_keys = [k for k in input if k in keys]
     return {k: input[k] for k in valid_keys}
 
 
-def exclude_none(input: dict) -> dict:
+def exclude_none(input: dict[str, Any]) -> dict[str, Any]:
     return {k: v for k, v in input.items() if v is not None}

--- a/python/beeai_framework/utils/models.py
+++ b/python/beeai_framework/utils/models.py
@@ -22,7 +22,7 @@ from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import CoreSchema, SchemaValidator
 
 T = TypeVar("T", bound=BaseModel)
-ModelLike = Union[T, dict]  # noqa: UP007
+ModelLike = Union[T, dict[str, Any]]  # noqa: UP007
 
 
 def to_model(cls: type[T], obj: ModelLike[T]) -> T:
@@ -68,7 +68,7 @@ class JSONSchemaModel(ABC, BaseModel):
         return cls._custom_json_schema.copy()
 
     @classmethod
-    def create(cls, schema_name: str, schema: dict) -> type["JSONSchemaModel"]:
+    def create(cls, schema_name: str, schema: dict[str, Any]) -> type["JSONSchemaModel"]:
         type_mapping = {
             "string": str,
             "integer": int,
@@ -87,7 +87,7 @@ class JSONSchemaModel(ABC, BaseModel):
             target_type = type_mapping.get(param.get("type"))
             is_optional = param_name not in required
             if is_optional:
-                target_type = target_type | type(None)
+                target_type = target_type or type(None)
 
             if not target_type:
                 raise ValueError(f"Unsupported type '{param.get('type')}' found in the schema.")
@@ -100,7 +100,7 @@ class JSONSchemaModel(ABC, BaseModel):
                 Field(description=param.get("description"), default=None if is_optional else ...),
             )
 
-        model: type[JSONSchemaModel] = create_model(
+        model: type[JSONSchemaModel] = create_model(  # type: ignore
             schema_name,
             **fields,
             __base__=cls,

--- a/python/beeai_framework/workflows/__init__.py
+++ b/python/beeai_framework/workflows/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from beeai_framework.workflows.errors import WorkflowError
-from beeai_framework.workflows.workflow import Workflow, WorkflowReservedStepName
+from beeai_framework.workflows.types import WorkflowReservedStepName
+from beeai_framework.workflows.workflow import Workflow
 
 __all__ = ["Workflow", "WorkflowError", "WorkflowReservedStepName"]

--- a/python/beeai_framework/workflows/agent.py
+++ b/python/beeai_framework/workflows/agent.py
@@ -35,7 +35,8 @@ from beeai_framework.memory import BaseMemory, ReadOnlyMemory, UnconstrainedMemo
 from beeai_framework.template import PromptTemplateInput
 from beeai_framework.tools.tool import AnyTool
 from beeai_framework.utils.asynchronous import ensure_async
-from beeai_framework.workflows.workflow import Workflow, WorkflowRun
+from beeai_framework.workflows.types import WorkflowRun
+from beeai_framework.workflows.workflow import Workflow
 
 AgentFactory = Callable[[ReadOnlyMemory], AnyAgent | Awaitable[AnyAgent]]
 

--- a/python/beeai_framework/workflows/agent.py
+++ b/python/beeai_framework/workflows/agent.py
@@ -29,7 +29,7 @@ from beeai_framework.agents.types import (
     AgentMeta,
 )
 from beeai_framework.backend.chat import ChatModel
-from beeai_framework.backend.message import AssistantMessage, Message
+from beeai_framework.backend.message import AnyMessage, AssistantMessage
 from beeai_framework.context import Run
 from beeai_framework.memory import BaseMemory, ReadOnlyMemory, UnconstrainedMemory
 from beeai_framework.template import PromptTemplateInput
@@ -51,16 +51,16 @@ class AgentFactoryInput(BaseModel):
 
 class Schema(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
-    messages: list[Message[Any]] = Field(min_length=1)
+    messages: list[AnyMessage] = Field(min_length=1)
     final_answer: str | None = None
-    new_messages: list[Message[Any]] = []
+    new_messages: list[AnyMessage] = []
 
 
 class AgentWorkflow:
     def __init__(self, name: str = "AgentWorkflow") -> None:
         self.workflow = Workflow(name=name, schema=Schema)
 
-    def run(self, messages: list[Message[Any]]) -> Run[WorkflowRun[Any, Any]]:
+    def run(self, messages: list[AnyMessage]) -> Run[WorkflowRun[Any, Any]]:
         return self.workflow.run(Schema(messages=messages))
 
     def del_agent(self, name: str) -> "AgentWorkflow":

--- a/python/beeai_framework/workflows/agent.py
+++ b/python/beeai_framework/workflows/agent.py
@@ -21,7 +21,7 @@ from typing import Any, Self
 
 from pydantic import BaseModel, ConfigDict, Field, InstanceOf
 
-from beeai_framework.agents.base import BaseAgent, BaseMemory
+from beeai_framework.agents.base import BaseAgent
 from beeai_framework.agents.react import ReActAgent
 from beeai_framework.agents.react.types import ReActAgentRunOutput
 from beeai_framework.agents.types import (
@@ -31,13 +31,13 @@ from beeai_framework.agents.types import (
 from beeai_framework.backend.chat import ChatModel
 from beeai_framework.backend.message import AssistantMessage, Message
 from beeai_framework.context import Run
-from beeai_framework.memory import ReadOnlyMemory, UnconstrainedMemory
+from beeai_framework.memory import BaseMemory, ReadOnlyMemory, UnconstrainedMemory
 from beeai_framework.template import PromptTemplateInput
 from beeai_framework.tools.tool import Tool
 from beeai_framework.utils.asynchronous import ensure_async
 from beeai_framework.workflows.workflow import Workflow, WorkflowRun
 
-AgentFactory = Callable[[ReadOnlyMemory], BaseAgent | Awaitable[BaseAgent]]
+AgentFactory = Callable[[ReadOnlyMemory], BaseAgent[Any, Any, Any] | Awaitable[BaseAgent[Any, Any, Any]]]
 
 
 class AgentFactoryInput(BaseModel):
@@ -45,22 +45,22 @@ class AgentFactoryInput(BaseModel):
     name: str
     llm: ChatModel
     instructions: str | None = None
-    tools: list[InstanceOf[Tool]] | None = None
+    tools: list[InstanceOf[Tool[Any, Any, Any]]] | None = None
     execution: AgentExecutionConfig | None = None
 
 
 class Schema(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
-    messages: list[Message] = Field(min_length=1)
+    messages: list[Message[Any]] = Field(min_length=1)
     final_answer: str | None = None
-    new_messages: list[Message] = []
+    new_messages: list[Message[Any]] = []
 
 
 class AgentWorkflow:
     def __init__(self, name: str = "AgentWorkflow") -> None:
         self.workflow = Workflow(name=name, schema=Schema)
 
-    def run(self, messages: list[Message]) -> Run[WorkflowRun]:
+    def run(self, messages: list[Message[Any]]) -> Run[WorkflowRun[Any, Any]]:
         return self.workflow.run(Schema(messages=messages))
 
     def del_agent(self, name: str) -> "AgentWorkflow":
@@ -70,7 +70,10 @@ class AgentWorkflow:
     def add_agent(
         self,
         agent: (
-            BaseAgent | Callable[[ReadOnlyMemory], BaseAgent | asyncio.Future[BaseAgent]] | AgentFactoryInput | None
+            BaseAgent[Any, Any, Any]
+            | Callable[[ReadOnlyMemory], BaseAgent[Any, Any, Any] | asyncio.Future[BaseAgent[Any, Any, Any]]]
+            | AgentFactoryInput
+            | None
         ) = None,
         /,
         **kwargs: Any,
@@ -84,11 +87,14 @@ class AgentWorkflow:
                 agent = AgentFactoryInput.model_validate(kwargs, strict=False, from_attributes=True)
         elif kwargs:
             raise ValueError("Agent object required or keyword arguments required but not both")
+        assert agent is not None
 
         if isinstance(agent, BaseAgent):
 
-            async def factory(memory: ReadOnlyMemory) -> BaseAgent:
-                instance: BaseAgent = await ensure_async(agent)(memory.as_read_only()) if isfunction(agent) else agent
+            async def factory(memory: ReadOnlyMemory) -> BaseAgent[Any, Any, Any]:
+                instance: BaseAgent[Any, Any, Any] = (
+                    await ensure_async(agent)(memory.as_read_only()) if isfunction(agent) else agent
+                )
                 instance.memory = memory
                 return instance
 
@@ -100,7 +106,7 @@ class AgentWorkflow:
 
     def _create_factory(self, agent_input: AgentFactoryInput) -> AgentFactory:
         def factory(memory: BaseMemory) -> ReActAgent:
-            def customizer(config: PromptTemplateInput) -> PromptTemplateInput:
+            def customizer(config: PromptTemplateInput[Any]) -> PromptTemplateInput[Any]:
                 new_config = config.model_copy()
                 new_config.defaults["instructions"] = agent_input.instructions or config.defaults.get("instructions")
                 return new_config

--- a/python/beeai_framework/workflows/events.py
+++ b/python/beeai_framework/workflows/events.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Generic, TypeVar
+from typing import Generic
 
 from pydantic import BaseModel, InstanceOf
+from typing_extensions import TypeVar
 
 from beeai_framework.errors import FrameworkError
 from beeai_framework.workflows.types import WorkflowRun

--- a/python/beeai_framework/workflows/events.py
+++ b/python/beeai_framework/workflows/events.py
@@ -1,0 +1,41 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Generic, TypeVar
+
+from pydantic import BaseModel, InstanceOf
+
+from beeai_framework.errors import FrameworkError
+from beeai_framework.workflows.types import WorkflowRun
+
+T = TypeVar("T", bound=BaseModel)
+K = TypeVar("K", default=str)
+
+
+class WorkflowStartEvent(BaseModel, Generic[T, K]):
+    run: WorkflowRun[T, K]
+    step: K
+
+
+class WorkflowSuccessEvent(BaseModel, Generic[T, K]):
+    run: WorkflowRun[T, K]
+    state: T
+    step: K
+    next: K
+
+
+class WorkflowErrorEvent(BaseModel, Generic[T, K]):
+    run: WorkflowRun[T, K]
+    step: K
+    error: InstanceOf[FrameworkError]

--- a/python/beeai_framework/workflows/types.py
+++ b/python/beeai_framework/workflows/types.py
@@ -1,0 +1,61 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Callable
+from dataclasses import field
+from typing import Any, Generic, Literal, TypeVar
+
+from pydantic import BaseModel
+
+from beeai_framework.cancellation import AbortSignal
+from beeai_framework.utils.types import MaybeAsync
+
+T = TypeVar("T", bound=BaseModel)
+K = TypeVar("K", default=str)
+
+
+WorkflowReservedStepName = Literal["__start__", "__self__", "__prev__", "__next__", "__end__"]
+WorkflowHandler = MaybeAsync[[T], K | WorkflowReservedStepName | None]
+
+
+class WorkflowRunOptions(BaseModel, Generic[K]):
+    start: K | None = None
+    signal: AbortSignal | None = None
+
+
+class WorkflowState(BaseModel, Generic[K]):
+    current: K
+    prev: K | None = None
+    next: K | None = None
+
+
+class WorkflowStepRes(BaseModel, Generic[T, K]):
+    name: K
+    state: T
+
+
+class WorkflowStepDefinition(BaseModel, Generic[T, K]):
+    handler: WorkflowHandler[T, K]
+
+
+class WorkflowRunContext(BaseModel, Generic[T, K]):
+    steps: list[WorkflowStepRes[T, K]] = field(default_factory=list)
+    signal: AbortSignal
+    abort: Callable[[Any], None]
+
+
+class WorkflowRun(BaseModel, Generic[T, K]):
+    state: T
+    result: T | None = None
+    steps: list[WorkflowStepRes[T, K]] = field(default_factory=list)

--- a/python/beeai_framework/workflows/types.py
+++ b/python/beeai_framework/workflows/types.py
@@ -14,9 +14,10 @@
 
 from collections.abc import Callable
 from dataclasses import field
-from typing import Any, Generic, Literal, TypeVar
+from typing import Any, Generic, Literal
 
 from pydantic import BaseModel
+from typing_extensions import TypeVar
 
 from beeai_framework.cancellation import AbortSignal
 from beeai_framework.utils.types import MaybeAsync

--- a/python/docs/backend.md
+++ b/python/docs/backend.md
@@ -336,7 +336,6 @@ Integrate external tools with your AI model:
 
 <!-- embedme examples/backend/tool_calling.py -->
 
-
 ```py
 import asyncio
 import json
@@ -345,8 +344,9 @@ import sys
 import traceback
 
 from beeai_framework import Message, SystemMessage, Tool, ToolMessage, UserMessage
-from beeai_framework.backend.chat import ChatModel, ChatModelParameters
+from beeai_framework.backend.chat import ChatModel
 from beeai_framework.backend.message import MessageToolResultContent
+from beeai_framework.backend.types import ChatModelParameters
 from beeai_framework.errors import FrameworkError
 from beeai_framework.tools import ToolOutput
 from beeai_framework.tools.search import DuckDuckGoSearchTool

--- a/python/docs/emitter.md
+++ b/python/docs/emitter.md
@@ -82,6 +82,7 @@ Event matching allows you to:
 
 ```py
 import asyncio
+import re
 import sys
 import traceback
 
@@ -108,6 +109,9 @@ async def main() -> None:
     model.emitter.match(
         lambda event: isinstance(event.creator, ChatModel), lambda data, event: print(data, ": match ChatModel")
     )
+
+    # Match events by regex
+    emitter.match(re.compile(r"watsonx"), lambda data, event: print(data, ": match regex"))
 
     await emitter.emit("update", "update")
     await Emitter.root().emit("root", "root")

--- a/python/docs/events.md
+++ b/python/docs/events.md
@@ -11,7 +11,7 @@ These events can be observed calling `agent.run`
 - "start":
     ```python
     {
-        "meta": BeeMeta,
+        "meta": ReActAgentIterationMeta,
         "tools": list[Tool],
         "memory": BaseMemory,
     }
@@ -20,13 +20,13 @@ These events can be observed calling `agent.run`
     ```python
     {
         "error": FrameworkError,
-        "meta": BeeMeta,
+        "meta": ReActAgentIterationMeta,
     }
 
 - "retry":
     ```python
     {
-        "meta": BeeMeta,
+        "meta": ReActAgentIterationMeta,
     }
 
 - "success":
@@ -61,7 +61,7 @@ These events can be observed calling `agent.run`
             "options": ReActAgentRunOptions,
             "iteration": ReActAgentIterationResult,
         },
-        "meta": BeeMeta,
+        "meta": ReActAgentIterationMeta,
     }
 
 - "toolSuccess":
@@ -74,7 +74,7 @@ These events can be observed calling `agent.run`
             "iteration": ReActAgentIterationResult,
             "result": ToolOutput,
         },
-        "meta": BeeMeta,
+        "meta": ReActAgentIterationMeta,
     }
 
 - "toolError":
@@ -87,14 +87,14 @@ These events can be observed calling `agent.run`
             "iteration": ReActAgentIterationResult,
             "error": FrameworkError,
         },
-        "meta": BeeMeta,
+        "meta": ReActAgentIterationMeta,
     }
 
 ### ChatModel Events
 
 These events can be observed when calling `ChatModel.create` or `ChatModel.create_structure`
 
-- "newToken":
+- "new_token":
     ```python
     {
       "value": ChatModelOutput,

--- a/python/docs/tools.md
+++ b/python/docs/tools.md
@@ -162,7 +162,7 @@ from beeai_framework.backend.chat import ChatModel
 from beeai_framework.errors import FrameworkError
 from beeai_framework.logger import Logger
 from beeai_framework.memory.unconstrained_memory import UnconstrainedMemory
-from beeai_framework.tools.tool import StringToolOutput
+from beeai_framework.tools import StringToolOutput
 
 logger = Logger(__name__)
 
@@ -395,6 +395,7 @@ To create a new tool, implement the base `Tool` class. The framework provides fl
 Here's an example of a simple custom tool that provides riddles:
 
 <!-- embedme examples/tools/custom/base.py -->
+
 ```py
 import asyncio
 import random
@@ -406,7 +407,9 @@ from pydantic import BaseModel, Field
 from beeai_framework.context import RunContext
 from beeai_framework.emitter.emitter import Emitter
 from beeai_framework.errors import FrameworkError
-from beeai_framework.tools.tool import StringToolOutput, Tool, ToolRunOptions
+from beeai_framework.tools import StringToolOutput
+from beeai_framework.tools.tool import Tool
+from beeai_framework.tools.types import ToolRunOptions
 
 
 class RiddleToolInput(BaseModel):
@@ -475,6 +478,7 @@ _Source: [/python/examples/tools/custom/base.py](/python/examples/tools/custom/b
 For more complex scenarios, you can implement tools with robust input validation, error handling, and structured outputs:
 
 <!-- embedme examples/tools/custom/openlibrary.py -->
+
 ```py
 import asyncio
 import sys
@@ -487,7 +491,8 @@ from beeai_framework.context import RunContext
 from beeai_framework.emitter.emitter import Emitter
 from beeai_framework.errors import FrameworkError
 from beeai_framework.tools import ToolInputValidationError
-from beeai_framework.tools.tool import JSONToolOutput, Tool, ToolRunOptions
+from beeai_framework.tools.tool import Tool
+from beeai_framework.tools.types import JSONToolOutput, ToolRunOptions
 
 
 class OpenLibraryToolInput(BaseModel):

--- a/python/docs/workflows.md
+++ b/python/docs/workflows.md
@@ -114,7 +114,8 @@ from typing import Literal, TypeAlias
 from pydantic import BaseModel
 
 from beeai_framework.errors import FrameworkError
-from beeai_framework.workflows.workflow import Workflow, WorkflowReservedStepName
+from beeai_framework.workflows import WorkflowReservedStepName
+from beeai_framework.workflows.workflow import Workflow
 
 WorkflowStep: TypeAlias = Literal["pre_process", "add_loop", "post_process"]
 
@@ -199,7 +200,8 @@ from typing import Literal, TypeAlias
 from pydantic import BaseModel
 
 from beeai_framework.errors import FrameworkError
-from beeai_framework.workflows.workflow import Workflow, WorkflowReservedStepName
+from beeai_framework.workflows import WorkflowReservedStepName
+from beeai_framework.workflows.workflow import Workflow
 
 WorkflowStep: TypeAlias = Literal["pre_process", "add_loop", "post_process"]
 
@@ -253,7 +255,6 @@ if __name__ == "__main__":
     except FrameworkError as e:
         traceback.print_exc()
         sys.exit(e.explain())
-
 
 ```
 

--- a/python/examples/agents/react.py
+++ b/python/examples/agents/react.py
@@ -10,7 +10,8 @@ from dotenv import load_dotenv
 from beeai_framework import Tool
 from beeai_framework.agents.react.agent import ReActAgent
 from beeai_framework.agents.types import AgentExecutionConfig
-from beeai_framework.backend.chat import ChatModel, ChatModelParameters
+from beeai_framework.backend.chat import ChatModel
+from beeai_framework.backend.types import ChatModelParameters
 from beeai_framework.emitter.emitter import EventMeta
 from beeai_framework.emitter.types import EmitterOptions
 from beeai_framework.errors import FrameworkError

--- a/python/examples/backend/providers/amazon_bedrock.py
+++ b/python/examples/backend/providers/amazon_bedrock.py
@@ -80,7 +80,9 @@ async def amazon_bedrock_stream_parser() -> None:
         await parser.add(chunk=data["value"].get_text_content())
 
     user_message = UserMessage("Produce 3 lines each starting with 'Prefix: ' followed by a sentence and a new line.")
-    await llm.create(messages=[user_message], stream=True).observe(lambda emitter: emitter.on("newToken", on_new_token))
+    await llm.create(messages=[user_message], stream=True).observe(
+        lambda emitter: emitter.on("new_token", on_new_token)
+    )
     result = await parser.end()
     print(result)
 

--- a/python/examples/backend/providers/anthropic.py
+++ b/python/examples/backend/providers/anthropic.py
@@ -79,7 +79,9 @@ async def anthropic_stream_parser() -> None:
         await parser.add(chunk=data["value"].get_text_content())
 
     user_message = UserMessage("Produce 3 lines each starting with 'Prefix: ' followed by a sentence and a new line.")
-    await llm.create(messages=[user_message], stream=True).observe(lambda emitter: emitter.on("newToken", on_new_token))
+    await llm.create(messages=[user_message], stream=True).observe(
+        lambda emitter: emitter.on("new_token", on_new_token)
+    )
     result = await parser.end()
     print(result)
 

--- a/python/examples/backend/providers/groq.py
+++ b/python/examples/backend/providers/groq.py
@@ -74,7 +74,9 @@ async def groq_stream_parser() -> None:
         await parser.add(data["value"].get_text_content())
 
     user_message = UserMessage("Produce 3 lines each starting with 'Prefix: ' followed by a sentence and a new line.")
-    await llm.create(messages=[user_message], stream=True).observe(lambda emitter: emitter.on("newToken", on_new_token))
+    await llm.create(messages=[user_message], stream=True).observe(
+        lambda emitter: emitter.on("new_token", on_new_token)
+    )
     result = await parser.end()
     print(result)
 

--- a/python/examples/backend/providers/ollama.py
+++ b/python/examples/backend/providers/ollama.py
@@ -83,7 +83,9 @@ async def ollama_stream_parser() -> None:
         await parser.add(data["value"].get_text_content())
 
     user_message = UserMessage("Produce 3 lines each starting with 'Prefix: ' followed by a sentence and a new line.")
-    await llm.create(messages=[user_message], stream=True).observe(lambda emitter: emitter.on("newToken", on_new_token))
+    await llm.create(messages=[user_message], stream=True).observe(
+        lambda emitter: emitter.on("new_token", on_new_token)
+    )
     result = await parser.end()
     print(result)
 

--- a/python/examples/backend/providers/openai_example.py
+++ b/python/examples/backend/providers/openai_example.py
@@ -86,7 +86,9 @@ async def openai_stream_parser() -> None:
         await parser.add(data["value"].get_text_content())
 
     user_message = UserMessage("Produce 3 lines each starting with 'Prefix: ' followed by a sentence and a new line.")
-    await llm.create(messages=[user_message], stream=True).observe(lambda emitter: emitter.on("newToken", on_new_token))
+    await llm.create(messages=[user_message], stream=True).observe(
+        lambda emitter: emitter.on("new_token", on_new_token)
+    )
     result = await parser.end()
     print(result)
 

--- a/python/examples/backend/providers/vertexai.py
+++ b/python/examples/backend/providers/vertexai.py
@@ -74,7 +74,9 @@ async def vertexai_stream_parser() -> None:
         await parser.add(data["value"].get_text_content())
 
     user_message = UserMessage("Produce 3 lines each starting with 'Prefix: ' followed by a sentence and a new line.")
-    await llm.create(messages=[user_message], stream=True).observe(lambda emitter: emitter.on("newToken", on_new_token))
+    await llm.create(messages=[user_message], stream=True).observe(
+        lambda emitter: emitter.on("new_token", on_new_token)
+    )
     result = await parser.end()
     print(result)
 

--- a/python/examples/backend/providers/xai.py
+++ b/python/examples/backend/providers/xai.py
@@ -77,7 +77,9 @@ async def xai_stream_parser() -> None:
         await parser.add(data["value"].get_text_content())
 
     user_message = UserMessage("Produce 3 lines each starting with 'Prefix: ' followed by a sentence and a new line.")
-    await llm.create(messages=[user_message], stream=True).observe(lambda emitter: emitter.on("newToken", on_new_token))
+    await llm.create(messages=[user_message], stream=True).observe(
+        lambda emitter: emitter.on("new_token", on_new_token)
+    )
     result = await parser.end()
     print(result)
 

--- a/python/examples/backend/tool_calling.py
+++ b/python/examples/backend/tool_calling.py
@@ -5,8 +5,9 @@ import sys
 import traceback
 
 from beeai_framework import Message, SystemMessage, Tool, ToolMessage, UserMessage
-from beeai_framework.backend.chat import ChatModel, ChatModelParameters
+from beeai_framework.backend.chat import ChatModel
 from beeai_framework.backend.message import MessageToolResultContent
+from beeai_framework.backend.types import ChatModelParameters
 from beeai_framework.errors import FrameworkError
 from beeai_framework.tools import ToolOutput
 from beeai_framework.tools.search import DuckDuckGoSearchTool

--- a/python/examples/emitter/matchers.py
+++ b/python/examples/emitter/matchers.py
@@ -1,4 +1,5 @@
 import asyncio
+import re
 import sys
 import traceback
 
@@ -25,6 +26,9 @@ async def main() -> None:
     model.emitter.match(
         lambda event: isinstance(event.creator, ChatModel), lambda data, event: print(data, ": match ChatModel")
     )
+
+    # Match events by regex
+    emitter.match(re.compile(r"watsonx"), lambda data, event: print(data, ": match regex"))
 
     await emitter.emit("update", "update")
     await Emitter.root().emit("root", "root")

--- a/python/examples/notebooks/agents.ipynb
+++ b/python/examples/notebooks/agents.ipynb
@@ -18,8 +18,8 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Basic ReAct Agent\n",
     "\n",
@@ -31,10 +31,10 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from typing import Any\n",
     "\n",
@@ -176,8 +176,8 @@
     "\n",
     "from beeai_framework.agents.react.agent import ReActAgent\n",
     "from beeai_framework.context import RunContext\n",
-    "from beeai_framework.tools import Tool\n",
-    "from beeai_framework.tools.tool import StringToolOutput, ToolRunOptions\n",
+    "from beeai_framework.tools import StringToolOutput, Tool\n",
+    "from beeai_framework.tools.types import ToolRunOptions\n",
     "\n",
     "\n",
     "class LangChainWikipediaToolInput(BaseModel):\n",

--- a/python/examples/notebooks/basics.ipynb
+++ b/python/examples/notebooks/basics.ipynb
@@ -212,7 +212,8 @@
     }
    ],
    "source": [
-    "from beeai_framework.backend.chat import ChatModel, ChatModelOutput\n",
+    "from beeai_framework.backend.chat import ChatModel\n",
+    "from beeai_framework.backend.types import ChatModelOutput\n",
     "\n",
     "# Create a ChatModel to interface with granite3.1-dense:8b on a local ollama\n",
     "model = ChatModel.from_name(\"ollama:granite3.1-dense:8b\")\n",

--- a/python/examples/notebooks/watsonx.ipynb
+++ b/python/examples/notebooks/watsonx.ipynb
@@ -55,8 +55,9 @@
     }
    ],
    "source": [
-    "from beeai_framework.backend.chat import ChatModel, ChatModelOutput\n",
+    "from beeai_framework.backend.chat import ChatModel\n",
     "from beeai_framework.backend.message import UserMessage\n",
+    "from beeai_framework.backend.types import ChatModelOutput\n",
     "\n",
     "# Create a ChatModel to interface with ibm/granite-3-8b-instruct from watsonx\n",
     "model = ChatModel.from_name(\n",
@@ -84,10 +85,10 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import json\n",
     "\n",

--- a/python/examples/notebooks/workflows.ipynb
+++ b/python/examples/notebooks/workflows.ipynb
@@ -106,8 +106,9 @@
     "from langchain_community.utilities import SearxSearchWrapper\n",
     "from pydantic import Field\n",
     "\n",
-    "from beeai_framework.backend.chat import ChatModel, ChatModelOutput, ChatModelStructureOutput\n",
+    "from beeai_framework.backend.chat import ChatModel\n",
     "from beeai_framework.backend.message import UserMessage\n",
+    "from beeai_framework.backend.types import ChatModelOutput, ChatModelStructureOutput\n",
     "from beeai_framework.template import PromptTemplate, PromptTemplateInput"
    ]
   },

--- a/python/examples/tools/custom/base.py
+++ b/python/examples/tools/custom/base.py
@@ -8,7 +8,9 @@ from pydantic import BaseModel, Field
 from beeai_framework.context import RunContext
 from beeai_framework.emitter.emitter import Emitter
 from beeai_framework.errors import FrameworkError
-from beeai_framework.tools.tool import StringToolOutput, Tool, ToolRunOptions
+from beeai_framework.tools import StringToolOutput
+from beeai_framework.tools.tool import Tool
+from beeai_framework.tools.types import ToolRunOptions
 
 
 class RiddleToolInput(BaseModel):

--- a/python/examples/tools/custom/openlibrary.py
+++ b/python/examples/tools/custom/openlibrary.py
@@ -9,7 +9,8 @@ from beeai_framework.context import RunContext
 from beeai_framework.emitter.emitter import Emitter
 from beeai_framework.errors import FrameworkError
 from beeai_framework.tools import ToolInputValidationError
-from beeai_framework.tools.tool import JSONToolOutput, Tool, ToolRunOptions
+from beeai_framework.tools.tool import Tool
+from beeai_framework.tools.types import JSONToolOutput, ToolRunOptions
 
 
 class OpenLibraryToolInput(BaseModel):

--- a/python/examples/tools/decorator.py
+++ b/python/examples/tools/decorator.py
@@ -12,7 +12,7 @@ from beeai_framework.backend.chat import ChatModel
 from beeai_framework.errors import FrameworkError
 from beeai_framework.logger import Logger
 from beeai_framework.memory.unconstrained_memory import UnconstrainedMemory
-from beeai_framework.tools.tool import StringToolOutput
+from beeai_framework.tools import StringToolOutput
 
 logger = Logger(__name__)
 

--- a/python/examples/tools/experimental/human.py
+++ b/python/examples/tools/experimental/human.py
@@ -2,7 +2,8 @@ from pydantic import BaseModel, Field, InstanceOf
 
 from beeai_framework.context import RunContext
 from beeai_framework.emitter import Emitter
-from beeai_framework.tools.tool import JSONToolOutput, Tool, ToolRunOptions
+from beeai_framework.tools.tool import Tool
+from beeai_framework.tools.types import JSONToolOutput, ToolRunOptions
 from examples.helpers.io import ConsoleReader
 
 

--- a/python/examples/tools/mcp_agent.py
+++ b/python/examples/tools/mcp_agent.py
@@ -12,7 +12,8 @@ from mcp.client.stdio import stdio_client
 from beeai_framework import Tool
 from beeai_framework.agents.react.agent import ReActAgent
 from beeai_framework.agents.types import AgentExecutionConfig
-from beeai_framework.backend.chat import ChatModel, ChatModelParameters
+from beeai_framework.backend.chat import ChatModel
+from beeai_framework.backend.types import ChatModelParameters
 from beeai_framework.emitter.emitter import Emitter, EventMeta
 from beeai_framework.errors import FrameworkError
 from beeai_framework.logger import Logger

--- a/python/examples/workflows/emitter.py
+++ b/python/examples/workflows/emitter.py
@@ -7,7 +7,8 @@ from pydantic import BaseModel
 
 from beeai_framework.emitter.emitter import Emitter, EventMeta
 from beeai_framework.errors import FrameworkError
-from beeai_framework.workflows.workflow import Workflow, WorkflowReservedStepName
+from beeai_framework.workflows import WorkflowReservedStepName
+from beeai_framework.workflows.workflow import Workflow
 
 WorkflowStep: TypeAlias = Literal["pre_process", "add_loop", "post_process"]
 

--- a/python/examples/workflows/nesting.py
+++ b/python/examples/workflows/nesting.py
@@ -6,7 +6,8 @@ from typing import Literal, TypeAlias
 from pydantic import BaseModel
 
 from beeai_framework.errors import FrameworkError
-from beeai_framework.workflows.workflow import Workflow, WorkflowReservedStepName
+from beeai_framework.workflows import WorkflowReservedStepName
+from beeai_framework.workflows.workflow import Workflow
 
 WorkflowStep: TypeAlias = Literal["pre_process", "add_loop", "post_process"]
 

--- a/python/examples/workflows/searx_agent.py
+++ b/python/examples/workflows/searx_agent.py
@@ -6,8 +6,8 @@ from langchain_community.utilities import SearxSearchWrapper
 from pydantic import BaseModel, Field
 
 from beeai_framework.adapters.ollama.backend.chat import OllamaChatModel
-from beeai_framework.backend.chat import ChatModelOutput, ChatModelStructureOutput
 from beeai_framework.backend.message import UserMessage
+from beeai_framework.backend.types import ChatModelOutput, ChatModelStructureOutput
 from beeai_framework.errors import FrameworkError
 from beeai_framework.template import PromptTemplate, PromptTemplateInput
 from beeai_framework.workflows.workflow import Workflow

--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -294,7 +294,7 @@ description = "Foreign Function Interface for Python calling C code."
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "platform_python_implementation == \"PyPy\" and extra == \"langchain\""
+markers = "extra == \"langchain\" and platform_python_implementation == \"PyPy\""
 files = [
     {file = "cffi-1.17.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:df8b1c11f177bc2313ec4b2d46baec87a5f3e71fc8b45dab2ee7cae86d9aba14"},
     {file = "cffi-1.17.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8f2cdc858323644ab277e9bb925ad72ae0e67f69e804f4898c070998d50b1a67"},
@@ -693,14 +693,14 @@ files = [
 
 [[package]]
 name = "duckduckgo-search"
-version = "7.5.0"
+version = "7.5.1"
 description = "Search for words, documents, images, news, maps and text translation using the DuckDuckGo.com search engine."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "duckduckgo_search-7.5.0-py3-none-any.whl", hash = "sha256:6a2d3f12ae29b3e076cd43be61f5f73cd95261e0a0f318fe0ad3648d7a5dff03"},
-    {file = "duckduckgo_search-7.5.0.tar.gz", hash = "sha256:3e28dc5ec9188efa3a7c8532aa05aaf03bb34b79370855760abd55e6051ff79b"},
+    {file = "duckduckgo_search-7.5.1-py3-none-any.whl", hash = "sha256:66edb228eed4a32d1f8437ce1d0ff9468f9eba6678c1685e7b43e80156cdc66e"},
+    {file = "duckduckgo_search-7.5.1.tar.gz", hash = "sha256:54d18bfcda75c485232a868552bea1cc7c52d82472a73f0c7791613e98d32137"},
 ]
 
 [package.dependencies]
@@ -892,7 +892,7 @@ description = "Lightweight in-process concurrent programming"
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "extra == \"langchain\" and (platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\") and python_version < \"3.14\""
+markers = "python_version < \"3.14\" and (platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\") and extra == \"langchain\""
 files = [
     {file = "greenlet-3.1.1-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:0bbae94a29c9e5c7e4a2b7f0aae5c17e8e90acbfd3bf6270eeba60c39fce3563"},
     {file = "greenlet-3.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fde093fb93f35ca72a556cf72c92ea3ebfda3d79fc35bb19fbe685853869a83"},
@@ -2115,7 +2115,7 @@ description = "Fast, correct Python JSON library supporting dataclasses, datetim
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "platform_python_implementation != \"PyPy\" and extra == \"langchain\""
+markers = "extra == \"langchain\" and platform_python_implementation != \"PyPy\""
 files = [
     {file = "orjson-3.10.15-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:552c883d03ad185f720d0c09583ebde257e41b9521b74ff40e08b7dec4559c04"},
     {file = "orjson-3.10.15-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:616e3e8d438d02e4854f70bfdc03a6bcdb697358dbaa6bcd19cbe24d24ece1f8"},
@@ -2426,7 +2426,7 @@ description = "C parser in Python"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "platform_python_implementation == \"PyPy\" and extra == \"langchain\""
+markers = "extra == \"langchain\" and platform_python_implementation == \"PyPy\""
 files = [
     {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
     {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
@@ -2730,7 +2730,7 @@ description = "Python for Window Extensions"
 optional = false
 python-versions = "*"
 groups = ["dev"]
-markers = "platform_python_implementation != \"PyPy\" and sys_platform == \"win32\""
+markers = "sys_platform == \"win32\" and platform_python_implementation != \"PyPy\""
 files = [
     {file = "pywin32-308-cp310-cp310-win32.whl", hash = "sha256:796ff4426437896550d2981b9c2ac0ffd75238ad9ea2d3bfa67a1abd546d262e"},
     {file = "pywin32-308-cp310-cp310-win_amd64.whl", hash = "sha256:4fc888c59b3c0bef905ce7eb7e2106a07712015ea1c8234b703a088d46110e8e"},
@@ -3874,4 +3874,4 @@ langchain = ["langchain-community", "langchain-core"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">= 3.11,<4.0"
-content-hash = "0a368fccc17dfd4991404546d32031b098ba3476371109871a7b291d11647d42"
+content-hash = "50aee6c2d003298e17db27ac55f7ee57ccf1a7b29c340fbe4e1d513ef19070e0"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -31,7 +31,7 @@ chevron = "^0.14.0"
 litellm = "^1.63.2"
 aiofiles = "^24.1.0"
 mcp = "^1.2.0"
-duckduckgo-search = "^7.3.2"
+duckduckgo-search = "^7.5.1"
 json-repair = "^0.39.0"
 wikipedia-api = "^0.8.1"
 langchain-core = {version = "^0.3.41", optional = true}

--- a/python/tests/backend/test_chatmodel.py
+++ b/python/tests/backend/test_chatmodel.py
@@ -29,16 +29,18 @@ from beeai_framework.adapters.watsonx.backend.chat import WatsonxChatModel
 from beeai_framework.adapters.xai.backend.chat import XAIChatModel
 from beeai_framework.backend.chat import (
     ChatModel,
-    ChatModelInput,
-    ChatModelOutput,
-    ChatModelStructureInput,
-    ChatModelStructureOutput,
 )
 from beeai_framework.backend.message import (
     AssistantMessage,
     CustomMessage,
     Message,
     UserMessage,
+)
+from beeai_framework.backend.types import (
+    ChatModelInput,
+    ChatModelOutput,
+    ChatModelStructureInput,
+    ChatModelStructureOutput,
 )
 from beeai_framework.cancellation import AbortSignal
 from beeai_framework.context import RunContext

--- a/python/tests/tools/test_opemmeteo.py
+++ b/python/tests/tools/test_opemmeteo.py
@@ -15,8 +15,7 @@
 
 import pytest
 
-from beeai_framework.tools import ToolInputValidationError
-from beeai_framework.tools.tool import StringToolOutput
+from beeai_framework.tools import StringToolOutput, ToolInputValidationError
 from beeai_framework.tools.weather.openmeteo import OpenMeteoTool, OpenMeteoToolInput
 
 """


### PR DESCRIPTION
### Which issue(s) does this pull-request address?

Ref #415 
Ref #433 

### Description

This include both the first part of typing the emitter event emits and addressing mypy:

#### Event Type work includes
- Adds types for each event in a `events.py` file for each submodule
- Updates emitter to take in and store an optional events dict that defines the expected events for that emitter. This events dict can be dynamically updated by users as needed
- Adds a event_data key to EventMeta that contains the data type for the event
- Add a events dict to each emitter instance with it's correct events and data types
- Update all internal event names to use underscores not camelCase
- Reintroduce regex support in emitter match

#### Event Types work TODOs
- [ ] Update internal emits to return the new event classes instead of dicts
- [ ] Update examples and tests to handle new event types
- [ ] Update docs 

#### MyPy updates
- mypy passes on everything in `beeai_framework/` except for `beeai_framework/adapters` and  `beeai_framework/memory`
- I had to add ignore lines in a few places where fixing the mypy warn would change how the code works
- Most updates deal with adding type hints or type params for generics
- Updated the generic names in Tool to match TS
- Added `AnyTool`, `AnyAgent` and `AnyMessage`
- created `types.py` for the `backend`, `tools`, and `workflows` submodules and move the relevant classes into those files

### Checklist

#### General
- [x] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [x] Linting passes: Python `poe lint` or `poe lint --fix` / TypeScript `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: Python `poe format` or `poe format --fix` / TypeScript: `yarn format` or `yarn format:fix`
- [x] Static type checks pass: Python `poe type-check`

#### Testing
- [x] Unit tests pass: Python `poe test --type unit` / TypeScript `yarn test:unit`
- [x] E2E tests pass: Python `poe test --type e2e` / TypeScript: `yarn test:e2e`
- [x] Integration tests pass: Python `poe test --type integration`
- [x] Tests are included (for bug fixes or new features)

#### Documentation
- [x] Documentation is updated
- [x] Embedme embeds code examples in docs. To update after edits, run: Python `poe docs --type build`
