### PR TITLE
chore(internal): Support context dictionary in FrameworkError

### DIFF
--- a/python/beeai_framework/agents/errors.py
+++ b/python/beeai_framework/agents/errors.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any
 
 from beeai_framework.errors import FrameworkError
 
@@ -19,5 +20,11 @@ from beeai_framework.errors import FrameworkError
 class AgentError(FrameworkError):
     """Raised for errors caused by agents."""
 
-    def __init__(self, message: str = "Agent error", *, cause: Exception | None = None) -> None:
-        super().__init__(message, is_fatal=True, is_retryable=False, cause=cause)
+    def __init__(
+        self,
+        message: str = "Agent error",
+        *,
+        cause: Exception | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message, is_fatal=True, is_retryable=False, cause=cause, context=context)

--- a/python/beeai_framework/backend/errors.py
+++ b/python/beeai_framework/backend/errors.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any
 
 from beeai_framework.errors import FrameworkError
 
@@ -24,15 +25,28 @@ class BackendError(FrameworkError):
         is_fatal: bool = True,
         is_retryable: bool = False,
         cause: Exception | None = None,
+        context: dict[str, Any] | None = None,
     ) -> None:
-        super().__init__(message, is_fatal=is_fatal, is_retryable=is_retryable, cause=cause)
+        super().__init__(message, is_fatal=is_fatal, is_retryable=is_retryable, cause=cause, context=context)
 
 
 class ChatModelError(BackendError):
-    def __init__(self, message: str = "Chat Model error", *, cause: Exception | None = None) -> None:
-        super().__init__(message, is_fatal=True, is_retryable=False, cause=cause)
+    def __init__(
+        self,
+        message: str = "Chat Model error",
+        *,
+        cause: Exception | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message, is_fatal=True, is_retryable=False, cause=cause, context=context)
 
 
 class MessageError(FrameworkError):
-    def __init__(self, message: str = "Message Error", *, cause: Exception | None = None) -> None:
-        super().__init__(message, is_fatal=True, is_retryable=False, cause=cause)
+    def __init__(
+        self,
+        message: str = "Message Error",
+        *,
+        cause: Exception | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message, is_fatal=True, is_retryable=False, cause=cause, context=context)

--- a/python/beeai_framework/emitter/errors.py
+++ b/python/beeai_framework/emitter/errors.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any
 
 from beeai_framework.errors import FrameworkError
 
@@ -19,5 +20,11 @@ from beeai_framework.errors import FrameworkError
 class EmitterError(FrameworkError):
     """Raised for errors caused by emitters."""
 
-    def __init__(self, message: str = "Emitter error", *, cause: Exception | None = None) -> None:
-        super().__init__(message, is_fatal=True, is_retryable=False, cause=cause)
+    def __init__(
+        self,
+        message: str = "Emitter error",
+        *,
+        cause: Exception | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message, is_fatal=True, is_retryable=False, cause=cause, context=context)

--- a/python/beeai_framework/errors.py
+++ b/python/beeai_framework/errors.py
@@ -143,4 +143,4 @@ class AbortError(FrameworkError, CancelledError):
         cause: BaseException | None = None,
         context: dict[str, Any] | None = None,
     ) -> None:
-        super().__init__(message, is_fatal=True, is_retryable=False, cause=cause, context=context or {})
+        super().__init__(message, is_fatal=True, is_retryable=False, cause=cause, context=context)

--- a/python/beeai_framework/errors.py
+++ b/python/beeai_framework/errors.py
@@ -12,19 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 from asyncio import CancelledError
 from collections.abc import Generator
+from typing import Any
 
 
 def _format_error_message(e: BaseException, *, offset: int = 0, strip_traceback: bool = True) -> str:
     cls = type(e).__name__
     module = type(e).__module__
-
     prefix = "  " * offset
     formatted = f"{cls}({module}): {e!s}"
