### PR TITLE
Align backend environment variable usage with typescript (>> LiteLLM)

### DIFF
--- a/python/.env.example
+++ b/python/.env.example
@@ -14,9 +14,12 @@ BEEAI_LOG_LEVEL=INFO
 ### watsonx specific configuration
 ########################
 
-# WATSONX_URL=your-watsonx-instance-base-url
 # WATSONX_PROJECT_ID=your-watsonx-project-id
 # WATSONX_API_KEY=your-watsonx-api-key
+#
+# Either
+# WATSONX_URL=
+# WATSONX_REGION=
 
 ########################
 ### Ollama specific configuration
@@ -45,7 +48,7 @@ BEEAI_LOG_LEVEL=INFO
 
 # GOOGLE_VERTEX_CHAT_MODEL=gemini-2.0-flash-lite-001
 # GOOGLE_VERTEX_PROJECT=""
-# GOOGLE_VERTEX_ENDPOINT=""
+# GOOGLE_VERTEX_LOCATION=""
 
 ########################
 ### Amazon Bedrock specific configuration
@@ -53,7 +56,7 @@ BEEAI_LOG_LEVEL=INFO
 
 # AWS_ACCESS_KEY_ID=
 # AWS_SECRET_ACCESS_KEY=
-# AWS_REGION_NAME=
+# AWS_REGION=
 # AWS_CHAT_MODEL=
 
 ########################

--- a/python/beeai_framework/adapters/amazon_bedrock/backend/README.md
+++ b/python/beeai_framework/adapters/amazon_bedrock/backend/README.md
@@ -6,7 +6,7 @@ Set the following environment variables
 
 * AWS_ACCESS_KEY_ID
 * AWS_SECRET_ACCESS_KEY
-* AWS_REGION_NAME
+* AWS_REGION
 
 ## Tested Models
 

--- a/python/beeai_framework/adapters/amazon_bedrock/backend/chat.py
+++ b/python/beeai_framework/adapters/amazon_bedrock/backend/chat.py
@@ -45,11 +45,11 @@ class AmazonBedrockChatModel(LiteLLMChatModel):
                 + "or set AWS_SECRET_ACCESS_KEY environment variable"
             )
 
-        aws_region_name = _settings.get("aws_region_name", os.getenv("AWS_REGION_NAME"))
+        aws_region_name = _settings.get("aws_region_name", os.getenv("AWS_REGION"))
         if not aws_region_name:
             raise ValueError(
                 "Region is required for Amazon Bedrock model. Specify *aws_region_name* "
-                + "or set AWS_REGION_NAME environment variable"
+                + "or set AWS_REGION environment variable"
             )
 
         super().__init__(

--- a/python/beeai_framework/adapters/amazon_bedrock/backend/chat.py
+++ b/python/beeai_framework/adapters/amazon_bedrock/backend/chat.py
@@ -45,11 +45,17 @@ class AmazonBedrockChatModel(LiteLLMChatModel):
                 + "or set AWS_SECRET_ACCESS_KEY environment variable"
             )
 
-        aws_region_name = _settings.get("aws_region_name", os.getenv("AWS_REGION"))
+        # Determine region name with the specified precedence
+        aws_region_name = _settings.get("aws_region_name")
+        if not aws_region_name:
+            aws_region_name = os.getenv("AWS_REGION")
+        if not aws_region_name:
+            aws_region_name = os.getenv("AWS_REGION_NAME")
+
         if not aws_region_name:
             raise ValueError(
-                "Region is required for Amazon Bedrock model. Specify *aws_region_name* "
-                + "or set AWS_REGION environment variable"
+                "Region is required for Amazon Bedrock model. Specify *aws_region_name* in settings, "
+                + "set the AWS_REGION environment variable, or set the AWS_REGION_NAME environment variable."
             )
 
         super().__init__(

--- a/python/beeai_framework/adapters/openai/backend/chat.py
+++ b/python/beeai_framework/adapters/openai/backend/chat.py
@@ -53,7 +53,7 @@ class OpenAIChatModel(LiteLLMChatModel):
             settings=_settings,
         )
         self._settings["extra_headers"] = utils.parse_extra_headers(
-            self._settings.get("extra_headers"), os.getenv("OPENAI_EXTRA_HEADERS")
+            self._settings.get("extra_headers"), os.getenv("OPENAI_API_HEADERS")
         )
 
         pass

