### PR TITLE
feat(adapters): Add support for extra headers to more backend providers

### DIFF
--- a/python/.env.example
+++ b/python/.env.example
@@ -9,6 +9,7 @@ BEEAI_LOG_LEVEL=INFO
 ########################
 
 # OPENAI_API_KEY=your-openai-api-key
+# OPENAI_API_HEADERS="secret-header=1234"
 
 ########################
 ### watsonx specific configuration
@@ -47,17 +48,21 @@ BEEAI_LOG_LEVEL=INFO
 ########################
 
 # GOOGLE_VERTEX_CHAT_MODEL=gemini-2.0-flash-lite-001
-# GOOGLE_VERTEX_PROJECT=""
-# GOOGLE_VERTEX_LOCATION=""
+# GOOGLE_VERTEX_PROJECT=your-vertexai-project
+# GOOGLE_VERTEX_LOCATION=your-vertexai-location
+# GOOGLE_VERTEX_API_HEADERS="secret-header=1234"
+
 
 ########################
 ### Amazon Bedrock specific configuration
 ########################
 
-# AWS_ACCESS_KEY_ID=
-# AWS_SECRET_ACCESS_KEY=
-# AWS_REGION=
-# AWS_CHAT_MODEL=
+# AWS_ACCESS_KEY_ID=your-aws-access-key
+# AWS_SECRET_ACCESS_KEY=your-secret-access-key
+# AWS_REGION=your-aws-region
+# AWS_CHAT_MODEL=llama-3.1-8b-instant
+# AWS_API_HEADERS="secret-header=1234"
+
 
 ########################
 ### Anthropic specific configuration
@@ -65,12 +70,16 @@ BEEAI_LOG_LEVEL=INFO
 
 # ANTHROPIC_API_KEY=your-anthropic-api-key
 # ANTHROPIC_CHAT_MODEL=claude-3-haiku-20240307"
+# ANTHROPIC_API_HEADERS="secret-header=1234"
+
 
 ########################
 ### Azure OpenAI specific configuration
 ########################
 
-# AZURE_OPENAI_API_KEY=
-# AZURE_OPENAI_API_BASE=
-# AZURE_OPENAI_API_VERSION=
-# AZURE_OPENAI_CHAT_MODEL=
+# AZURE_OPENAI_API_KEY=your-azure-api-key
+# AZURE_OPENAI_API_BASE=your-base-url
+# AZURE_OPENAI_API_VERSION=2024-10-21
+# AZURE_OPENAI_CHAT_MODEL=gpt-4o-mini
+# AZURE_OPENAI_API_HEADERS="secret-header=1234"
+

--- a/python/beeai_framework/adapters/amazon_bedrock/backend/chat.py
+++ b/python/beeai_framework/adapters/amazon_bedrock/backend/chat.py
@@ -16,6 +16,7 @@
 import os
 from typing import Any
 
+from beeai_framework.adapters.litellm import utils
 from beeai_framework.adapters.litellm.chat import LiteLLMChatModel
 from beeai_framework.backend.constants import ProviderName
 from beeai_framework.logger import Logger
@@ -67,4 +68,7 @@ class AmazonBedrockChatModel(LiteLLMChatModel):
                 "aws_secret_access_key": aws_secret_access_key,
                 "aws_region_name": aws_region_name,
             },
+        )
+        self._settings["extra_headers"] = utils.parse_extra_headers(
+            self._settings.get("extra_headers"), os.getenv("AWS_API_HEADERS")
         )

--- a/python/beeai_framework/adapters/anthropic/backend/chat.py
+++ b/python/beeai_framework/adapters/anthropic/backend/chat.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from dotenv import load_dotenv
 
+from beeai_framework.adapters.litellm import utils
 from beeai_framework.adapters.litellm.chat import LiteLLMChatModel
 from beeai_framework.backend.constants import ProviderName
 from beeai_framework.logger import Logger
