### PR TITLE
feat: experimental workflows prototype

### DIFF
--- a/python/beeai_framework/workflows/experimental/__init__.py
+++ b/python/beeai_framework/workflows/experimental/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/python/beeai_framework/workflows/experimental/agent.py
+++ b/python/beeai_framework/workflows/experimental/agent.py
@@ -1,0 +1,123 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import random
+
+from pydantic import BaseModel
+
+from beeai_framework.workflows.experimental.workflow import Workflow, fan_in, listen, router, start
+
+
+class MyAgentState(BaseModel):
+    a: int = 0
+    b: int = 0
+    c: int = 0
+    status: str = ""
+
+
+class MyAgent(Workflow[MyAgentState]):
+    @start
+    async def start(self) -> None:
+        """Start the agent workflow"""
+        print("Starting")
+        print("Start state:", self.state)
+
+    @router("start")
+    async def route(self) -> str:
+        """Conditional routing"""
+        print("Routing")
+        if random.randint(0, 1) > 0.5:
+            self.state.status = "proceed"
+            return "proceed"
+        else:
+            self.state.status = "stop"
+            return "stop"
+
+    @listen("stop")
+    async def stop_func(self) -> None:
+        """Listen for a conditional route"""
+        print("Stop event triggered")
+        print("Final state:", self.state)
+
+    @listen("proceed")
+    async def load_data(self) -> None:
+        """Listen for a conditional route"""
+        print("Proceed event triggered")
+
+    @listen("load_data")
+    async def process_data_a(self) -> None:
+        """Static fan out"""
+        self.state.a += 1
+        await asyncio.sleep(3)
+        print("Processed a...")
+
+    @listen("load_data")
+    async def process_data_b(self) -> None:
+        """Static fan out"""
+        self.state.b += 1
+        await asyncio.sleep(2)
+        print("Processed b...")
+
+    @listen("load_data")
+    async def process_data_c(self) -> None:
+        """Static fan out"""
+        self.state.c += 1
+        await asyncio.sleep(1)
+        print("Processed c...")
+
+    @listen("process_data_a", "process_data_b", "process_data_c")
+    async def do_fan_out(self) -> None:
+        """Static fan in, AND logic"""
+        print("Processing complete")
+        print("State is now:", self.state)
+        print("Dynamic fan out")
+        # Dynamically fan out
+        await self.fan_out("process", [["a"], ["b"], ["c"]], fan_in="fan_in")
+
+    async def process(self, item: str) -> str:
+        if item == "a":
+            self.state.a += 1
+            await asyncio.sleep(3)
+        elif item == "b":
+            self.state.b += 1
+            await asyncio.sleep(2)
+        elif item == "c":
+            self.state.c += 1
+            await asyncio.sleep(1)
+
+        print(f"Fan out function called: {item}")
+        return item
+
+    @fan_in("fan_in")
+    async def done(self, results: list[str]) -> None:
+        """Waits on fan_in event from the fan_out operation"""
+        for r in results:
+            print(r)
+
+        print("Final state:", self.state)
+        print("Done!")
+
+
+async def main() -> None:
+    agent = MyAgent()
+    await agent.run(MyAgentState())
+
+    print("########")
+
+    agent2 = MyAgent()
+    await agent2.run(MyAgentState())
+
+
+asyncio.run(main())