--- a/python/beeai_framework/adapters/vertexai/backend/chat.py
+++ b/python/beeai_framework/adapters/vertexai/backend/chat.py
@@ -31,12 +31,14 @@ class VertexAIChatModel(LiteLLMChatModel):
     def __init__(self, model_id: str | None = None, settings: dict[str, Any] | None = None) -> None:
         _settings = settings.copy() if settings is not None else {}
 
-        vertexai_project = _settings.get("vertexai_project", os.getenv("VERTEXAI_PROJECT"))
+        vertexai_project = _settings.get("vertexai_project", os.getenv("GOOGLE_VERTEX_PROJECT"))
         if not vertexai_project:
             raise ValueError(
                 "Project ID is required for Vertex AI model. Specify *vertexai_project* "
-                + "or set VERTEXAI_PROJECT environment variable"
+                + "or set GOOGLE_VERTEX_PROJECT environment variable"
             )
+
+        vertexai_location = _settings.get("vertexai_location", os.getenv("GOOGLE_VERTEX_LOCATION"))
 
         # Ensure standard google auth credentials are available
         # Set GOOGLE_APPLICATION_CREDENTIALS / GOOGLE_CREDENTIALS / GOOGLE_APPLICATION_CREDENTIALS_JSON
@@ -47,5 +49,6 @@ class VertexAIChatModel(LiteLLMChatModel):
             settings=_settings
             | {
                 "vertex_project": vertexai_project,
+                "vertex_location": vertexai_location,
             },
         )

--- a/python/beeai_framework/adapters/watsonx/backend/chat.py
+++ b/python/beeai_framework/adapters/watsonx/backend/chat.py
@@ -28,8 +28,44 @@ class WatsonxChatModel(LiteLLMChatModel):
     def provider_id(self) -> ProviderName:
         return "watsonx"
 
+    # Differs between typescript & litellm so directly set relevant property here if env specified -> litellm:
+    # Litellm docs have WATSONX_APIKEY. This does not work. It's WATSONX_API_KEY . See     https://github.com/BerriAI/litellm/issues/7595
+    # WATSONX_SPACE_ID [WATSONX_DEPLOYMENT_SPACE_ID] -> space_id
+
+    # LiteLLM uses 'url', from WATSONX_URL
+    # If set we use that (as more specific), otherwise compose from WATSONX_REGION & a constant base.
+
+    # Extra for LiteLLM - no code here - passthrough
+    # WATSONX_TOKEN (not in ts)
+    # WATSONX_ZENAPIKEY (not in ts)
+    # WATSONX_URL
+
+    # https://docs.litellm.ai/docs/providers/watsonx
+
     def __init__(self, model_id: str | None = None, settings: dict[str, Any] | None = None) -> None:
         _settings = settings.copy() if settings is not None else {}
