### PR TITLE
fix(tools): SandboxTool fails when run by an agent

### DIFF
--- a/python/beeai_framework/agents/react/runners/default/runner.py
+++ b/python/beeai_framework/agents/react/runners/default/runner.py
@@ -72,7 +72,6 @@ from beeai_framework.parsers.line_prefix import (
 from beeai_framework.retryable import Retryable, RetryableConfig, RetryableContext, RetryableInput
 from beeai_framework.tools import StringToolOutput, ToolError, ToolInputValidationError, ToolOutput
 from beeai_framework.tools.tool import AnyTool
-from beeai_framework.tools.types import ToolRunOptions
 from beeai_framework.utils.strings import create_strenum, to_json
 
 
@@ -283,9 +282,7 @@ class DefaultRunner(BaseRunner):
 
         async def executor(_: RetryableContext) -> ReActAgentRunnerToolResult:
             try:
-                tool_output: ToolOutput = await tool.run(
-                    input.state.tool_input, options=ToolRunOptions()
-                )  # TODO: pass tool options
+                tool_output: ToolOutput = await tool.run(input.state.tool_input)  # TODO: pass tool options
                 output = (
                     tool_output
                     if not tool_output.is_empty()

--- a/python/beeai_framework/tools/code/sandbox.py
+++ b/python/beeai_framework/tools/code/sandbox.py
@@ -67,7 +67,7 @@ class SandboxTool(Tool[BaseModel, SandboxToolOptions, StringToolOutput]):
         return JSONSchemaModel.create(self.name, self._options.input_schema)
 
     async def _run(
-        self, tool_input: BaseModel | dict[str, Any], options: ToolRunOptions | None, context: RunContext
+        self, tool_input: BaseModel | dict[str, Any], options: SandboxToolOptions | None, context: RunContext
     ) -> StringToolOutput:
         try:
             result = await PythonTool.call_code_interpreter(
@@ -77,7 +77,7 @@ class SandboxTool(Tool[BaseModel, SandboxToolOptions, StringToolOutput]):
                     "tool_input_json": tool_input.model_dump_json()
                     if isinstance(tool_input, BaseModel)
                     else json.dumps(tool_input),
-                    "env": {**self._options.env},
+                    "env": {**self._options.env, **(options.env if options else {})},
                 },
             )
 

--- a/python/beeai_framework/tools/code/sandbox.py
+++ b/python/beeai_framework/tools/code/sandbox.py
@@ -67,7 +67,7 @@ class SandboxTool(Tool[BaseModel, SandboxToolOptions, StringToolOutput]):
         return JSONSchemaModel.create(self.name, self._options.input_schema)
 
     async def _run(
-        self, tool_input: BaseModel | dict[str, Any], options: SandboxToolOptions | None, context: RunContext
+        self, tool_input: BaseModel | dict[str, Any], options: ToolRunOptions | None, context: RunContext
     ) -> StringToolOutput:
         try:
             result = await PythonTool.call_code_interpreter(
@@ -77,7 +77,7 @@ class SandboxTool(Tool[BaseModel, SandboxToolOptions, StringToolOutput]):
                     "tool_input_json": tool_input.model_dump_json()
                     if isinstance(tool_input, BaseModel)
                     else json.dumps(tool_input),
-                    "env": {**self._options.env, **(options.env if options else {})},
+                    "env": {**self._options.env},
                 },
             )
 

