### PR TITLE
feat(agents): Granite sample now loops for chat

### DIFF
--- a/python/examples/agents/granite.py
+++ b/python/examples/agents/granite.py
@@ -22,14 +22,15 @@ async def main() -> None:
 
     reader = ConsoleReader()
 
-    prompt = reader.prompt()
+    reader.write("🛠️ System: ", "Agent initialized with DuckDuckGo and OpenMeteo tools.")
 
-    output: ReActAgentRunOutput = await agent.run(
-        prompt=prompt, execution=AgentExecutionConfig(total_max_retries=2, max_retries_per_step=3, max_iterations=8)
-    ).on(
-        "update",
-        lambda data, event: reader.write(f"Agent({data.update.key}) 🤖 : ", data.update.parsed_value),
-    )
+    for prompt in reader:
+        output: ReActAgentRunOutput = await agent.run(
+            prompt=prompt, execution=AgentExecutionConfig(total_max_retries=2, max_retries_per_step=3, max_iterations=8)
+        ).on(
+            "update",
+            lambda data, event: reader.write(f"Agent({data.update.key}) 🤖 : ", data.update.parsed_value),
+        )
 
     reader.write("Agent 🤖 : ", output.result.text)
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review and complete the sections below.
-->

### Which issue(s) does this pull-request address?

<!--
Please include a link to an issue in the tracker.  The issue describes the problem to be solved.  If there is no issue raised for this PR then either raise one with a summary and description of the problem or add a summary and description of the problem here
-->

Closes: #512

### Description

<!-- Provide a description of the change, pay special attention to describing any breaking changes.  The description describes the resolution to the problem described in the linked issue (or to the problem outlined in this PR). -->

Granite sample now loops on user input, similar to the react agent:
```
(beeai-framework-py3.13) ➜  python git:(sampleloop) python examples/agents/react.py                                   
🛠️ System:  Agent initialized with Wikipedia tool.
Interactive session has started. To escape, input 'q' and submit.
User 👤 : what is the time?
Agent 🤖 :  starting new iteration
Agent(thought) 🤖 :  The user wants to know the current time. I can provide this information directly without using any tool.

Agent(final_answer) 🤖 :  The current time is Tuesday, March 25, 2025 at 03:41:16 PM.
Agent 🤖 :  success
Agent 🤖 :  The current time is Tuesday, March 25, 2025 at 03:41:16 PM.
User 👤 : q
(beeai-framework-py3.13) ➜  python git:(sampleloop) python examples/agents/granite.py                                 
🛠️ System:  Agent initialized with DuckDuckGo and OpenMeteo tools.
Interactive session has started. To escape, input 'q' and submit.
User 👤 : what is the time?
Agent(thought) 🤖 :  The user wants to know the current time. I don't need any tools for this, as the information is available in the prompt.

Agent(final_answer) 🤖 :  The current time is Tuesday, March 25, 2025 at 03:41:35 PM.
User 👤 : what is the weather in London?
Agent(thought) 🤖 :  I need to use the OpenMeteoTool to get the current weather information for London.

Agent(tool_name) 🤖 :  OpenMeteoTool
```
...etc...

I did not make other changes (slightly different chat api call & reporting of events)

### Checklist

#### General
- [ ] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [ ] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [ ] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [ ] Linting passes: Python `poe lint` or `poe lint --fix` / TypeScript `yarn lint` or `yarn lint:fix`
- [ ] Formatting is applied: Python `poe format` or `poe format --fix` / TypeScript: `yarn format` or `yarn format:fix`
- [ ] Static type checks pass: Python `poe type-check`

#### Testing
- [ ] Unit tests pass: Python `poe test --type unit` / TypeScript `yarn test:unit`
- [ ] E2E tests pass: Python `poe test --type e2e` / TypeScript: `yarn test:e2e`
- [ ] Integration tests pass: Python `poe test --type integration`
- [ ] Tests are included (for bug fixes or new features)

#### Documentation
- [ ] Documentation is updated
- [ ] Embedme embeds code examples in docs. To update after edits, run: Python `poe docs --type build`
