### PR TITLE
fix(backend): do not pass empty tool calls to Watsonx

### DIFF
--- a/python/beeai_framework/adapters/litellm/chat.py
+++ b/python/beeai_framework/adapters/litellm/chat.py
@@ -150,7 +150,8 @@ class LiteLLMChatModel(ChatModel, ABC):
                                 },
                             }
                             for call in message.get_tool_calls()
-                        ],
+                        ]
+                        or None,
                     }
                 )
             else:


### PR DESCRIPTION
Watsonx does not handle empty array of tool calls.