### PR TITLE
fix: Fix tool calling error with watsonx

### DIFF
--- a/python/beeai_framework/adapters/watsonx/backend/chat.py
+++ b/python/beeai_framework/adapters/watsonx/backend/chat.py
@@ -12,12 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import os
 from typing import Any, ClassVar
 
+# Import necessary types from base classes and pydantic
+from pydantic import BaseModel
+
 from beeai_framework.adapters.litellm.chat import LiteLLMChatModel
 from beeai_framework.backend.constants import ProviderName
+
+# Assuming ChatModelInput is needed for _transform_input override later
 from beeai_framework.logger import Logger
 
 logger = Logger(__name__)
@@ -25,6 +29,7 @@ logger = Logger(__name__)
 
 class WatsonxChatModel(LiteLLMChatModel):
     tool_choice_support: ClassVar[set[str]] = {"none", "single", "auto"}
+    # TODO: WatsonX seems to require 'required' for tool_choice when forcing a tool call
 
     @property
     def provider_id(self) -> ProviderName:
@@ -47,13 +52,19 @@ class WatsonxChatModel(LiteLLMChatModel):
     def __init__(self, model_id: str | None = None, settings: dict[str, Any] | None = None) -> None:
         _settings = settings.copy() if settings is not None else {}
 
-        # Set space_id only if not already in settings
+        # Set project_id (LiteLLM uses project_id for WatsonX)
+        if "project_id" not in _settings or not _settings["project_id"]:
+            watsonx_project_id = os.getenv("WATSONX_PROJECT_ID")
+            if watsonx_project_id:
+                _settings["project_id"] = watsonx_project_id
+
+        # Set space_id only if not already in settings - also used in watsonx
         if "space_id" not in _settings or not _settings["space_id"]:
             watsonx_space_id = os.getenv("WATSONX_SPACE_ID")
             if watsonx_space_id:
                 _settings["space_id"] = watsonx_space_id
 
-        # Set URL based on priority: existing setting > WATSONX_URL env > region-based > error
+        # Set URL (api_base for LiteLLM)
         if "api_base" not in _settings or not _settings["api_base"]:
             watsonx_url = os.getenv("WATSONX_URL")
             if watsonx_url:
@@ -68,9 +79,26 @@ class WatsonxChatModel(LiteLLMChatModel):
                         "set the WATSONX_URL environment variable, "
                         "or set the WATSONX_REGION environment variable."
                     )
+        # TODO: Consider validating other sufficient parms are provided
 
         super().__init__(
-            model_id if model_id else os.getenv("WATSONX_CHAT_MODEL", "ibm/granite-3-8b-instruct"),
+            model_id=model_id if model_id else os.getenv("WATSONX_CHAT_MODEL", "ibm/granite-3-8b-instruct"),
             provider_id="watsonx",
             settings=_settings,
         )
+
+    def _format_response_model(
+        self, model: type[BaseModel] | dict[str, Any] | None
+    ) -> type[BaseModel] | dict[str, Any]:
+        """
+        Based on the error "Missing json field response_format.type", watsonx
+        return {'type': 'json_object'} when a format is requested.
+        """
+        if model is None:
+            # If no response format schema was provided in the input, return empty dict.
+            return {}
+
+        # Regardless of the input schema details (BaseModel type or dict),
+        # return the specific dictionary that WatsonX expects to enable JSON mode.
+        logger.debug("Formatting response_format for WatsonX: {'type': 'json_object'}")
+        return {"type": "json_object"}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review and complete the sections below.
-->

### Which issue(s) does this pull-request address?

<!--
Please include a link to an issue in the tracker.  The issue describes the problem to be solved.  If there is no issue raised for this PR then either raise one with a summary and description of the problem or add a summary and description of the problem here
-->

Closes: #746

### Description

<!-- Provide a description of the change, pay special attention to describing any breaking changes.  The description describes the resolution to the problem described in the linked issue (or to the problem outlined in this PR). -->

Fixes an issue with watsonx whereby passing a schema as `response_format` is not supported by watsonx and results in an API error
```shell
litellm.llms.openai_like.common_utils.OpenAILikeError: {"errors":[{"code":"invalid_request_entity","message":"Missing json field response_format.type in request entity","more_info":"https://cloud.ibm.com/apidocs/watsonx-ai"}],"trace":"4f007b7b872ef0660bc129c0958d3336","status_code":400}
```
This was due to response_format being set to a schema - for example this *begins*:
```json
"response_format": {
        "anyOf": [
            {
                "additionalProperties": "False",
                "properties": {
                    "name": {
                        "const": "OpenMeteoTool",
```
The response_format can only be specified as json (see [spec](https://ibm.github.io/watsonx-ai-python-sdk/fm_schema.html#chat-parameters)) . A spec cannot be provided, nor can an additional scheme be added (as [ollama supports](https://github.com/ollama/ollama/blob/main/docs/api.md))

NOTES:
 - The main fix is the definition of `_format_response_model`(the rest is some format & minor parameter corrections)
 - Tested this works with the travel planner example. Before the fix this fails. After it works
 - Tried several llama and granite models with consistent results
 - Unclear if it could apply to other providers/models, so opted to localise changes to watsonx
 - looking for review comments to check how this relates to `tool_call_fallback_via_response_format`
 - Not being able to specify a schema in the response format (which ollama, as an example, does support) is reduced functionality, and could result in less reliability in the results of tool calls, but other than consider extending prompt, unclear what else could be done.

### Checklist

#### General
- [ ] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [ ] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [ ] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [ ] Linting passes: Python `poe lint` or `poe lint --fix` / TypeScript `yarn lint` or `yarn lint:fix`
- [ ] Formatting is applied: Python `poe format` or `poe format --fix` / TypeScript: `yarn format` or `yarn format:fix`
- [ ] Static type checks pass: Python `poe type-check`

#### Testing
- [ ] Unit tests pass: Python `poe test --type unit` / TypeScript `yarn test:unit`
- [ ] E2E tests pass: Python `poe test --type e2e` / TypeScript: `yarn test:e2e`
- [ ] Integration tests pass: Python `poe test --type integration`
- [ ] Tests are included (for bug fixes or new features)

#### Documentation
- [ ] Documentation is updated
- [ ] Embedme embeds code examples in docs. To update after edits, run: Python `poe docs --type build`
