### PR TITLE
docs(example): github issue manager use case

### DIFF
--- a/python/examples/use_cases/github_issue_manager.py
+++ b/python/examples/use_cases/github_issue_manager.py
@@ -1,0 +1,109 @@
+import asyncio
+import os
+import sys
+import traceback
+
+from dotenv import load_dotenv
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+from beeai_framework.agents.react.agent import ReActAgent
+from beeai_framework.agents.types import AgentExecutionConfig
+from beeai_framework.backend.chat import ChatModel
+from beeai_framework.backend.message import SystemMessage, UserMessage
+from beeai_framework.emitter.emitter import EventMeta
+from beeai_framework.errors import FrameworkError
+from beeai_framework.memory.token_memory import TokenMemory
+from beeai_framework.tools.mcp_tools import MCPTool
+from examples.helpers.io import ConsoleReader
+
+load_dotenv()
+
+server_params = StdioServerParameters(
+    command="npx",
+    args=["-y", "@modelcontextprotocol/server-github"],
+    env={
+        "GITHUB_TOKEN": os.environ["GITHUB_TOKEN"],
+        "GITHUB_OWNER": os.environ["GITHUB_OWNER"],
+        "GITHUB_REPO": os.environ["GITHUB_REPO"],
+        "PATH": os.getenv("PATH", default=""),
+    },
+)
+
+
+async def setup_github_tools() -> list[MCPTool]:
+    async with stdio_client(server_params) as (read, write), ClientSession(read, write) as session:
+        await session.initialize()
+        github_tools = await MCPTool.from_client(session)
+        print(f"Available GitHub tools: {[tool.name for tool in github_tools]}")
+        return github_tools
+
+
+async def create_issue_agent() -> ReActAgent:
+    tools = await setup_github_tools()
+    
+    llm = ChatModel.from_name("ollama:llama3.1")
+    
+    memory = TokenMemory(llm)
+    await memory.add(SystemMessage(f"""
+You are a GitHub Issue Manager assistant for the repository {os.environ.get('GITHUB_OWNER')}/{os.environ.get('GITHUB_REPO')}.
+
+You have access to GitHub tools that can list, create, and manage issues. When helping users:
+1. Always use the appropriate GitHub tool instead of explaining GitHub concepts
+2. Use the exact repository owner and name in your tool calls
+3. For listing issues, use the list_issues tool with the proper state parameter
+4. Be concise and focus on executing the user's requests
+
+When listing issues, include specific issue numbers, titles, and states in your response.
+"""))
+    
+    agent = ReActAgent(
+        llm=llm,
+        tools=tools,
+        memory=memory
+    )
+    
+    return agent
+
+
+def print_tool_usage(data: any, event: EventMeta) -> None:
+    if event.name == "update":
+        if data.update.key == "tool_name":
+            print(f"Using tool: {data.update.parsed_value}")
+        elif data.update.key == "tool_input":
+            print(f"Tool input: {data.update.parsed_value}")
+    elif event.name == "error":
+        print(f"Error: {FrameworkError.ensure(data.error).explain()}")
+
+
+async def main() -> None:
+    reader = ConsoleReader()
+    
+    print(f"GitHub Issue Manager for {os.environ.get('GITHUB_OWNER')}/{os.environ.get('GITHUB_REPO')}")
+    print("Type 'exit' to quit.")
+    print("-" * 50)
+    
+    agent = await create_issue_agent()
+    
+    for prompt in reader:
+        if prompt.lower() == "exit":
+            print("Goodbye!")
+            break
+        
+        response = await agent.run(
+            prompt=prompt,
+            execution=AgentExecutionConfig(
+                max_retries_per_step=3,
+                max_iterations=10
+            )
+        ).on("*", print_tool_usage)
+        
+        reader.write("GitHub Issue Manager: ", response.result.text)
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except FrameworkError as e:
+        traceback.print_exc()
+        sys.exit(e.explain())


### PR DESCRIPTION
_**WORK IN PROGRESS**_

<!--
Thank you for your pull request. Please review and complete the sections below.
-->

### Which issue(s) does this pull-request address?

<!--
Please include a link to an issue in the tracker.  The issue describes the problem to be solved.  If there is no issue raised for this PR then either raise one with a summary and description of the problem or add a summary and description of the problem here
-->

Closes: #

### Description

I started working on a Github Issue Manager use case to help product managers (aka me) manage github issues more efficiently. It's built using MCP (@modelcontextprotocol/server-github). This is adapted based on @vabarbosa's Slack agent example but adjusted based on my findings in testing - e.g., I found that `template.update` didn't work (I tried `template.fork` too) and instead I found success in adding a system message to memory to best control agent behavior.