@@ -44,4 +45,7 @@ class AnthropicChatModel(LiteLLMChatModel):
             (model_id if model_id else os.getenv("ANTHROPIC_CHAT_MODEL", "claude-3-haiku-20240307")),
             provider_id="anthropic",
             settings=_settings | {"api_key": api_key},
+        )
+        self._settings["extra_headers"] = utils.parse_extra_headers(
+            self._settings.get("extra_headers"), os.getenv("ANTHROPIC_API_HEADERS")
         )

--- a/python/beeai_framework/adapters/azure_openai/backend/chat.py
+++ b/python/beeai_framework/adapters/azure_openai/backend/chat.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from dotenv import load_dotenv
 
+from beeai_framework.adapters.litellm import utils
 from beeai_framework.adapters.litellm.chat import LiteLLMChatModel
 from beeai_framework.backend.constants import ProviderName
 from beeai_framework.logger import Logger
@@ -122,4 +123,7 @@ class AzureOpenAIChatModel(LiteLLMChatModel):
             model_id=(model_id if model_id is not None else os.getenv("AZURE_OPENAI_CHAT_MODEL", "gpt-4o-mini")),
             provider_id="azure",  # LiteLLM uses 'azure' for Azure OpenAI
             settings=config,
+        )
+        self._settings["extra_headers"] = utils.parse_extra_headers(
+            self._settings.get("extra_headers"), os.getenv("AZURE_OPENAI_API_HEADERS")
         )

--- a/python/beeai_framework/adapters/vertexai/backend/chat.py
+++ b/python/beeai_framework/adapters/vertexai/backend/chat.py
@@ -16,6 +16,7 @@
 import os
 from typing import Any
 
+from beeai_framework.adapters.litellm import utils
 from beeai_framework.adapters.litellm.chat import LiteLLMChatModel
 from beeai_framework.backend.constants import ProviderName
 from beeai_framework.logger import Logger
@@ -44,11 +45,14 @@ class VertexAIChatModel(LiteLLMChatModel):
         # Set GOOGLE_APPLICATION_CREDENTIALS / GOOGLE_CREDENTIALS / GOOGLE_APPLICATION_CREDENTIALS_JSON
 
         super().__init__(
-            model_id if model_id else os.getenv("VERTEXAI_CHAT_MODEL", "geminid-2.0-flash-lite-001"),
+            model_id if model_id else os.getenv("GOOGLE_VERTEX_CHAT_MODEL", "gemini-2.0-flash-lite-001"),
             provider_id="vertex_ai",
             settings=_settings
             | {
                 "vertex_project": vertexai_project,
                 "vertex_location": vertexai_location,
             },
+        )
+        self._settings["extra_headers"] = utils.parse_extra_headers(
+            self._settings.get("extra_headers"), os.getenv("GOOGLE_VERTEX_API_HEADERS")
         )

--- a/python/docs/backend.md
+++ b/python/docs/backend.md
@@ -47,10 +47,10 @@ The following table depicts supported providers. Each provider requires specific
 | `OpenAI`         |  ✅  |          | `openai`     | OPENAI_CHAT_MODEL<br/>OPENAI_API_BASE<br/>OPENAI_API_KEY<br/>OPENAI_ORGANIZATION<br>OPENAI_API_HEADERS                                                                                                       |
 | `Watsonx`        |  ✅  |          | `@ibm-cloud/watsonx-ai`  | WATSONX_CHAT_MODEL<br>WATSONX_API_KEY<br>WATSONX_PROJECT_ID<br>WATSONX_SPACE_ID<br>WATSONX_TOKEN<br>WATSONX_ZENAPIKEY<br>WATSONX_URL<br>WATSONX_REGION |
 | `Groq`           |  ✅  |         | | GROQ_CHAT_MODEL<br>GROQ_API_KEY |
