### PR TITLE
fix: typeerror when cloning chatmodel

### DIFF
--- a/python/beeai_framework/adapters/litellm/chat.py
+++ b/python/beeai_framework/adapters/litellm/chat.py
@@ -282,11 +282,7 @@ class LiteLLMChatModel(ChatModel, ABC):
         return model
 
     async def clone(self) -> Self:
-        if self.__class__ == LiteLLMChatModel:
-            cloned = type(self)(self._model_id, provider_id=self._litellm_provider_id, settings=self._settings)
-        else:
-            cloned = type(self)(self._model_id, settings=self._settings)  # type: ignore [call-arg]
-
+        cloned = type(self)(self._model_id, settings=self._settings.copy())  # type: ignore
         cloned.parameters = self.parameters.model_copy() if self.parameters else ChatModelParameters()
         cloned.cache = await self.cache.clone() if self.cache else NullCache[list[ChatModelOutput]]()
         cloned.tool_call_fallback_via_response_format = self.tool_call_fallback_via_response_format

--- a/python/beeai_framework/adapters/litellm/chat.py
+++ b/python/beeai_framework/adapters/litellm/chat.py
@@ -282,13 +282,15 @@ class LiteLLMChatModel(ChatModel, ABC):
         return model
 
     async def clone(self) -> Self:
-        kwargs: ChatModelKwargs = {
-            "parameters": self.parameters.model_copy() if self.parameters else ChatModelParameters(),
-            "cache": await self.cache.clone() if self.cache else NullCache[list[ChatModelOutput]](),
-            "tool_call_fallback_via_response_format": self.tool_call_fallback_via_response_format,
-            "model_supports_tool_calling": self.model_supports_tool_calling,
-        }
-        cloned = type(self)(self._model_id, provider_id=self._litellm_provider_id, settings=self._settings, **kwargs)
+        if self.__class__ == LiteLLMChatModel:
+            cloned = type(self)(self._model_id, provider_id=self._litellm_provider_id, settings=self._settings)
+        else:
+            cloned = type(self)(self._model_id, settings=self._settings)  # type: ignore [call-arg]
+
+        cloned.parameters = self.parameters.model_copy() if self.parameters else ChatModelParameters()
+        cloned.cache = await self.cache.clone() if self.cache else NullCache[list[ChatModelOutput]]()
+        cloned.tool_call_fallback_via_response_format = self.tool_call_fallback_via_response_format
+        cloned.model_supports_tool_calling = self.model_supports_tool_calling
         return cloned
 
 

--- a/python/beeai_framework/adapters/ollama/backend/chat.py
+++ b/python/beeai_framework/adapters/ollama/backend/chat.py
@@ -43,7 +43,6 @@ class OllamaChatModel(LiteLLMChatModel):
         if not base_url.endswith("/v1"):
             base_url += "/v1"
 
-        kwargs.pop("provider_id", None)  # type: ignore [typeddict-item]
         super().__init__(
             model_id if model_id else os.getenv("OLLAMA_CHAT_MODEL", "llama3.1"),
             provider_id="openai",

--- a/python/beeai_framework/adapters/ollama/backend/chat.py
+++ b/python/beeai_framework/adapters/ollama/backend/chat.py
@@ -43,6 +43,7 @@ class OllamaChatModel(LiteLLMChatModel):
         if not base_url.endswith("/v1"):
             base_url += "/v1"
 
+        kwargs.pop("provider_id", None)  # type: ignore [typeddict-item]
         super().__init__(
             model_id if model_id else os.getenv("OLLAMA_CHAT_MODEL", "llama3.1"),
             provider_id="openai",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review and complete the sections below.
-->

### Which issue(s) does this pull-request address?

TypeError when trying to clone a chatmodel:

```
TypeError: beeai_framework.adapters.litellm.chat.LiteLLMChatModel.__init__() got multiple values for keyword argument 'provider_id'
```


Closes: #

### Description

TypeError when trying to clone a chatmodel:

```python
async def main() -> None:
    model = OllamaChatModel(model_id="llama3.1")
    return await model.clone()  # throws an error
```

error thrown:
```
TypeError: beeai_framework.adapters.litellm.chat.LiteLLMChatModel.__init__() got multiple values for keyword argument 'provider_id'
```


### Checklist

#### General
- [x] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [x] Linting passes: Python `poe lint` or `poe lint --fix` / TypeScript `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: Python `poe format` or `poe format --fix` / TypeScript: `yarn format` or `yarn format:fix`
- [x] Static type checks pass: Python `poe type-check`

#### Testing
- [x] Unit tests pass: Python `poe test --type unit` / TypeScript `yarn test:unit`
- [x] E2E tests pass: Python `poe test --type e2e` / TypeScript: `yarn test:e2e`
- [x] Integration tests pass: Python `poe test --type integration`
- [x] Tests are included (for bug fixes or new features)

#### Documentation
- [ ] Documentation is updated
- [ ] Embedme embeds code examples in docs. To update after edits, run: Python `poe docs --type build`
