### PR TITLE
fix(tools): avoid session management in mcp tool

### DIFF
--- a/python/docs/tools.md
+++ b/python/docs/tools.md
@@ -369,13 +369,14 @@ async def slack_tool() -> MCPTool:
     async with stdio_client(server_params) as (read, write), ClientSession(read, write) as session:
         await session.initialize()
         # Discover Slack tools via MCP client
-        slacktools = await MCPTool.from_client(session, server_params)
+        slacktools = await MCPTool.from_client(session)
         filter_tool = filter(lambda tool: tool.name == "slack_post_message", slacktools)
         slack = list(filter_tool)
         return slack[0]
 
 
 agent = ReActAgent(llm=OllamaChatModel("llama3.1"), tools=[asyncio.run(slack_tool())], memory=UnconstrainedMemory())
+
 ```
 
 _Source: [/python/examples/tools/mcp_tool_creation.py](/python/examples/tools/mcp_tool_creation.py)_

--- a/python/examples/tools/mcp_agent.py
+++ b/python/examples/tools/mcp_agent.py
@@ -18,6 +18,7 @@ from beeai_framework.errors import FrameworkError
 from beeai_framework.logger import Logger
 from beeai_framework.memory.token_memory import TokenMemory
 from beeai_framework.tools.mcp_tools import MCPTool
+from beeai_framework.tools.tool import AnyTool
 from examples.helpers.io import ConsoleReader
 
 # Load environment variables
@@ -55,7 +56,7 @@ async def create_agent(session: ClientSession) -> ReActAgent:
 
     # Configure tools
     slacktools = await MCPTool.from_client(session)
-    tools = filter(lambda tool: tool.name == "slack_post_message", slacktools)
+    tools: list[AnyTool] = list(filter(lambda tool: tool.name == "slack_post_message", slacktools))
 
     # Create agent with memory and tools
     agent = ReActAgent(llm=llm, tools=tools, memory=TokenMemory(llm))

--- a/python/examples/tools/mcp_agent.py
+++ b/python/examples/tools/mcp_agent.py
@@ -45,7 +45,7 @@ async def slack_tool() -> MCPTool:
     async with stdio_client(server_params) as (read, write), ClientSession(read, write) as session:
         await session.initialize()
         # Discover Slack tools via MCP client
-        slacktools = await MCPTool.from_client(session, server_params)
+        slacktools = await MCPTool.from_client(session)
         filter_tool = filter(lambda tool: tool.name == "slack_post_message", slacktools)
         slack = list(filter_tool)
         return slack[0]

--- a/python/examples/tools/mcp_agent.py
+++ b/python/examples/tools/mcp_agent.py
@@ -80,7 +80,7 @@ def process_agent_events(data: Any, event: EventMeta) -> None:
     elif event.name == "retry":
         reader.write("Agent 🤖 : ", "retrying the action...")
     elif event.name == "update":
-        reader.write(f"Agent({data.update.key}) 🤖 : ", data.update.parsedValue)
+        reader.write(f"Agent({data.update.key}) 🤖 : ", data.update.parsed_value)
     elif event.name == "start":
         reader.write("Agent 🤖 : ", "starting new iteration")
     elif event.name == "success":

--- a/python/examples/tools/mcp_agent.py
+++ b/python/examples/tools/mcp_agent.py
@@ -18,7 +18,6 @@ from beeai_framework.errors import FrameworkError
 from beeai_framework.logger import Logger
 from beeai_framework.memory.token_memory import TokenMemory
 from beeai_framework.tools.mcp_tools import MCPTool
-from beeai_framework.tools.tool import AnyTool
 from examples.helpers.io import ConsoleReader
 
 # Load environment variables
@@ -57,7 +56,6 @@ async def create_agent(session: ClientSession) -> ReActAgent:
     # Configure tools
     slacktools = await MCPTool.from_client(session)
     tools = filter(lambda tool: tool.name == "slack_post_message", slacktools)
-
 
     # Create agent with memory and tools
     agent = ReActAgent(llm=llm, tools=tools, memory=TokenMemory(llm))

--- a/python/examples/tools/mcp_tool_creation.py
+++ b/python/examples/tools/mcp_tool_creation.py
@@ -28,7 +28,7 @@ async def slack_tool() -> MCPTool:
     async with stdio_client(server_params) as (read, write), ClientSession(read, write) as session:
         await session.initialize()
         # Discover Slack tools via MCP client
-        slacktools = await MCPTool.from_client(session, server_params)
+        slacktools = await MCPTool.from_client(session)
         filter_tool = filter(lambda tool: tool.name == "slack_post_message", slacktools)
         slack = list(filter_tool)
         return slack[0]

--- a/python/tests/tools/test_mcp_tool.py
+++ b/python/tests/tools/test_mcp_tool.py
@@ -90,9 +90,9 @@ class TestMCPTool:
     @pytest.mark.asyncio
     @pytest.mark.unit
     async def test_mcp_tool_initialization(
-        self, mock_server_params: StdioServerParameters, mock_tool_info: MCPToolInfo
+        self, mock_client_session: ClientSession, mock_tool_info: MCPToolInfo
     ) -> None:
-        tool = MCPTool(server_params=mock_server_params, tool=mock_tool_info)
+        tool = MCPTool(session=mock_client_session, tool=mock_tool_info)
 
         assert tool.name == "test_tool"
         assert tool.description == "A test tool"
@@ -103,12 +103,12 @@ class TestMCPTool:
     async def test_mcp_tool_run(  # type: ignore
         self,
         mock__run,  # noqa: ANN001
-        mock_server_params: StdioServerParameters,
+        mock_client_session: ClientSession,
         mock_tool_info: MCPToolInfo,
         call_tool_result: str,
     ) -> None:
         mock__run.return_value = StringToolOutput(str(call_tool_result))
-        tool = MCPTool(server_params=mock_server_params, tool=mock_tool_info)
+        tool = MCPTool(session=mock_client_session, tool=mock_tool_info)
         input_data = {"a": 1, "b": 2}
 
         result = await tool.run(input_data)
@@ -118,14 +118,12 @@ class TestMCPTool:
 
     @pytest.mark.asyncio
     @pytest.mark.unit
-    async def test_mcp_tool_from_client(
-        self, mock_client_session: ClientSession, mock_server_params: StdioServerParameters, mock_tool_info: MCPToolInfo
-    ) -> None:
+    async def test_mcp_tool_from_client(self, mock_client_session: ClientSession, mock_tool_info: MCPToolInfo) -> None:
         tools_result = MagicMock()
         tools_result.tools = [mock_tool_info]
         mock_client_session.list_tools = AsyncMock(return_value=tools_result)  # type: ignore
 
-        tools = await MCPTool.from_client(mock_client_session, server_params=mock_server_params)
+        tools = await MCPTool.from_client(mock_client_session)
 
         mock_client_session.list_tools.assert_awaited_once()
         assert len(tools) == 1
@@ -141,12 +139,12 @@ class TestAddNumbersTool:
     async def test_add_numbers_mcp(  # type: ignore
         self,
         mock__run,  # noqa: ANN001
-        mock_server_params: StdioServerParameters,
+        mock_client_session: ClientSession,
         add_numbers_tool_info: MCPToolInfo,
         add_result: Callable[..., Any],
     ) -> None:
         mock__run.return_value = StringToolOutput(str(add_result))
-        tool = MCPTool(server_params=mock_server_params, tool=add_numbers_tool_info)
+        tool = MCPTool(session=mock_client_session, tool=add_numbers_tool_info)
         input_data = {"a": 5, "b": 3}
 
         result = await tool.run(input_data)
@@ -158,14 +156,13 @@ class TestAddNumbersTool:
     async def test_add_numbers_from_client(
         self,
         mock_client_session: ClientSession,
-        mock_server_params: StdioServerParameters,
         add_numbers_tool_info: MCPToolInfo,
     ) -> None:
         tools_result = MagicMock()
         tools_result.tools = [add_numbers_tool_info]
         mock_client_session.list_tools = AsyncMock(return_value=tools_result)  # type: ignore
 
-        tools = await MCPTool.from_client(mock_client_session, server_params=mock_server_params)
+        tools = await MCPTool.from_client(mock_client_session)
 
         mock_client_session.list_tools.assert_awaited_once()
         assert len(tools) == 1


### PR DESCRIPTION
Signed-off-by: Tomas Pilar <tomas.pilar@apoco.com>

<!--
Thank you for your pull request. Please review and complete the sections below.
-->

### Which issue(s) does this pull-request address?

<!--
Please include a link to an issue in the tracker.  The issue describes the problem to be solved.  If there is no issue raised for this PR then either raise one with a summary and description of the problem or add a summary and description of the problem here
-->

Closes: #566 

### Description

<!-- Provide a description of the change, pay special attention to describing any breaking changes.  The description describes the resolution to the problem described in the linked issue (or to the problem outlined in this PR). -->

### Checklist

#### General
- [ ] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [ ] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [ ] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [ ] Linting passes: Python `poe lint` or `poe lint --fix` / TypeScript `yarn lint` or `yarn lint:fix`
- [ ] Formatting is applied: Python `poe format` or `poe format --fix` / TypeScript: `yarn format` or `yarn format:fix`
- [ ] Static type checks pass: Python `poe type-check`

#### Testing
- [ ] Unit tests pass: Python `poe test --type unit` / TypeScript `yarn test:unit`
- [ ] E2E tests pass: Python `poe test --type e2e` / TypeScript: `yarn test:e2e`
- [ ] Integration tests pass: Python `poe test --type integration`
- [ ] Tests are included (for bug fixes or new features)

#### Documentation
- [ ] Documentation is updated
- [ ] Embedme embeds code examples in docs. To update after edits, run: Python `poe docs --type build`