+
+        # Set space_id only if not already in settings
+        if "space_id" not in _settings or not _settings["space_id"]:
+            watsonx_space_id = os.getenv("WATSONX_SPACE_ID")
+            if watsonx_space_id:
+                _settings["space_id"] = watsonx_space_id
+
+        # Set URL based on priority: existing setting > WATSONX_URL env > region-based > error
+        if "url" not in _settings or not _settings["url"]:
+            watsonx_url = os.getenv("WATSONX_URL")
+            if watsonx_url:
+                _settings["url"] = watsonx_url
+            else:
+                watsonx_region = os.getenv("WATSONX_REGION")
+                if watsonx_region:
+                    _settings["url"] = f"https://{watsonx_region}.ml.cloud.ibm.com"
+                else:
+                    raise ValueError(
+                        "Watsonx URL not set. Please provide a 'url' in settings, "
+                        "set the WATSONX_URL environment variable, "
+                        "or set the WATSONX_REGION environment variable."
+                    )
 
         super().__init__(
             model_id if model_id else os.getenv("WATSONX_CHAT_MODEL", "ibm/granite-3-8b-instruct"),

--- a/python/docs/backend.md
+++ b/python/docs/backend.md
@@ -44,11 +44,11 @@ The following table depicts supported providers. Each provider requires specific
 | Name             | Chat | Embedding | Dependency               | Environment Variables                                                                                                                                                 |
 | ---------------- | :--: | :-------: | ------------------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Ollama`         |  ✅  |          | `ollama-ai-provider`     | OLLAMA_CHAT_MODEL<br/>OLLAMA_BASE_URL                                                                                                       |
-| `OpenAI`         |  ✅  |          | `openai`     | OPENAI_CHAT_MODEL<br/>OPENAI_API_BASE<br/>OPENAI_API_KEY<br/>OPENAI_ORGANIZATION<br>OPENAI_EXTRA_HEADERS                                                                                                       |
-| `Watsonx`        |  ✅  |          | `@ibm-cloud/watsonx-ai`  | WATSONX_CHAT_MODEL<br/>WATSONX_EMBEDDING_MODEL<br>WATSONX_API_KEY<br/>WATSONX_PROJECT_ID<br/>WATSONX_SPACE_ID<br>WATSONX_VERSION<br>WATSONX_REGION                    |
+| `OpenAI`         |  ✅  |          | `openai`     | OPENAI_CHAT_MODEL<br/>OPENAI_API_BASE<br/>OPENAI_API_KEY<br/>OPENAI_ORGANIZATION<br>OPENAI_API_HEADERS                                                                                                       |
+| `Watsonx`        |  ✅  |          | `@ibm-cloud/watsonx-ai`  | WATSONX_CHAT_MODEL<br>WATSONX_API_KEY<br>WATSONX_PROJECT_ID<br>WATSONX_SPACE_ID<br>WATSONX_TOKEN<br>WATSONX_ZENAPIKEY<br>WATSONX_URL<br>WATSONX_REGION |
 | `Groq`           |  ✅  |         | | GROQ_CHAT_MODEL<br>GROQ_API_KEY |
-| `Amazon Bedrock` |  ✅  |         |  `boto3`| AWS_CHAT_MODEL<br>AWS_ACCESS_KEY_ID<br>AWS_SECRET_ACCESS_KEY<br>AWS_REGION_NAME |
-| `Google Vertex`  |  ✅  |         |  | VERTEXAI_CHAT_MODEL<br>VERTEXAI_PROJECT<br>GOOGLE_APPLICATION_CREDENTIALS<br>GOOGLE_APPLICATION_CREDENTIALS_JSON<br>GOOGLE_CREDENTIALS |
+| `Amazon Bedrock` |  ✅  |         |  `boto3`| AWS_CHAT_MODEL<br>AWS_ACCESS_KEY_ID<br>AWS_SECRET_ACCESS_KEY<br>AWS_REGION |
+| `Google Vertex`  |  ✅  |         |  | VERTEXAI_CHAT_MODEL<br>GOOGLE_VERTEX_PROJECT<br>GOOGLE_APPLICATION_CREDENTIALS<br>GOOGLE_APPLICATION_CREDENTIALS_JSON<br>GOOGLE_CREDENTIALS |
 | `Azure OpenAI`   |  ✅  |         |  | AZURE_OPENAI_CHAT_MODEL<br>AZURE_OPENAI_API_KEY<br>AZURE_OPENAI_API_BASE<br>AZURE_OPENAI_API_VERSION<br>AZURE_AD_TOKEN<br>AZURE_API_TYPE |
 | `Anthropic`      |  ✅  |         |  | ANTHROPIC_CHAT_MODEL<br>ANTHROPIC_API_KEY |
 | `xAI`           |  ✅  |         | | XAI_CHAT_MODEL<br>XAI_API_KEY |

--- a/python/examples/llms.py
+++ b/python/examples/llms.py
@@ -20,7 +20,7 @@ Arguments
   `watsonx` - requires environment variable
       - WATSONX_URL - base URL of your WatsonX instance
     and one of the following
-      - WATSONX_APIKEY: API key
+      - WATSONX_API_KEY: API key
       - WATSONX_TOKEN: auth token
 """
 

--- a/python/tests/backend/test_chatmodel.py
+++ b/python/tests/backend/test_chatmodel.py
@@ -191,7 +191,7 @@ def test_chat_model_from(monkeypatch: pytest.MonkeyPatch) -> None:
     xai_chat_model = ChatModel.from_name("xai:grok-2")
     assert isinstance(xai_chat_model, XAIChatModel)
 
-    monkeypatch.setenv("VERTEXAI_PROJECT", "myproject")
+    monkeypatch.setenv("GOOGLE_VERTEX_PROJECT", "myproject")
     vertexai_chat_model = ChatModel.from_name("vertexai:gemini-2.0-flash-lite-001")
     assert isinstance(vertexai_chat_model, VertexAIChatModel)
 
@@ -201,7 +201,7 @@ def test_chat_model_from(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "secret1")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret2")
-    monkeypatch.setenv("AWS_REGION_NAME", "region1")
+    monkeypatch.setenv("AWS_REGION", "region1")
     amazon_bedrock_chat_model = ChatModel.from_name("amazon_bedrock:meta.llama3-8b-instruct-v1:0")
     assert isinstance(amazon_bedrock_chat_model, AmazonBedrockChatModel)
 

--- a/python/tests/examples/test_examples.py
+++ b/python/tests/examples/test_examples.py
@@ -35,7 +35,7 @@ exclude = list(
             "backend/providers/groq.py" if os.getenv("GROQ_API_KEY") is None else None,
             "backend/providers/xai.py" if os.getenv("XAI_API_KEY") is None else None,
             # Google backend picks up environment variables/google auth credentials directly
-            "backend/providers/vertexai.py" if os.getenv("VERTEXAI_PROJECT") is None else None,
+            "backend/providers/vertexai.py" if os.getenv("GOOGLE_VERTEX_PROJECT") is None else None,
             "backend/providers/amazon_bedrock.py" if os.getenv("AWS_ACCESS_KEY_ID") is None else None,
             "backend/providers/anthropic.py" if os.getenv("ANTHROPIC_API_KEY") is None else None,
             "backend/providers/azure_openai.py" if os.getenv("AZURE_API_KEY") is None else None,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review and complete the sections below.
-->

### Which issue(s) does this pull-request address?

<!--
Please include a link to an issue in the tracker.  The issue describes the problem to be solved.  If there is no issue raised for this PR then either raise one with a summary and description of the problem or add a summary and description of the problem here
-->

Closes: #527

### Description

<!-- Provide a description of the change, pay special attention to describing any breaking changes.  The description describes the resolution to the problem described in the linked issue (or to the problem outlined in this PR). -->


Updates environment variables to follow [typescript](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/docs/backend.md) as close as possible

In all cases explicit entries in the settings dict take precedence. 

If neither are set, the LiteLLM variables will initialize that value

Note we don't have any embedding model support, so those variables are omitted.

The typescript implementations do have some extra variables such as url. These have been omitted where there's no reference in the litellm documentation to this support. (not tried adding these settings)

Each provider has been tested with a basic configuration, but not a broad set of configuration options.

#### WatsonX

In typescript we use `WATSONX_REGION` from which the base URL is determined
In python we did use the default LiteLLM `WATSONX_URL`. Now we use this first (seemed appropriate as it's the most specific), but if not we try `WATSONX_REGION`. If we can't determine a URL, an exception is thrown

The code now also respects `WATSONX_SPACE_ID` from ts, whilst previously we'd just use the litellm value passed through from `WATSONX_DEPLOYMENT_SPACE_ID`

The liteLLM docs also have an incorrect name for the api key as reported [here](https://github.com/BerriAI/litellm/issues/7595)

LiteLLM also supports some other extra variables - these aren't touched by our code
* WATSONX_TOKEN (not in ts)
* WATSONX_ZENAPIKEY (not in ts)

#### Google AI

Added `GOOGLE_VERTEX_LOCATION` (LiteLM uses `VERTEXAI_LOCATION`)
Updated project id to `GOOGLE_VERTEX_PROJECT` (LiteLLM was `VERTEXAI_PROJECT`)
Either being set will effectively override the litellm env values (but not settings)

#### Amazon 

Use `AWS_REGION_NAME` (LiteLLM) to override `AWS_REGION` (as in typescript)

This provider was problematic in testing, and currently has extra parameter validation. Region is required, so the code now needs to check for the litellm value as well as the new value of ours. (an alternative was to remove validation, but I opted to leave it in for now)

#### OpenAI

Use `OPENAI_EXTRA_HEADERS` instead of `OPENAI_API_HEADERS`

### Checklist

#### General
- [x] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [x] Linting passes: Python `poe lint` or `poe lint --fix` / TypeScript `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: Python `poe format` or `poe format --fix` / TypeScript: `yarn format` or `yarn format:fix`
- [x] Static type checks pass: Python `poe type-check`

#### Testing
- [x] Unit tests pass: Python `poe test --type unit` / TypeScript `yarn test:unit`
- [x] E2E tests pass: Python `poe test --type e2e` / TypeScript: `yarn test:e2e`
- [x] Integration tests pass: Python `poe test --type integration`
- [x] Tests are included (for bug fixes or new features)

#### Documentation
- [x] Documentation is updated
- [x] Embedme embeds code examples in docs. To update after edits, run: Python `poe docs --type build`
