### PR TITLE
fix: mcp tool error

### DIFF
--- a/python/beeai_framework/tools/mcp_tools.py
+++ b/python/beeai_framework/tools/mcp_tools.py
@@ -68,7 +68,7 @@ class MCPTool(Tool[BaseModel, ToolRunOptions, ToolOutput]):
                 name=self._tool.name, arguments=input_data.model_dump(exclude_none=True, exclude_unset=True)
             )
             logger.debug(f"Tool result: {result}")
-            return JSONToolOutput([c.model_dump() for c in result.content])
+            return JSONToolOutput(result.content)
 
     @classmethod
     async def from_client(cls, client: ClientSession, server_params: StdioServerParameters) -> list["MCPTool"]:

--- a/python/beeai_framework/utils/models.py
+++ b/python/beeai_framework/utils/models.py
@@ -69,7 +69,7 @@ class JSONSchemaModel(ABC, BaseModel):
 
     @classmethod
     def create(cls, schema_name: str, schema: dict[str, Any]) -> type["JSONSchemaModel"]:
-        type_mapping = {
+        type_mapping: dict[str, Any] = {
             "string": str,
             "integer": int,
             "number": float,
@@ -87,7 +87,7 @@ class JSONSchemaModel(ABC, BaseModel):
             target_type = type_mapping.get(param.get("type"))
             is_optional = param_name not in required
             if is_optional:
-                target_type = target_type or type(None)
+                target_type = target_type | None if target_type else type(None)
 
             if not target_type:
                 raise ValueError(f"Unsupported type '{param.get('type')}' found in the schema.")

--- a/python/beeai_framework/utils/models.py
+++ b/python/beeai_framework/utils/models.py
@@ -15,7 +15,7 @@
 from abc import ABC
 from collections.abc import Sequence
 from contextlib import suppress
-from typing import Any, TypeVar, Union
+from typing import Any, Optional, TypeVar, Union
 
 from pydantic import BaseModel, ConfigDict, Field, GetJsonSchemaHandler, create_model
 from pydantic.json_schema import JsonSchemaValue
@@ -87,7 +87,7 @@ class JSONSchemaModel(ABC, BaseModel):
             target_type = type_mapping.get(param.get("type"))
             is_optional = param_name not in required
             if is_optional:
-                target_type = target_type | None if target_type else type(None)
+                target_type = Optional[target_type] if target_type else type(None)  # noqa: UP007
 
             if not target_type:
                 raise ValueError(f"Unsupported type '{param.get('type')}' found in the schema.")

--- a/python/tests/utils/test_json_schema.py
+++ b/python/tests/utils/test_json_schema.py
@@ -1,0 +1,64 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+from pydantic import ValidationError
+
+from beeai_framework.utils.models import JSONSchemaModel
+
+"""
+Utility functions and classes
+"""
+
+
+@pytest.fixture
+def test_json_schema() -> dict[str, list | str | dict]:
+    return {
+        "title": "User",
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "age": {"type": "integer"},
+            "is_active": {"type": "boolean"},
+            "address": {
+                "type": "object",
+                "properties": {
+                    "street": {"type": "string"},
+                    "city": {"type": "string"},
+                    "zipcode": {"type": "integer"},
+                },
+            },
+            "roles": {"type": "array", "items": {"type": "string", "enum": ["admin", "user", "guest"]}},
+        },
+        "required": ["name", "age"],
+    }
+
+
+"""
+Unit Tests
+"""
+
+
+@pytest.mark.unit
+def test_json_schema_model(test_json_schema: dict[str, list | str | dict]) -> None:
+    model = JSONSchemaModel.create("test_schema", test_json_schema)
+    assert model.model_json_schema()
+
+    # should throw exception if required fields are missing
+    with pytest.raises(ValidationError):  # No description provided
+        model.model_validate({"name": "aaa"})
+
+    # should not fail if optional fields are not included
+    assert model.model_validate({"name": "aaa", "age": 25})

--- a/python/tests/utils/test_json_schema.py
+++ b/python/tests/utils/test_json_schema.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+from typing import Any
+
 import pytest
 from pydantic import ValidationError
 
@@ -24,7 +26,7 @@ Utility functions and classes
 
 
 @pytest.fixture
-def test_json_schema() -> dict[str, list | str | dict]:
+def test_json_schema() -> dict[str, list[str] | str | Any]:
     return {
         "title": "User",
         "type": "object",
@@ -52,7 +54,7 @@ Unit Tests
 
 
 @pytest.mark.unit
-def test_json_schema_model(test_json_schema: dict[str, list | str | dict]) -> None:
+def test_json_schema_model(test_json_schema: dict[str, list[str] | str | Any]) -> None:
     model = JSONSchemaModel.create("test_schema", test_json_schema)
     assert model.model_json_schema()
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review and complete the sections below.
-->

### Which issue(s) does this pull-request address?

<!--
Please include a link to an issue in the tracker.  The issue describes the problem to be solved.  If there is no issue raised for this PR then either raise one with a summary and description of the problem or add a summary and description of the problem here
-->

Closes: #553 

### Description

this PR updates the result returned by the MCP tool. more specifically, how the MCP tool_call result is transformed into the JSONToolOutput.

this resolves the following error seen when the json schema contains an optional field which is not included by the tool_input

```
Agent 🤖 :  ToolError(beeai_framework.tools.errors): Tool Error
  ExceptionGroup(builtins): unhandled errors in a TaskGroup (1 sub-exception)
...
LinePrefixParserError(beeai_framework.parsers.line_prefix): The generated output does not adhere to the schema.
Value for 'tool_input' cannot be retrieved because its value does not adhere to the appropriate schema.
```



### Checklist

#### General
- [x] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [x] Linting passes: Python `poe lint` or `poe lint --fix` / TypeScript `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: Python `poe format` or `poe format --fix` / TypeScript: `yarn format` or `yarn format:fix`
- [x] Static type checks pass: Python `poe type-check`

#### Testing
- [x] Unit tests pass: Python `poe test --type unit` / TypeScript `yarn test:unit`
- [x] E2E tests pass: Python `poe test --type e2e` / TypeScript: `yarn test:e2e`
- [x] Integration tests pass: Python `poe test --type integration`
- [x] Tests are included (for bug fixes or new features)

#### Documentation
- [ ] Documentation is updated
- [ ] Embedme embeds code examples in docs. To update after edits, run: Python `poe docs --type build`