-| `Amazon Bedrock` |  ✅  |         |  `boto3`| AWS_CHAT_MODEL<br>AWS_ACCESS_KEY_ID<br>AWS_SECRET_ACCESS_KEY<br>AWS_REGION |
-| `Google Vertex`  |  ✅  |         |  | VERTEXAI_CHAT_MODEL<br>GOOGLE_VERTEX_PROJECT<br>GOOGLE_APPLICATION_CREDENTIALS<br>GOOGLE_APPLICATION_CREDENTIALS_JSON<br>GOOGLE_CREDENTIALS |
-| `Azure OpenAI`   |  ✅  |         |  | AZURE_OPENAI_CHAT_MODEL<br>AZURE_OPENAI_API_KEY<br>AZURE_OPENAI_API_BASE<br>AZURE_OPENAI_API_VERSION<br>AZURE_AD_TOKEN<br>AZURE_API_TYPE |
-| `Anthropic`      |  ✅  |         |  | ANTHROPIC_CHAT_MODEL<br>ANTHROPIC_API_KEY |
+| `Amazon Bedrock` |  ✅  |         |  `boto3`| AWS_CHAT_MODEL<br>AWS_ACCESS_KEY_ID<br>AWS_SECRET_ACCESS_KEY<br>AWS_REGION<br>AWS_API_HEADERS |
+| `Google Vertex`  |  ✅  |         |  | GOOGLE_VERTEX_CHAT_MODEL<br>GOOGLE_VERTEX_PROJECT<br>GOOGLE_APPLICATION_CREDENTIALS<br>GOOGLE_APPLICATION_CREDENTIALS_JSON<br>GOOGLE_CREDENTIALS<br>GOOGLE_VERTEX_API_HEADERS |
+| `Azure OpenAI`   |  ✅  |         |  | AZURE_OPENAI_CHAT_MODEL<br>AZURE_OPENAI_API_KEY<br>AZURE_OPENAI_API_BASE<br>AZURE_OPENAI_API_VERSION<br>AZURE_AD_TOKEN<br>AZURE_API_TYPE<br>AZURE_API_HEADERS |
+| `Anthropic`      |  ✅  |         |  | ANTHROPIC_CHAT_MODEL<br>ANTHROPIC_API_KEY<br>ANTHROPIC_API_HEADERS |
 | `xAI`           |  ✅  |         | | XAI_CHAT_MODEL<br>XAI_API_KEY |
 
 > [!TIP]


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review and complete the sections below.
-->

### Which issue(s) does this pull-request address?


<!--
Please include a link to an issue in the tracker.  The issue describes the problem to be solved.  If there is no issue raised for this PR then either raise one with a summary and description of the problem or add a summary and description of the problem here
-->

Closes: #586

### Description

<!-- Provide a description of the change, pay special attention to describing any breaking changes.  The description describes the resolution to the problem described in the linked issue (or to the problem outlined in this PR). -->

Adds support for extra headers to:

- Azure OpenAI
- Anthropic
- Amazon Bedrock
- Google VertexAI

In the above cases support for *extra_headers* is documented in the LiteLLM docs and/or found from a code scan

Changes were not made to
- Ollama (note there is a [PR](https://github.com/BerriAI/litellm/pull/7180) open)
- WatsonX
- Groq
- XAI

due to lack of support in liteLLM.

- OpenAI adapter already has support

Testing
 **IN PROGRESS**
- [x] Check modified providers still work with no extra headers
- [x] check extra headers sent by network traffic inspection

No test is made that the extra headers have any effect on the actual provider.

### Checklist

#### General
- [x] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [x] Linting passes: Python `poe lint` or `poe lint --fix` / TypeScript `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: Python `poe format` or `poe format --fix` / TypeScript: `yarn format` or `yarn format:fix`
- [x] Static type checks pass: Python `poe type-check`

#### Testing
- [ ] Unit tests pass: Python `poe test --type unit` / TypeScript `yarn test:unit`
- [ ] E2E tests pass: Python `poe test --type e2e` / TypeScript: `yarn test:e2e`
- [ ] Integration tests pass: Python `poe test --type integration`
- [ ] Tests are included (for bug fixes or new features)

#### Documentation
- [ ] Documentation is updated
- [ ] Embedme embeds code examples in docs. To update after edits, run: Python `poe docs --type build`