--- a/python/beeai_framework/workflows/experimental/workflow.py
+++ b/python/beeai_framework/workflows/experimental/workflow.py
@@ -1,0 +1,158 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import functools
+import inspect
+import types
+from collections import defaultdict
+from collections.abc import Callable, Coroutine
+from typing import Any, Generic, TypeVar
+
+from pydantic import BaseModel
+
+StateType = TypeVar("StateType", bound=BaseModel)
+# TODO: Dont know how to type self
+F = TypeVar("F", bound=Callable[[Any], Coroutine[Any, Any, None]])
+# TODO: Dont know how to type self
+F_FIN = TypeVar("F_FIN", bound=Callable[[Any, list[Any]], Coroutine[Any, Any, None]])
+# TODO: Dont know how to type self
+F_ROUTER = TypeVar("F_ROUTER", bound=Callable[[Any], Coroutine[Any, Any, str]])
+
+
+def start(func: F) -> F:
+    func._is_start = True  # type: ignore[attr-defined]
+    return func
+
+
+def listen(*func_names: str) -> Callable[[F], F]:
+    def decorator(func: F) -> F:
+        if func.__name__ in func_names:
+            raise ValueError(f"Method '{func.__name__}' cannot listen to itself.")
+        func._listens_to = set(func_names)  # type: ignore[attr-defined]
+        return func
+
+    return decorator
+
+
+def fan_in(func_name: str) -> Callable[[F_FIN], F_FIN]:
+    def decorator(func: F_FIN) -> F_FIN:
+        if func.__name__ == func_name:
+            raise ValueError(f"Method '{func.__name__}' cannot listen to itself.")
+        func._listens_to = {func_name}  # type: ignore[attr-defined]
+        return func
+
+    return decorator
+
+
+def router(*func_names: str) -> Callable[[F_ROUTER], F_ROUTER]:
+    def decorator(func: F_ROUTER) -> F_ROUTER:
+        if func.__name__ in func_names:
+            raise ValueError(f"Method '{func.__name__}' cannot listen to itself.")
+        func._listens_to = set(func_names)  # type: ignore[attr-defined]
+        func._is_router = True  # type: ignore[attr-defined]
+        return func
+
+    return decorator
+
+
+class Workflow(Generic[StateType]):
+    def __init__(self, max_concurrency: int = 20) -> None:
+        self._listeners: dict[str, set[str]] = {}
+        self._fired_sources_map: dict[str, set[str]] = defaultdict(set)
+        self._start_method: str | None = None
+        subclass = self.__class__  # Get the subclass
+
+        # initialize static listeners from static decorator metadata
+        for name, method in subclass.__dict__.items():
+            if inspect.iscoroutinefunction(method):
+                if hasattr(method, "_listens_to"):
+                    for dependency in method._listens_to:
+                        self._listeners.setdefault(dependency, set()).add(name)
+                if hasattr(method, "_is_start"):
+                    if self._start_method is not None:
+                        raise RuntimeError("Only one @start method is allowed per class.")
+                    self._start_method = name
+
+        # Wrap static methods
+        self._wrap_all_listeners()
+        self._max_concurrency = max_concurrency
+
+    def _wrap_all_listeners(self) -> None:
+        for method_name in self._listeners:
+            if hasattr(self, method_name):  # Only wrap if method actually exists
+                self._wrap_method(method_name)
+
+    def _wrap_method(self, method_name: str) -> None:
+        orig = getattr(self, method_name)
+
+        @functools.wraps(orig)
+        async def wrapped(self: "Workflow[StateType]", *args: tuple[Any, ...], **kwargs: dict[str, Any]) -> Any:
+            result = await orig(*args, **kwargs)
+            await self._run_listeners(method_name)
+            return result
+
+        setattr(self, method_name, types.MethodType(wrapped, self))
+
+    def _ready_to_run(self, listener_name: str, triggered_method: str) -> bool:
+        listener_func = getattr(self, listener_name).__func__
+        sources = self._fired_sources_map[listener_name]
+        sources.add(triggered_method)
+
+        if sources == listener_func._listens_to:
+            self._fired_sources_map[listener_name].clear()
+            return True
+        return False
+
+    async def _run_listeners(self, triggered_method: str) -> None:
+        listeners = [
+            getattr(self, listener_name)()
+            for listener_name in self._listeners.get(triggered_method, [])
+            if self._ready_to_run(listener_name, triggered_method)
+        ]
+
+        results = await asyncio.gather(*listeners)
+        routes = [r for r in results if r is not None]
+
+        for r in routes:
+            await self._run_listeners(r)
+
+    async def fan_out(self, method_name: str, args_list: list[Any], fan_in: str) -> None:
+        sem = asyncio.Semaphore(self._max_concurrency)
+
+        async def run_one(args: Any) -> Any:
+            async with sem:
+                method = getattr(self, method_name)
+                if not isinstance(args, list | tuple):
+                    args = [args]
+                return await method(*args)
+
+        results: list[Any] = await asyncio.gather(*[run_one(args) for args in args_list], return_exceptions=True)
+
+        # Call fan_in directly, bypass static listeners
+        listeners = [
+            getattr(self, listener_name)(results)
+            for listener_name in self._listeners.get(fan_in, [])
+            if self._ready_to_run(listener_name, fan_in)
+        ]
+
+        await asyncio.gather(*listeners)
+
+    async def run(self, state: StateType) -> None:
+        if self._start_method is None:
+            raise RuntimeError("No @start method defined.")
+
+        self.state = state
+
+        await getattr(self, self._start_method)()


### PR DESCRIPTION
### Which issue(s) does this pull-request address?

The PR contains a prototype for more flexible workflows. Its supports the standard features of our previous implementation such as shared state, and basic flows but adds:

1. Workflow is defined in a single class
2. Each step in a method
3. Support static fan out and in
4. Supports dynamic fan out and in 

The major advantage of this approach is that you can have a step wait on multiple other steps to run, and you can have multiple steps that wait on a single step. The implementation also supports dynamic fan out/in.

### Checklist

#### General
- [x] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [x] Linting passes: Python `poe lint` or `poe lint --fix` / TypeScript `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: Python `poe format` or `poe format --fix` / TypeScript: `yarn format` or `yarn format:fix`
- [x] Static type checks pass: Python `poe type-check`

#### Testing
- [x] Unit tests pass: Python `poe test --type unit` / TypeScript `yarn test:unit`
- [x] E2E tests pass: Python `poe test --type e2e` / TypeScript: `yarn test:e2e`
- [x] Integration tests pass: Python `poe test --type integration`
- [ ] Tests are included (for bug fixes or new features)

#### Documentation
- [ ] Documentation is updated
- [ ] Embedme embeds code examples in docs. To update after edits, run: Python `poe docs --type build`