+    if isinstance(e, FrameworkError) and e.context:
+        try:
+            # Directly use json.dumps, with sort_keys for consistent output.
+            context_json: str = json.dumps(e.context, sort_keys=True)
+            formatted += f"\n{prefix}Context: {context_json}"
+        except TypeError:
+            # Handle serialization errors gracefully.
+            formatted += f'\n{prefix}Context: "Cannot serialize context to JSON"'
     if strip_traceback:
         formatted = formatted.split("\nTraceback")[0]
-
     return "\n".join([f"{prefix}{line}" for line in formatted.split("\n")])
 
 
@@ -41,14 +49,17 @@ class FrameworkError(Exception):
         is_fatal: bool = False,
         is_retryable: bool = True,
         cause: BaseException | None = None,
+        context: dict[str, Any] | None = None,
     ) -> None:
         super().__init__(message)
 
         self.message = message
         self.fatal = is_fatal
         self.retryable = is_retryable
-        self._predecessor = cause
+        # Only set _predecessor if cause is a FrameworkError
+        self._predecessor = cause if isinstance(cause, FrameworkError) else None
         self.__cause__ = cause
+        self.context = context or {}
 
     @property
     def predecessor(self) -> BaseException | None:
@@ -85,7 +96,7 @@ class FrameworkError(Exception):
         return False
 
     def traverse(self) -> Generator["FrameworkError", None, None]:
-        next: FrameworkError | BaseException | None = self
+        next: FrameworkError | BaseException | None = self  # Use | for union
         while isinstance(next, FrameworkError):
             yield next
             next = next.predecessor
@@ -125,5 +136,11 @@ class FrameworkError(Exception):
 class AbortError(FrameworkError, CancelledError):
     """Raised when an operation has been aborted."""
 
-    def __init__(self, message: str = "Operation has been aborted!", *, cause: BaseException | None = None) -> None:
-        super().__init__(message, is_fatal=True, is_retryable=False, cause=cause)
+    def __init__(
+        self,
+        message: str = "Operation has been aborted!",
+        *,
+        cause: BaseException | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message, is_fatal=True, is_retryable=False, cause=cause, context=context or {})

--- a/python/beeai_framework/logger.py
+++ b/python/beeai_framework/logger.py
@@ -26,8 +26,14 @@ from beeai_framework.utils.events import MessageEvent
 class LoggerError(FrameworkError):
     """Raised for errors caused by logging."""
 
-    def __init__(self, message: str = "Logger error", *, cause: Exception | None = None) -> None:
-        super().__init__(message, is_fatal=True, is_retryable=False, cause=cause)
+    def __init__(
+        self,
+        message: str = "Logger error",
+        *,
+        cause: Exception | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message, is_fatal=True, is_retryable=False, cause=cause, context=context)
 
 
 class LoggerFormatter(Formatter):

--- a/python/beeai_framework/memory/errors.py
+++ b/python/beeai_framework/memory/errors.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any
 
 from beeai_framework.errors import FrameworkError
 
@@ -26,19 +27,32 @@ class ResourceError(FrameworkError):
         is_fatal: bool = False,
         is_retryable: bool = False,
         cause: Exception | None = None,
+        context: dict[str, Any] | None = None,
     ) -> None:
-        super().__init__(message, is_fatal=is_fatal, is_retryable=is_retryable, cause=cause)
+        super().__init__(message, is_fatal=is_fatal, is_retryable=is_retryable, cause=cause, context=context)
 
 
 class ResourceFatalError(ResourceError):
     """Fatal memory errors that cannot be recovered from."""
 
-    def __init__(self, message: str = "Memory error - fatal", *, cause: Exception | None = None) -> None:
-        super().__init__(message, is_fatal=True, is_retryable=False, cause=cause)
+    def __init__(
+        self,
+        message: str = "Memory error - fatal",
+        *,
+        cause: Exception | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message, is_fatal=True, is_retryable=False, cause=cause, context=context)
 
 
 class SerializerError(FrameworkError):
     """Raised for errors caused by serializer."""
 
