### PR TITLE
chore: cleanup unused emitter event

### DIFF
--- a/python/beeai_framework/agents/react/__init__.py
+++ b/python/beeai_framework/agents/react/__init__.py
@@ -18,7 +18,6 @@ from beeai_framework.agents.react.events import (
     ReActAgentRetryEvent,
     ReActAgentStartEvent,
     ReActAgentSuccessEvent,
-    ReActAgentToolEvent,
     ReActAgentUpdateEvent,
 )
 from beeai_framework.agents.react.types import ReActAgentRunOutput, ReActAgentTemplateFactory
@@ -31,6 +30,5 @@ __all__ = [
     "ReActAgentStartEvent",
     "ReActAgentSuccessEvent",
     "ReActAgentTemplateFactory",
-    "ReActAgentToolEvent",
     "ReActAgentUpdateEvent",
 ]

--- a/python/beeai_framework/agents/react/events.py
+++ b/python/beeai_framework/agents/react/events.py
@@ -20,12 +20,10 @@ from beeai_framework.agents.react.types import (
     ReActAgentIterationMeta,
     ReActAgentIterationResult,
     ReActAgentRunIteration,
-    ReActAgentRunOptions,
 )
 from beeai_framework.backend.message import AnyMessage
 from beeai_framework.errors import FrameworkError
 from beeai_framework.memory.base_memory import BaseMemory
-from beeai_framework.tools import ToolOutput
 from beeai_framework.tools.tool import AnyTool
 
 
@@ -67,20 +65,6 @@ class ReActAgentUpdateEvent(BaseModel):
     meta: ReActAgentUpdateMeta
     tools: list[InstanceOf[AnyTool]] | None = None
     memory: InstanceOf[BaseMemory] | None = None
-
-
-class ReActAgentToolEventData(BaseModel):
-    tool: InstanceOf[AnyTool]
-    input: Any
-    options: ReActAgentRunOptions
-    iteration: ReActAgentIterationResult
-    result: InstanceOf[ToolOutput] | None = None
-    error: InstanceOf[FrameworkError] | None = None
-
-
-class ReActAgentToolEvent(BaseModel):
-    data: ReActAgentToolEventData
-    meta: ReActAgentIterationMeta
 
 
 react_agent_event_types: dict[str, type] = {

--- a/python/beeai_framework/agents/react/runners/default/runner.py
+++ b/python/beeai_framework/agents/react/runners/default/runner.py
@@ -20,8 +20,6 @@ from beeai_framework.agents.react.events import (
     ReActAgentErrorEvent,
     ReActAgentRetryEvent,
     ReActAgentStartEvent,
-    ReActAgentToolEvent,
-    ReActAgentToolEventData,
     ReActAgentUpdate,
     ReActAgentUpdateEvent,
     ReActAgentUpdateMeta,
@@ -265,19 +263,6 @@ class DefaultRunner(BaseRunner):
             )
 
         async def on_error(error: Exception, _: RetryableContext) -> None:
-            await input.emitter.emit(
-                "toolError",
-                ReActAgentToolEvent(
-                    data=ReActAgentToolEventData(
-                        iteration=input.state,
-                        tool=tool,
-                        input=input.state.tool_input,
-                        options=self._options,
-                        error=FrameworkError.ensure(error),
-                    ),
-                    meta=input.meta,
-                ),
-            )
             self._failed_attempts_counter.use(error)
 
         async def executor(_: RetryableContext) -> ReActAgentRunnerToolResult:

--- a/python/docs/events.md
+++ b/python/docs/events.md
@@ -45,9 +45,6 @@ The following events can be observed calling `ReActAgent.run`.
 | `retry`                       | `ReActAgentRetryEvent`   | Triggered when the agent is retrying an operation.         |
 | `success`                     | `ReActAgentSuccessEvent` | Triggered when the agent successfully completes execution. |
 | `update` and `partial_update` | `ReActAgentUpdateEvent`  | Triggered when the agent updates its state.                |
-| `tool_start`                  | `ReActAgentToolEvent`    | Triggered when the agent begins using a tool.              |
-| `tool_success`                | `ReActAgentToolEvent`    | Triggered when a tool operation completes successfully.    |
-| `tool_error`                  | `ReActAgentToolEvent`    | Triggered when a tool operation fails.                     |
 
 _Source: [python/beeai_framework/agents/react/events.py](/python/beeai_framework/agents/react/events.py)_
 


### PR DESCRIPTION

### Which issue(s) does this pull-request address?

Followup to #726

### Description

Removes the remaining references to `ReActAgentToolEvent`

### Checklist

#### General
- [x] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [x] Linting passes: Python `poe lint` or `poe lint --fix` / TypeScript `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: Python `poe format` or `poe format --fix` / TypeScript: `yarn format` or `yarn format:fix`
- [x] Static type checks pass: Python `poe type-check`

#### Testing
- [x] Unit tests pass: Python `poe test --type unit` / TypeScript `yarn test:unit`
- [x] E2E tests pass: Python `poe test --type e2e` / TypeScript: `yarn test:e2e`
- [x] Integration tests pass: Python `poe test --type integration`
- [x] Tests are included (for bug fixes or new features)

#### Documentation
- [x] Documentation is updated
- [x] Embedme embeds code examples in docs. To update after edits, run: Python `poe docs --type build`
