### PR TITLE
docs(tools): clarify pip install message

### DIFF
--- a/python/beeai_framework/adapters/langchain/tools.py
+++ b/python/beeai_framework/adapters/langchain/tools.py
@@ -22,7 +22,7 @@ try:
     from langchain_core.tools import Tool as LangChainSimpleTool
 except ModuleNotFoundError as e:
     raise ModuleNotFoundError(
-        "Optional module [langchain] not found.\nRun 'pip install beeai-framework[langchain]' to install."
+        "Optional module [langchain] not found.\nRun 'pip install \"beeai-framework[langchain]\"' to install."
     ) from e
 
 from pydantic import BaseModel, ConfigDict

--- a/python/beeai_framework/agents/experimental/remote/agent.py
+++ b/python/beeai_framework/agents/experimental/remote/agent.py
@@ -20,7 +20,7 @@ try:
     from acp_sdk.models.errors import Error
 except ModuleNotFoundError as e:
     raise ModuleNotFoundError(
-        "Optional module [acp] not found.\nRun 'pip install beeai-framework[acp]' to install."
+        "Optional module [acp] not found.\nRun 'pip install \"beeai-framework[acp]\"' to install."
     ) from e
 
 from beeai_framework.agents.base import BaseAgent

--- a/python/beeai_framework/tools/mcp/mcp.py
+++ b/python/beeai_framework/tools/mcp/mcp.py
@@ -21,7 +21,7 @@ try:
     from mcp.types import Tool as MCPToolInfo
 except ModuleNotFoundError as e:
     raise ModuleNotFoundError(
-        "Optional module [mcp] not found.\nRun 'pip install beeai-framework[mcp]' to install."
+        "Optional module [mcp] not found.\nRun 'pip install \"beeai-framework[mcp]\"' to install."
     ) from e
 
 from pydantic import BaseModel

--- a/python/beeai_framework/tools/search/duckduckgo/duckduckgo.py
+++ b/python/beeai_framework/tools/search/duckduckgo/duckduckgo.py
@@ -19,7 +19,7 @@ try:
     from duckduckgo_search import DDGS
 except ModuleNotFoundError as e:
     raise ModuleNotFoundError(
-        "Optional module [duckduckgo] not found.\nRun 'pip install beeai-framework[duckduckgo]' to install."
+        "Optional module [duckduckgo] not found.\nRun 'pip install \"beeai-framework[duckduckgo]\"' to install."
     ) from e
 
 from pydantic import BaseModel, Field

--- a/python/beeai_framework/tools/search/wikipedia/wikipedia.py
+++ b/python/beeai_framework/tools/search/wikipedia/wikipedia.py
@@ -17,7 +17,7 @@ try:
     import wikipediaapi  # type: ignore
 except ModuleNotFoundError as e:
     raise ModuleNotFoundError(
-        "Optional module [wikipedia] not found.\nRun 'pip install beeai-framework[wikipedia]' to install."
+        "Optional module [wikipedia] not found.\nRun 'pip install \"beeai-framework[wikipedia]\"' to install."
     ) from e
 
 from pydantic import BaseModel, Field


### PR DESCRIPTION
Ref: #807

<!--
Thank you for your pull request. Please review and complete the sections below.
-->

### Which issue(s) does this pull-request address?

<!--
Please include a link to an issue in the tracker.  The issue describes the problem to be solved.  If there is no issue raised for this PR then either raise one with a summary and description of the problem or add a summary and description of the problem here
-->

Closes: #

### Description

<!-- Provide a description of the change, pay special attention to describing any breaking changes.  The description describes the resolution to the problem described in the linked issue (or to the problem outlined in this PR). -->

On some Unix/Linux shells, such as zsh, square brackets `[` and `]` are pre-processed by the shell and not handed over to the pip command, resulting in a confusing error statement such as:
```sh
$ pip3 install beeai-framework[wikipedia] --dry-run
zsh: no matches found: beeai-framework[wikipedia]
```

This PR clarifies the installation command by including quotes to stop shells from pre-processing the command, and passing it as-is to pip to run.

### Checklist

#### General
- [x] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [x] Linting passes: Python `poe lint` or `poe lint --fix` / TypeScript `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: Python `poe format` or `poe format --fix` / TypeScript: `yarn format` or `yarn format:fix`
- [x] Static type checks pass: Python `poe type-check`

#### Testing
- [ ] Unit tests pass: Python `poe test --type unit` / TypeScript `yarn test:unit`
- [ ] E2E tests pass: Python `poe test --type e2e` / TypeScript: `yarn test:e2e`
- [ ] Integration tests pass: Python `poe test --type integration`
- [ ] Tests are included (for bug fixes or new features)

#### Documentation
- [ ] Documentation is updated
- [ ] Embedme embeds code examples in docs. To update after edits, run: Python `poe docs --type build`