-    def __init__(self, message: str = "Serializer error", *, cause: Exception | None = None) -> None:
-        super().__init__(message, is_fatal=True, is_retryable=False, cause=cause)
+    def __init__(
+        self,
+        message: str = "Serializer error",
+        *,
+        cause: Exception | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message, is_fatal=True, is_retryable=False, cause=cause, context=context)

--- a/python/beeai_framework/template.py
+++ b/python/beeai_framework/template.py
@@ -71,5 +71,11 @@ class PromptTemplate(Generic[T]):
 class PromptTemplateError(FrameworkError):
     """Raised for errors caused by PromptTemplate."""
 
-    def __init__(self, message: str = "PromptTemplate error", *, cause: Exception | None = None) -> None:
-        super().__init__(message, is_fatal=True, is_retryable=False, cause=cause)
+    def __init__(
+        self,
+        message: str = "PromptTemplate error",
+        *,
+        cause: Exception | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message, is_fatal=True, is_retryable=False, cause=cause, context=context)

--- a/python/beeai_framework/tools/errors.py
+++ b/python/beeai_framework/tools/errors.py
@@ -12,18 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any
+
 from pydantic import ValidationError
 
 from beeai_framework.errors import FrameworkError
 
 
 class ToolError(FrameworkError):
-    def __init__(self, message: str = "Tool Error", *, cause: Exception | None = None) -> None:
-        super().__init__(message, is_fatal=True, is_retryable=False, cause=cause)
+    def __init__(
+        self,
+        message: str = "Tool Error",
+        *,
+        cause: Exception | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message, is_fatal=True, is_retryable=False, cause=cause, context=context)
 
 
 class ToolInputValidationError(ToolError):
     def __init__(
-        self, message: str = "Tool Input Validation Error", *, cause: ValidationError | ValueError | None = None
+        self,
+        message: str = "Tool Input Validation Error",
+        *,
+        cause: ValidationError | ValueError | None = None,
+        context: dict[str, Any] | None = None,
     ) -> None:
-        super().__init__(message, cause=cause)
+        super().__init__(message, cause=cause, context=context)

--- a/python/beeai_framework/utils/errors.py
+++ b/python/beeai_framework/utils/errors.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any
 
 from beeai_framework.errors import FrameworkError
 
@@ -19,5 +20,11 @@ from beeai_framework.errors import FrameworkError
 class LoggerError(FrameworkError):
     """Raised for errors caused by logging."""
 
-    def __init__(self, message: str = "Logger error", *, cause: Exception | None = None) -> None:
-        super().__init__(message, is_fatal=True, is_retryable=False, cause=cause)
+    def __init__(
+        self,
+        message: str = "Logger error",
+        *,
+        cause: Exception | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message, is_fatal=True, is_retryable=False, cause=cause, context=context)

--- a/python/beeai_framework/workflows/errors.py
+++ b/python/beeai_framework/workflows/errors.py
@@ -12,10 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any
 
 from beeai_framework.errors import FrameworkError
 
 
 class WorkflowError(FrameworkError):
-    def __init__(self, message: str = "Workflow error", *, cause: Exception | None = None) -> None:
-        super().__init__(message, is_fatal=True, is_retryable=False, cause=cause)
+    def __init__(
+        self,
+        message: str = "Workflow error",
+        *,
+        cause: Exception | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message, is_fatal=True, is_retryable=False, cause=cause, context=context)

--- a/python/docs/errors.md
+++ b/python/docs/errors.md
@@ -32,6 +32,7 @@ Benefits of using `FrameworkError`:
 
 - **Additional properties**: Exceptions may include additional properties to provide a more detailed view of the error.
 - **Preserved error chains**: Retains the full history of errors, giving developers full context for debugging.
