### PR TITLE
feat(workflows): preserve agent metadata in workflow step

### DIFF
--- a/python/beeai_framework/agents/types.py
+++ b/python/beeai_framework/agents/types.py
@@ -14,6 +14,8 @@
 
 from pydantic import BaseModel, InstanceOf
 
+from beeai_framework.backend.constants import ProviderName
+from beeai_framework.backend.types import ChatModelParameters
 from beeai_framework.cancellation import AbortSignal
 from beeai_framework.tools.tool import AnyTool
 
@@ -33,3 +35,10 @@ class AgentMeta(BaseModel):
     description: str
     tools: list[InstanceOf[AnyTool]]
     extra_description: str | None = None
+
+
+class AgentMetaDetail(AgentMeta):
+    llm_provider_id: ProviderName
+    llm_model_id: str
+    llm_parameters: ChatModelParameters
+    instructions: str | None = None

--- a/python/beeai_framework/workflows/types.py
+++ b/python/beeai_framework/workflows/types.py
@@ -19,6 +19,7 @@ from typing import Any, Generic, Literal
 from pydantic import BaseModel
 from typing_extensions import TypeVar
 
+from beeai_framework.agents.types import AgentMetaDetail
 from beeai_framework.cancellation import AbortSignal
 from beeai_framework.utils.types import MaybeAsync
 
@@ -47,6 +48,7 @@ class WorkflowStepRes(BaseModel, Generic[T, K]):
 
 
 class WorkflowStepDefinition(BaseModel, Generic[T, K]):
+    agent_metadata: AgentMetaDetail | None
     handler: WorkflowHandler[T, K]
 
 

--- a/python/beeai_framework/workflows/workflow.py
+++ b/python/beeai_framework/workflows/workflow.py
@@ -20,6 +20,7 @@ from typing import ClassVar, Final, Generic, Literal
 from pydantic import BaseModel
 from typing_extensions import TypeVar
 
+from beeai_framework.agents.types import AgentMetaDetail
 from beeai_framework.context import Run, RunContext
 from beeai_framework.emitter.emitter import Emitter
 from beeai_framework.errors import FrameworkError
@@ -90,7 +91,9 @@ class Workflow(Generic[T, K]):
     def start_step(self) -> K | None:
         return self._start_step
 
-    def add_step(self, step_name: K, runnable: WorkflowHandler[T, K]) -> "Workflow[T, K]":
+    def add_step(
+        self, step_name: K, runnable: WorkflowHandler[T, K], agent_metadata: AgentMetaDetail | None = None
+    ) -> "Workflow[T, K]":
         if (len(str(step_name).strip())) == 0:
             raise ValueError("Step name cannot be empty!")
 
@@ -100,7 +103,7 @@ class Workflow(Generic[T, K]):
         if step_name in Workflow._RESERVED_STEP_NAMES:
             raise ValueError(f"The name '{step_name}' is reserved and cannot be used!")
 
-        self.steps[step_name] = WorkflowStepDefinition[T, K](handler=runnable)
+        self.steps[step_name] = WorkflowStepDefinition[T, K](handler=runnable, agent_metadata=agent_metadata)
 
         return self
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review and complete the sections below.
-->

### Which issue(s) does this pull-request address?

When jsonpickling a workflow, all of the information that describes the agents is lost, due to it being hidden behind a closure. This preserves this information in a pickle-able form. I had to extend the existing `AgentMeta` because it does not capture the ChatModel or instructions information. I did this in AgentMetaDetail, a subclass of AgentMeta.

<!--
Please include a link to an issue in the tracker.  The issue describes the problem to be solved.  If there is no issue raised for this PR then either raise one with a summary and description of the problem or add a summary and description of the problem here
-->

Closes: #

### Description

<!-- Provide a description of the change, pay special attention to describing any breaking changes.  The description describes the resolution to the problem described in the linked issue (or to the problem outlined in this PR). -->

### Checklist

#### General
- [x] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [x] Linting passes: Python `poe lint` or `poe lint --fix` / TypeScript `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: Python `poe format` or `poe format --fix` / TypeScript: `yarn format` or `yarn format:fix`
- [ ] Static type checks pass: Python `poe type-check`

#### Testing
- [x] Unit tests pass: Python `poe test --type unit` / TypeScript `yarn test:unit`
- [ ] E2E tests pass: Python `poe test --type e2e` / TypeScript: `yarn test:e2e`
- [ ] Integration tests pass: Python `poe test --type integration`
- [ ] Tests are included (for bug fixes or new features)

#### Documentation
- [ ] Documentation is updated
- [ ] Embedme embeds code examples in docs. To update after edits, run: Python `poe docs --type build`