Currently, I've had success with connecting the agent to github via MCP and discovering available tools (16 github tools available) and getting the agent to understand user requests and select the appropriate GitHub tool.

But  I'm encountering connection stability issues. The MCP server connection seems to close unexpectedly during tool calls... 

Simple prompt I've been using for testing: `list issue #702 details for i-am-bee/beeai-framework`

Questions:
- Has anyone experienced similar MCP connection issues?
- Are there recommended patterns for maintaining stable connections with MCP servers?

<details>
  <summary>Click here to see one of my example interactions</summary>

  ```sh
(myenv) jennawinkler@Jennas-MacBook-Pro python % python examples/playground/github_mcp_agent.py
GitHub Issue Manager for i-am-bee/beeai-framework
Type 'exit' to quit.
--------------------------------------------------
GitHub MCP Server running on stdio
Available GitHub tools: ['create_or_update_file', 'search_repositories', 'create_repository', 'get_file_contents', 'push_files', 'create_issue', 'create_pull_request', 'fork_repository', 'create_branch', 'list_commits', 'list_issues', 'update_issue', 'add_issue_comment', 'search_code', 'search_issues', 'search_users', 'get_issue']
Interactive session has started. To escape, input 'q' and submit.
User 👤 : - list issue #702 details for i-am-bee/beeai-framework
Using tool: get_issue
Tool input: {'issue_number': 702, 'owner': 'i-am-bee', 'repo': 'beeai-framework'}
Using tool: list_issues
Tool input: {'state': 'open', 'owner': 'i-am-bee', 'repo': 'beeai-framework'}
Traceback (most recent call last):
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/beeai_framework/tools/tool.py", line 140, in handler
    output = await Retryable(
             ^^^^^^^^^^^^^^^^
    ...<12 lines>...
    ).get()
    ^^^^^^^
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/beeai_framework/retryable.py", line 154, in get
    return await do_retry(_retry, options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/beeai_framework/retryable.py", line 91, in do_retry
    return await abort_signal_handler(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<2 lines>...
    )
    ^
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/beeai_framework/cancellation.py", line 109, in abort_signal_handler
    return await fn()
           ^^^^^^^^^^
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/beeai_framework/retryable.py", line 84, in handler
    raise e
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/beeai_framework/retryable.py", line 72, in handler
    return await fn(attempt)
           ^^^^^^^^^^^^^^^^^
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/beeai_framework/retryable.py", line 126, in _retry
    value: T = await self._handlers.executor(ctx)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/beeai_framework/tools/tool.py", line 118, in executor
    result = await self._run(validated_input, options, context)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/beeai_framework/tools/mcp_tools.py", line 64, in _run
    result: CallToolResult = await self._session.call_tool(
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        name=self._tool.name, arguments=input_data.model_dump(exclude_none=True, exclude_unset=True)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/mcp/client/session.py", line 236, in call_tool
    return await self.send_request(
           ^^^^^^^^^^^^^^^^^^^^^^^^
    ...<7 lines>...
    )
    ^
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/mcp/shared/session.py", line 257, in send_request
    await self._write_stream.send(JSONRPCMessage(jsonrpc_request))
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/anyio/streams/memory.py", line 242, in send
    self.send_nowait(item)
    ~~~~~~~~~~~~~~~~^^^^^^
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/anyio/streams/memory.py", line 211, in send_nowait
    raise ClosedResourceError
anyio.ClosedResourceError

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/beeai_framework/agents/react/runners/default/runner.py", line 286, in executor
    tool_output: ToolOutput = await tool.run(
                              ^^^^^^^^^^^^^^^
        input.state.tool_input, options=ToolRunOptions()
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )  # TODO: pass tool options
    ^
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/beeai_framework/context.py", line 78, in _run_tasks
    return await self.handler()
           ^^^^^^^^^^^^^^^^^^^^
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/beeai_framework/context.py", line 192, in handler
    raise error
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/beeai_framework/context.py", line 179, in handler
    result = done.pop().result()
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/beeai_framework/context.py", line 159, in _context_storage_run
    return await fn(context)
           ^^^^^^^^^^^^^^^^^
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/beeai_framework/tools/tool.py", line 163, in handler
    raise err
beeai_framework.tools.errors.ToolError: Tool Error

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/jennawinkler/Desktop/beeai-framework/python/examples/playground/github_mcp_agent.py", line 120, in <module>
    asyncio.run(main())
    ~~~~~~~~~~~^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.2/Frameworks/Python.framework/Versions/3.13/lib/python3.13/asyncio/runners.py", line 195, in run
    return runner.run(main)
           ~~~~~~~~~~^^^^^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.2/Frameworks/Python.framework/Versions/3.13/lib/python3.13/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.2/Frameworks/Python.framework/Versions/3.13/lib/python3.13/asyncio/base_events.py", line 725, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
  File "/Users/jennawinkler/Desktop/beeai-framework/python/examples/playground/github_mcp_agent.py", line 107, in main
    response = await agent.run(
               ^^^^^^^^^^^^^^^^
    ...<5 lines>...
    ).on("*", print_tool_usage)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/beeai_framework/context.py", line 78, in _run_tasks
    return await self.handler()
           ^^^^^^^^^^^^^^^^^^^^
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/beeai_framework/context.py", line 192, in handler
    raise error
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/beeai_framework/context.py", line 179, in handler
    result = done.pop().result()
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/beeai_framework/context.py", line 159, in _context_storage_run
    return await fn(context)
           ^^^^^^^^^^^^^^^^^
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/beeai_framework/agents/base.py", line 85, in handler
    raise AgentError.ensure(e)
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/beeai_framework/agents/base.py", line 83, in handler
    return await fn(context)
           ^^^^^^^^^^^^^^^^^
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/beeai_framework/agents/react/agent.py", line 148, in handler
    tool_result: ReActAgentRunnerToolResult = await runner.tool(
                                              ^^^^^^^^^^^^^^^^^^
    ...<6 lines>...
    )
    ^
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/beeai_framework/agents/react/runners/default/runner.py", line 320, in tool
    return await Retryable(
           ^^^^^^^^^^^^^^^^
    ...<5 lines>...
    ).get()
    ^^^^^^^
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/beeai_framework/retryable.py", line 154, in get
    return await do_retry(_retry, options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/beeai_framework/retryable.py", line 91, in do_retry
    return await abort_signal_handler(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<2 lines>...
    )
    ^
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/beeai_framework/cancellation.py", line 109, in abort_signal_handler
    return await fn()
           ^^^^^^^^^^
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/beeai_framework/retryable.py", line 81, in handler
    await options["on_failed_attempt"](e, meta)
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/beeai_framework/retryable.py", line 141, in _on_failed_attempt
    await self._handlers.on_error(e, self._get_context(meta.attempt)) if self._handlers.on_error else None
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/beeai_framework/agents/react/runners/default/runner.py", line 282, in on_error
    self._failed_attempts_counter.use(error)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/beeai_framework/utils/counter.py", line 33, in use
    raise self._finalError
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/beeai_framework/retryable.py", line 72, in handler
    return await fn(attempt)
           ^^^^^^^^^^^^^^^^^
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/beeai_framework/retryable.py", line 126, in _retry
    value: T = await self._handlers.executor(ctx)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/beeai_framework/agents/react/runners/default/runner.py", line 309, in executor
    self._failed_attempts_counter.use(err)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^
  File "/Users/jennawinkler/Desktop/beeai-framework/python/myenv/lib/python3.13/site-packages/beeai_framework/utils/counter.py", line 43, in use
    raise self._finalError
beeai_framework.agents.errors.AgentError: Maximal amount of global retries (1) has been reached.
AgentError(beeai_framework.agents.errors): Maximal amount of global retries (1) has been reached.
  ToolError(beeai_framework.tools.errors): Tool Error
    Context: {"name": "list_issues"}
    ClosedResourceError(anyio):
```
</details>

<!-- Provide a description of the change, pay special attention to describing any breaking changes.  The description describes the resolution to the problem described in the linked issue (or to the problem outlined in this PR). -->

### Checklist

#### General
- [ ] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [ ] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [ ] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [ ] Linting passes: Python `poe lint` or `poe lint --fix` / TypeScript `yarn lint` or `yarn lint:fix`
- [ ] Formatting is applied: Python `poe format` or `poe format --fix` / TypeScript: `yarn format` or `yarn format:fix`
- [ ] Static type checks pass: Python `poe type-check`

#### Testing
- [ ] Unit tests pass: Python `poe test --type unit` / TypeScript `yarn test:unit`
- [ ] E2E tests pass: Python `poe test --type e2e` / TypeScript: `yarn test:e2e`
- [ ] Integration tests pass: Python `poe test --type integration`
- [ ] Tests are included (for bug fixes or new features)

#### Documentation
- [ ] Documentation is updated
- [ ] Embedme embeds code examples in docs. To update after edits, run: Python `poe docs --type build`