+- **Context**: Each error can now contain a dictionary of context, allowing you to store additional values to help the user identify and debug the error.
 - **Utility functions:** Includes methods for formatting error stack traces and explanations, making them suitable for use with LLMs and other external tools.
 - **Native support:** Built on native Python Exceptions functionality, avoiding the need for additional dependencies while leveraging familiar mechanisms.
 
@@ -149,9 +150,10 @@ If you wish to create additional errors, you can extend `FrameworkError` or any 
 ```py
 from beeai_framework.errors import FrameworkError
 
+```py
 class MyCustomError(FrameworkError):
-    def __init__(self, message: str = "My custom error", *, cause: Exception | None = None) -> None:
-        super().__init__(message, is_fatal=True, is_retryable=False, cause=cause)
+    def __init__(self, message: str = "My custom error", *, cause: Exception | None = None, context: dict | None = None) -> None:
+        super().__init__(message, is_fatal=True, is_retryable=False, cause=cause, context=context or {})
 ```
 
 ### Wrapping existing errors

--- a/python/docs/errors.md
+++ b/python/docs/errors.md
@@ -32,7 +32,7 @@ Benefits of using `FrameworkError`:
 
 - **Additional properties**: Exceptions may include additional properties to provide a more detailed view of the error.
 - **Preserved error chains**: Retains the full history of errors, giving developers full context for debugging.
-- **Context**: Each error can now contain a dictionary of context, allowing you to store additional values to help the user identify and debug the error.
+- **Context**: Each error can contain a dictionary of context, allowing you to store additional values to help the user identify and debug the error.
 - **Utility functions:** Includes methods for formatting error stack traces and explanations, making them suitable for use with LLMs and other external tools.
 - **Native support:** Built on native Python Exceptions functionality, avoiding the need for additional dependencies while leveraging familiar mechanisms.
 
@@ -42,18 +42,33 @@ This structure ensures that users can trace the complete error history while cle
 ```py
 from beeai_framework.errors import FrameworkError
 
-error = FrameworkError("Fuction 'getUser' has failed.", is_fatal=True, is_retryable=False)
+# Create the main FrameworkError instance
+error = FrameworkError("Function 'getUser' has failed.", is_fatal=True, is_retryable=False)
 inner_error = FrameworkError("Cannot retrieve data from the API.")
 innermost_error = ValueError("User with Given ID Does not exist!")
 
+# Chain the errors together using __cause__
 inner_error.__cause__ = innermost_error
 error.__cause__ = inner_error
 
+# Set the context dictionary for the top level error
+# Add any additional context here. This will help with debugging
+error.context["workflow"] = "activity_planner"
+error.context["provider"] = "ollama"
+error.context["chat_model"] = "granite3.2:8b"
+
+# Print some properties of the error
+print("\n-- Error properties:")
 print(f"Message: {error.message}")  # Main error message
 # Is the error fatal/retryable?
 print(f"Meta: fatal:{FrameworkError.is_fatal(error)} retryable:{FrameworkError.is_retryable(error)}")
 print(f"Cause: {error.get_cause()}")  # Prints the cause of the error
+print(f"Context: {error.context}")  # Prints the dictionary of the error context
+
+print("\n-- Explain:")
 print(error.explain())  # Human-readable format without stack traces (ideal for LLMs)
+print("\n-- str():")
+print(str(error))  # Human-readable format (for debug)
 
 ```
 
@@ -153,7 +168,7 @@ from beeai_framework.errors import FrameworkError
 ```py
 class MyCustomError(FrameworkError):
     def __init__(self, message: str = "My custom error", *, cause: Exception | None = None, context: dict | None = None) -> None:
