### PR TITLE
fix(adapters): actually return usage in ChatModelOutput

### DIFF
--- a/python/beeai_framework/adapters/litellm/chat.py
+++ b/python/beeai_framework/adapters/litellm/chat.py
@@ -42,6 +42,7 @@ from beeai_framework.backend.types import (
     ChatModelOutput,
     ChatModelStructureInput,
     ChatModelStructureOutput,
+    ChatModelUsage,
 )
 from beeai_framework.backend.utils import parse_broken_json
 from beeai_framework.context import RunContext
@@ -201,7 +202,7 @@ class LiteLLMChatModel(ChatModel, ABC):
     def _transform_output(self, chunk: ModelResponse | ModelResponseStream) -> ChatModelOutput:
         choice = chunk.choices[0]
         finish_reason = choice.finish_reason
-        usage = choice.get("usage")  # type: ignore
+        usage = chunk.get("usage")  # type: ignore
         update = choice.delta if isinstance(choice, StreamingChoices) else choice.message
 
         return ChatModelOutput(
@@ -226,7 +227,7 @@ class LiteLLMChatModel(ChatModel, ABC):
                 else []
             ),
             finish_reason=finish_reason,
-            usage=usage,
+            usage=ChatModelUsage(**usage.model_dump()) if usage else None,
         )
 
     def _format_tool_model(self, model: type[BaseModel]) -> dict[str, Any]:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review and complete the sections below.
-->

### Which issue(s) does this pull-request address?

<!--
Please include a link to an issue in the tracker.  The issue describes the problem to be solved.  If there is no issue raised for this PR then either raise one with a summary and description of the problem or add a summary and description of the problem here
-->

Closes: #609

### Description

We were looking for the usage data in the wrong place, this updates it to look in the correct location and properly types usage now it is no longer always None

### Checklist

#### General
- [x] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [x] Linting passes: Python `poe lint` or `poe lint --fix` / TypeScript `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: Python `poe format` or `poe format --fix` / TypeScript: `yarn format` or `yarn format:fix`
- [x] Static type checks pass: Python `poe type-check`

#### Testing
- [x] Unit tests pass: Python `poe test --type unit` / TypeScript `yarn test:unit`
- [x] E2E tests pass: Python `poe test --type e2e` / TypeScript: `yarn test:e2e`
- [x] Integration tests pass: Python `poe test --type integration`
- [x] Tests are included (for bug fixes or new features)

#### Documentation
- [x] Documentation is updated
- [x] Embedme embeds code examples in docs. To update after edits, run: Python `poe docs --type build`