--- a/python/docs/tools.md
+++ b/python/docs/tools.md
@@ -410,7 +410,6 @@ _Source: [examples/tools/custom/sandbox.py](/typescript/examples/tools/custom/sa
 >
 > 1. During the creation of a `SandboxTool`, either via the constructor or the factory function (`SandboxTool.from_source_code`).
 > 2. By passing them directly as part of the options when invoking: `my_tool.run(..., env={ "MY_ENV": "MY_VALUE" })`.
-<!-- 3. Dynamically during execution via [`Emitter`](/python/docs/emitter.md): `my_tool.emitter.on("start", lambda data, event: (data.options.env.update({"MY_ENV": "MY_VALUE"})))`. -->
 
 > [!IMPORTANT]
 >

--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -322,7 +322,7 @@ description = "Foreign Function Interface for Python calling C code."
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "platform_python_implementation == \"PyPy\" and extra == \"langchain\""
+markers = "extra == \"langchain\" and platform_python_implementation == \"PyPy\""
 files = [
     {file = "cffi-1.17.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:df8b1c11f177bc2313ec4b2d46baec87a5f3e71fc8b45dab2ee7cae86d9aba14"},
     {file = "cffi-1.17.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8f2cdc858323644ab277e9bb925ad72ae0e67f69e804f4898c070998d50b1a67"},
@@ -938,7 +938,7 @@ description = "Lightweight in-process concurrent programming"
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "extra == \"langchain\" and (platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\") and python_version < \"3.14\""
+markers = "python_version < \"3.14\" and (platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\") and extra == \"langchain\""
 files = [
     {file = "greenlet-3.1.1-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:0bbae94a29c9e5c7e4a2b7f0aae5c17e8e90acbfd3bf6270eeba60c39fce3563"},
     {file = "greenlet-3.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fde093fb93f35ca72a556cf72c92ea3ebfda3d79fc35bb19fbe685853869a83"},
@@ -2182,7 +2182,7 @@ description = "Fast, correct Python JSON library supporting dataclasses, datetim
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "platform_python_implementation != \"PyPy\" and extra == \"langchain\""
+markers = "extra == \"langchain\" and platform_python_implementation != \"PyPy\""
 files = [
     {file = "orjson-3.10.16-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:4cb473b8e79154fa778fb56d2d73763d977be3dcc140587e07dbc545bbfc38f8"},
     {file = "orjson-3.10.16-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:622a8e85eeec1948690409a19ca1c7d9fd8ff116f4861d261e6ae2094fe59a00"},
@@ -2482,7 +2482,7 @@ description = "C parser in Python"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "platform_python_implementation == \"PyPy\" and extra == \"langchain\""
+markers = "extra == \"langchain\" and platform_python_implementation == \"PyPy\""
 files = [
     {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
     {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
@@ -2786,7 +2786,7 @@ description = "Python for Window Extensions"
 optional = false
 python-versions = "*"
 groups = ["dev"]
-markers = "platform_python_implementation != \"PyPy\" and sys_platform == \"win32\""
+markers = "sys_platform == \"win32\" and platform_python_implementation != \"PyPy\""
 files = [
     {file = "pywin32-310-cp310-cp310-win32.whl", hash = "sha256:6dd97011efc8bf51d6793a82292419eba2c71cf8e7250cfac03bba284454abc1"},
     {file = "pywin32-310-cp310-cp310-win_amd64.whl", hash = "sha256:c3e78706e4229b915a0821941a84e7ef420bf2b77e08c9dae3c76fd03fd2ae3d"},

--- a/python/tests/examples/test_examples.py
+++ b/python/tests/examples/test_examples.py
@@ -46,7 +46,7 @@ exclude = list(
             "workflows/searx_agent.py",
             # Requires BeeAI platform to be running
             "agents/experimental/remote.py",
-            "examples/workflows/remote.py",
+            "workflows/remote.py",
             # Requires Code Interpreter to be running
             "tools/python_tool.py" if os.getenv("CODE_INTERPRETER_URL") is None else None,
             "tools/custom/sandbox.py" if os.getenv("CODE_INTERPRETER_URL") is None else None,


### PR DESCRIPTION
### Which issue(s) does this pull-request address?

Related to #683 

### Description

While testing https://github.com/i-am-bee/beeai-framework-py-starter/blob/main/beeai_framework_starter/agent_code_interpreter.py I was hitting the following error:
```
SandboxToolExecuteError(beeai_framework.tools.code.sandbox): Framework error
Context: {"name": "get_riddle"}
  AttributeError(builtins): 'ToolRunOptions' object has no attribute 'env'
```
which I was able to trace back to https://github.com/i-am-bee/beeai-framework/blob/58f17bcc8c1e3065db6040055fa524f7c1ad8a60/python/beeai_framework/tools/code/sandbox.py#L80

This is because `ToolRunOptions` is being passed in rather than the expected `SandboxToolOptions`.

This removes the unnecessary `ToolRunOptions` initialization in `DefaultRunner`

### Checklist

#### General
- [x] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [x] Linting passes: Python `poe lint` or `poe lint --fix` / TypeScript `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: Python `poe format` or `poe format --fix` / TypeScript: `yarn format` or `yarn format:fix`
- [x] Static type checks pass: Python `poe type-check`

#### Testing
- [x] Unit tests pass: Python `poe test --type unit` / TypeScript `yarn test:unit`
- [x] E2E tests pass: Python `poe test --type e2e` / TypeScript: `yarn test:e2e`
- [x] Integration tests pass: Python `poe test --type integration`
- [x] Tests are included (for bug fixes or new features)

#### Documentation
- [x] Documentation is updated
- [x] Embedme embeds code examples in docs. To update after edits, run: Python `poe docs --type build`