-        super().__init__(message, is_fatal=True, is_retryable=False, cause=cause, context=context or {})
+        super().__init__(message, is_fatal=True, is_retryable=False, cause=cause, context=context)
 ```
 
 ### Wrapping existing errors

--- a/python/examples/errors/base.py
+++ b/python/examples/errors/base.py
@@ -1,14 +1,29 @@
 from beeai_framework.errors import FrameworkError
 
-error = FrameworkError("Fuction 'getUser' has failed.", is_fatal=True, is_retryable=False)
+# Create the main FrameworkError instance
+error = FrameworkError("Function 'getUser' has failed.", is_fatal=True, is_retryable=False)
 inner_error = FrameworkError("Cannot retrieve data from the API.")
 innermost_error = ValueError("User with Given ID Does not exist!")
 
+# Chain the errors together using __cause__
 inner_error.__cause__ = innermost_error
 error.__cause__ = inner_error
 
+# Set the context dictionary for the top level error
+# Add any additional context here. This will help with debugging
+error.context["workflow"] = "activity_planner"
+error.context["provider"] = "ollama"
+error.context["chat_model"] = "granite3.2:8b"
+
+# Print some properties of the error
+print("\n-- Error properties:")
 print(f"Message: {error.message}")  # Main error message
 # Is the error fatal/retryable?
 print(f"Meta: fatal:{FrameworkError.is_fatal(error)} retryable:{FrameworkError.is_retryable(error)}")
 print(f"Cause: {error.get_cause()}")  # Prints the cause of the error
+print(f"Context: {error.context}")  # Prints the dictionary of the error context
+
+print("\n-- Explain:")
 print(error.explain())  # Human-readable format without stack traces (ideal for LLMs)
+print("\n-- str():")
+print(str(error))  # Human-readable format (for debug)

--- a/python/tests/errors_test.py
+++ b/python/tests/errors_test.py
@@ -12,138 +12,193 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from asyncio import CancelledError
+from typing import Any
 
 import pytest
 
-from beeai_framework.errors import (
-    FrameworkError,
-)
+from beeai_framework.errors import AbortError, FrameworkError
 
-"""
-Unit Tests
-"""
+
+class CustomError(FrameworkError):
+    """A custom subclass of FrameworkError for testing."""
+
+    def __init__(
+        self,
+        message: str = "Custom error",
+        *,
+        cause: BaseException | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message, is_fatal=False, is_retryable=True, cause=cause, context=context)
 
 
 class TestFrameworkError:
-    """
-    Test cases for Framework Error
-
-    Note that FrameworkError does not support passing cause on constructor.
-    In these tests this is setup directly by assigning error.__cause__
-    In consuming code we expect to use 'raise ValueError("Calculation failed") from e'
-    """
-
-    # TODO: Add test methods that create actual exceptions
-    # TODO: Update direct setting of __cause__ after instantiation with use of constructor
-
     @pytest.mark.unit
     def test_basic_exception(self) -> None:
-        err = FrameworkError("Basic")
-        assert err.message == "Basic"
-        assert FrameworkError.is_fatal(err) is False
-        assert FrameworkError.is_retryable(err) is True
-        # Will be this exception or exception at end of chain
-        assert err.get_cause() == err
-        assert err.name() == "FrameworkError"
+        err = FrameworkError("Test error")
+        assert str(err) == "Test error"
+        assert err.message == "Test error"
 
     @pytest.mark.unit
     def test_custom_properties(self) -> None:
-        err = FrameworkError("Custom", is_fatal=False, is_retryable=False)
-        assert err.fatal is False
-        assert FrameworkError.is_retryable(err) is False
+        err = FrameworkError("Test error", is_fatal=True, is_retryable=False)
+        assert err.fatal is True
+        assert err.retryable is False
 
-    # Get cause returns the last exception in the chain - *itself* otherwise
     @pytest.mark.unit
     def test_cause_single(self) -> None:
-        err = FrameworkError("Error")
-        assert err.get_cause() == err
-
-    @pytest.mark.unit
-    def test_cause(self) -> None:
-        # Often a standard exception will be the original cause
         inner_err = ValueError("Inner")
-        err = FrameworkError("Outer")
-        err.__cause__ = inner_err
+        err = FrameworkError("Outer", cause=inner_err)
+        assert err.__cause__ == inner_err
+        assert err.predecessor == inner_err
         assert err.get_cause() == inner_err
 
     @pytest.mark.unit
+    def test_cause(self) -> None:
+        inner_err1 = ValueError("Inner1")
+        inner_err2 = TypeError("Inner2")
+        err1 = FrameworkError("Outer1", cause=inner_err1)
+        err2 = FrameworkError("Outer2", cause=inner_err2)
+        err1.__cause__ = err2
+
+        assert err1.__cause__ == err2
+        assert err1.predecessor == err2
+        assert err2.__cause__ == inner_err2
+        assert err2.predecessor == inner_err2
+        assert err1.get_cause() == inner_err2
+
+    @pytest.mark.unit
     def test_has_fatal_error(self) -> None:
-        err = FrameworkError("Fatal", is_fatal=True)
+        inner_err = FrameworkError("Inner", is_fatal=True)
+        err = FrameworkError("Outer", cause=inner_err)
         assert err.has_fatal_error() is True
 
-        err2 = FrameworkError("Non-fatal", is_fatal=False)
-        assert err2.has_fatal_error() is False
+        inner_err = ValueError("Inner")  # type: ignore[assignment]
+        err = FrameworkError("Outer", is_fatal=False, cause=inner_err)
+        assert err.has_fatal_error() is False
 
-        inner_err = ValueError("Inner error")
-        err3 = FrameworkError("Outer non-fatal", is_fatal=False)
-        err3.__cause__ = inner_err
-        assert err3.has_fatal_error() is False
-
-        inner_err2 = FrameworkError("Inner fatal", is_fatal=True)
-        err4 = FrameworkError("Outer non-fatal", is_fatal=False)
-        err4.__cause__ = inner_err2
-        assert err4.has_fatal_error() is True
+        inner_err2 = FrameworkError("Inner2", is_fatal=True)
+        inner_err1 = FrameworkError("Inner1", cause=inner_err2)
+        err = FrameworkError("Outer", cause=inner_err1)
+        assert err.has_fatal_error() is True
 
     @pytest.mark.unit
     def test_traverse_errors(self) -> None:
-        # Simple - one level of nesting - so 2 in total
-        inner_err = ValueError("error 2")
-        err = FrameworkError("error 1")
-        err.__cause__ = inner_err
-        errors: list[Exception] = list(err.traverse())
+        inner_err = ValueError("Inner")
+        err = FrameworkError("Outer", cause=inner_err)
+
+        errors: list[BaseException] = list(err.traverse())
         assert len(errors) == 1
-        assert err in errors
-        assert inner_err not in errors
-        assert err.predecessor == inner_err
+        assert errors[0] == err
 
-        # Test deeper nesting - 4
-        err4 = ValueError("error 4")
-        err3 = FrameworkError("error 3")
-        err3.__cause__ = err4
-        err2 = FrameworkError("error 2")
-        err2.__cause__ = err3
-        err1 = FrameworkError("error 1")
-        err1.__cause__ = err2
-        errors = list(err1.traverse())
+        inner_err2 = FrameworkError("inner2")
+        inner_err1 = FrameworkError("inner", cause=inner_err2)
+        err = FrameworkError("outer", cause=inner_err1)
+        errors = list(err.traverse())
         assert len(errors) == 3
-        assert err1 in errors
-        assert err2 in errors
-        assert err3 in errors
-        assert err4 not in errors
-        assert err3.predecessor == err4
-        assert err2.predecessor == err3
-        assert err1.predecessor == err2
+        assert errors[0] == err
+        assert errors[1] == inner_err1
+        assert errors[2] == inner_err2
 
-    # @unittest.skip("TODO: Skip as message ie str(err) needs to be used in dump/explain")
     @pytest.mark.unit
     def test_explain(self) -> None:
         inner_err = ValueError("Inner")
         err = FrameworkError("Outer")
         err.__cause__ = inner_err
-        explanation = err.explain()
-        assert explanation == "FrameworkError(beeai_framework.errors): Outer\n  ValueError(builtins): Inner"
+        err.context = {"key1": "value1", "key2": "value2"}
+        explanation: str = err.explain()
+        assert 'Outer\nContext: {"key1": "value1", "key2": "value2"}' in explanation
+        assert "ValueError(builtins): Inner" in explanation
 
-        # Test with an exception that doesn't have a 'message' attribute (not all do)
-        class NoMessageError(Exception):
-            pass
-
-        inner_err2 = NoMessageError()
-        err2 = FrameworkError("Outer error")
-        err2.__cause__ = inner_err2
-        explanation2 = err2.explain()
-        assert (
-            explanation2 == "FrameworkError(beeai_framework.errors): Outer error\n  NoMessageError(tests.errors_test):"
-        )
-
-    # @unittest.skip("TODO: Skip as wrapped exception is not implemented correctly")
     @pytest.mark.unit
     def test_ensure(self) -> None:
-        inner_err = ValueError("Value error")
-        wrapped_err = FrameworkError.ensure(inner_err)
-        assert isinstance(wrapped_err, FrameworkError)
-        assert wrapped_err.get_cause() == inner_err
+        # Test that ValueError is converted to FrameworkError
+        value_error = ValueError("Test ensure")
+        framework_error = FrameworkError.ensure(value_error)
+        assert isinstance(framework_error, FrameworkError)
+        assert framework_error.predecessor == value_error
+        assert framework_error.message == "Framework error"  # default
 
-        # Ensure doesn't re-wrap a FrameworkError
-        fw_err = FrameworkError("Already a FrameworkError")
-        wrapped_fw_err = FrameworkError.ensure(fw_err)
-        assert wrapped_fw_err == fw_err  # Check it returns the original.
+        # Test that CancelledError is converted to AbortError
+        cancelled_error = CancelledError()
+        abort_error = FrameworkError.ensure(cancelled_error)  # type: ignore[arg-type]
+        assert isinstance(abort_error, AbortError)
+        assert abort_error.predecessor == cancelled_error
+
+        # Test that FrameworkError is returned unchanged
+        existing_framework_error = FrameworkError("Existing error")
+        returned_error = FrameworkError.ensure(existing_framework_error)
+        assert returned_error is existing_framework_error  # Check for same object
+
+    @pytest.mark.unit
+    def test_set_context(self) -> None:
+        err = FrameworkError("Simple context", context={"key1": "value1"})
+        assert 'Simple context\nContext: {"key1": "value1"}' in err.explain()
+
+    @pytest.mark.unit
+    def test_context_subclass(self) -> None:
+        err = AbortError("Simple context", cause=ValueError("a value error"), context={"key1": "value1"})
+        assert 'Simple context\nContext: {"key1": "value1"}' in err.explain()
+
+    @pytest.mark.unit
+    def test_context_custom_subclass(self) -> None:
+        err = CustomError("Simple context", cause=ValueError("a value error"), context={"key1": "value1"})
+        assert 'Simple context\nContext: {"key1": "value1"}' in err.explain()
+
+    @pytest.mark.unit
+    def test_json_context(self) -> None:
+        err1 = FrameworkError("JSON context test", context={"a": 1, "b": [2, 3], "c": "string"})
+        assert 'Context: {"a": 1, "b": [2, 3], "c": "string"}' in err1.explain()
+
+        err2 = FrameworkError("String context test", context={"data": "some_string"})
+        assert 'Context: {"data": "some_string"}' in err2.explain()
+
+        def my_func() -> None:
+            pass
+
+        err3 = FrameworkError("Unserializable", context={"func": my_func})
+        assert 'Context: "Cannot serialize context to JSON"' in err3.explain()
+
+        err4 = FrameworkError("Empty Context", context={})
+        assert "Context:" not in err4.explain()
+
+        err5 = FrameworkError("None Context", context=None)
+        assert "Context:" not in err5.explain()
+
+        err6 = FrameworkError("Mixed Context", context={"a": 1, "b": my_func})
+        assert 'Context: "Cannot serialize context to JSON"' in err6.explain()
+
+    def test_is_fatal(self) -> None:
+        err = FrameworkError("Test", is_fatal=True)
+        assert FrameworkError.is_fatal(err) is True
+
+        err = FrameworkError("Test", is_fatal=False)
+        assert FrameworkError.is_fatal(err) is False
+
+        # We need to be able to pass Exceptions here as well, so ignore the assignment error
+        err = ValueError("Test")  # type: ignore[assignment]
+        assert FrameworkError.is_fatal(err) is False
+
+    def test_is_retryable(self) -> None:
+        err = FrameworkError("Test", is_retryable=True)
+        assert FrameworkError.is_retryable(err) is True
+
+        err = FrameworkError("Test", is_retryable=False)
+        assert FrameworkError.is_retryable(err) is False
+
+        err = ValueError("Test")  # type: ignore[assignment]
+        assert FrameworkError.is_retryable(err) is True
+
+        err = CancelledError("Cancelled")  # type: ignore[assignment]
+        assert FrameworkError.is_retryable(err) is False
+
+    def test_name(self) -> None:
+        err = FrameworkError("Test")
+        assert err.name() == "FrameworkError"
+
+        err = AbortError("Abort Test")
+        assert err.name() == "AbortError"
+
+        err = CustomError("Custom Test")
+        assert err.name() == "CustomError"


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review and complete the sections below.
-->

### Which issue(s) does this pull-request address?

<!--
Please include a link to an issue in the tracker.  The issue describes the problem to be solved.  If there is no issue raised for this PR then either raise one with a summary and description of the problem or add a summary and description of the problem here
-->

Closes: #510

### Description

Adds support for additional 'context' to be associated with an error.

Updated implementation, docs, testcase, example

Example output (from the base error example):
```
(beeai-framework-py3.13) ➜  python git:(context) ✗ /Users/jonesn/AI/bee/beeai-framework/python/.venv/bin/python /Users/jonesn/AI/bee/beeai-framework/python/examples/errors/base.py
Message: Function 'getUser' has failed.
Meta: fatal:True retryable:False
Cause: User with Given ID Does not exist!
FrameworkError(beeai_framework.errors): Function 'getUser' has failed.
  FrameworkError(beeai_framework.errors): Cannot retrieve data from the API.
    ValueError(builtins): User with Given ID Does not exist!
