### PR TITLE
chore(tools): remove branding from code interpreter references

### DIFF
--- a/python/beeai_framework/tools/code/python.py
+++ b/python/beeai_framework/tools/code/python.py
@@ -160,7 +160,7 @@ Do not use this tool multiple times in a row, always write the full code you wan
                 return response.json()
         except httpx.HTTPStatusError as err:
             raise ToolError.ensure(
-                err, message=f"Request to bee-code-interpreter has failed with HTTP status code {response.status_code}."
+                err, message=f"Request to code interpreter has failed with HTTP status code {response.status_code}."
             )
         except httpx.HTTPError as err:
             raise ToolError(
@@ -171,4 +171,4 @@ Do not use this tool multiple times in a row, always write the full code you wan
                 cause=err,
             )
         except Exception as err:
-            raise ToolError.ensure(err, message="Request to bee-code-interpreter has failed.")
+            raise ToolError.ensure(err, message="Request to code interpreter has failed.")

--- a/typescript/src/tools/custom.test.ts
+++ b/typescript/src/tools/custom.test.ts
@@ -67,7 +67,7 @@ describe("CustomTool", () => {
     await expect(
       CustomTool.fromSourceCode({ url: "http://localhost" }, "source code"),
     ).rejects.toThrow(
-      "Request to bee-code-interpreter has failed -- ensure that CODE_INTERPRETER_URL points to the new HTTP endpoint",
+      "Request to code interpreter has failed -- ensure that CODE_INTERPRETER_URL points to the new HTTP endpoint",
     );
   });
 
@@ -163,6 +163,6 @@ describe("CustomTool", () => {
 
     await expect(
       CustomTool.fromSourceCode({ url: "http://localhost" }, "source code"),
-    ).rejects.toThrow("Request to bee-code-interpreter has failed with HTTP status code 500");
+    ).rejects.toThrow("Request to code interpreter has failed with HTTP status code 500");
   });
 });

--- a/typescript/src/tools/python/python.ts
+++ b/typescript/src/tools/python/python.ts
@@ -206,17 +206,17 @@ export async function callCodeInterpreter({
   }).catch((error) => {
     if (error.cause.name == "HTTPParserError") {
       throw new ToolError(
-        "Request to bee-code-interpreter has failed -- ensure that CODE_INTERPRETER_URL points to the new HTTP endpoint (default port: 50081).",
+        "Request to code interpreter has failed -- ensure that CODE_INTERPRETER_URL points to the new HTTP endpoint (default port: 50081).",
         [error],
       );
     } else {
-      throw new ToolError("Request to bee-code-interpreter has failed.", [error]);
+      throw new ToolError("Request to code interpreter has failed.", [error]);
     }
   });
 
   if (!response?.ok && response.status > 400) {
     throw new ToolError(
-      `Request to bee-code-interpreter has failed with HTTP status code ${response.status}.`,
+      `Request to code interpreter has failed with HTTP status code ${response.status}.`,
       [new Error(await response.text())],
     );
   }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review and complete the sections below.
-->

### Which issue(s) does this pull-request address?

Ref: #688 

### Description

remove branding from code interpreter references
### Checklist

#### General
- [x] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [x] Linting passes: Python `poe lint` or `poe lint --fix` / TypeScript `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: Python `poe format` or `poe format --fix` / TypeScript: `yarn format` or `yarn format:fix`
- [x] Static type checks pass: Python `poe type-check`

#### Testing
- [ ] Unit tests pass: Python `poe test --type unit` / TypeScript `yarn test:unit`
- [ ] E2E tests pass: Python `poe test --type e2e` / TypeScript: `yarn test:e2e`
- [ ] Integration tests pass: Python `poe test --type integration`
- [ ] Tests are included (for bug fixes or new features)

#### Documentation
- [ ] Documentation is updated
- [ ] Embedme embeds code examples in docs. To update after edits, run: Python `poe docs --type build`