Context: {'workflow': 'activity_planner', 'provider': 'ollama', 'chat_model': 'granite3.2:8b'}
```

STILL TO DO
- [x] Updates to explain/dump 
- [x] Resolve many mypi errors (not in modified code) - needed to use `-n` on commit for draft 

**Note that this PR does not update our existing errors which subclass FrameworkError, nor their invocations which need updating to pull in relevant context**

<!-- Provide a description of the change, pay special attention to describing any breaking changes.  The description describes the resolution to the problem described in the linked issue (or to the problem outlined in this PR). -->

### Checklist

#### General
- [x] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [x] Linting passes: Python `poe lint` or `poe lint --fix` / TypeScript `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: Python `poe format` or `poe format --fix` / TypeScript: `yarn format` or `yarn format:fix`
- [x] Static type checks pass: Python `poe type-check`

#### Testing
- [x] Unit tests pass: Python `poe test --type unit` / TypeScript `yarn test:unit`
- [x] E2E tests pass: Python `poe test --type e2e` / TypeScript: `yarn test:e2e`
- [x] Integration tests pass: Python `poe test --type integration`
- [x] Tests are included (for bug fixes or new features)

#### Documentation
- [x] Documentation is updated
- [x] Embedme embeds code examples in docs. To update after edits, run: Python `poe docs --type build`
