### PR TITLE
test(examples): Address failing e2e test

### DIFF
--- a/python/tests/examples/test_examples.py
+++ b/python/tests/examples/test_examples.py
@@ -49,6 +49,7 @@ exclude = list(
             "agents/experimental/remote.py",
             "workflows/remote.py",
             "serve/acp.py",
+            "serve/acp_with_custom_agent.py",
             # Requires Code Interpreter to be running
             "tools/python_tool.py" if os.getenv("CODE_INTERPRETER_URL") is None else None,
             "tools/custom/sandbox.py" if os.getenv("CODE_INTERPRETER_URL") is None else None,


### PR DESCRIPTION
### Description

#810 added a couple new examples for ACP, but didn't add both the to example test whitelist, causing the e2e tests to fail if the platform is not running

### Checklist

#### General
- [x] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [x] Linting passes: Python `poe lint` or `poe lint --fix` / TypeScript `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: Python `poe format` or `poe format --fix` / TypeScript: `yarn format` or `yarn format:fix`
- [x] Static type checks pass: Python `poe type-check`

#### Testing
- [x] Unit tests pass: Python `poe test --type unit` / TypeScript `yarn test:unit`
- [x] E2E tests pass: Python `poe test --type e2e` / TypeScript: `yarn test:e2e`
- [x] Integration tests pass: Python `poe test --type integration`
- [x] Tests are included (for bug fixes or new features)

#### Documentation
- [x] Documentation is updated
- [x] Embedme embeds code examples in docs. To update after edits, run: Python `poe docs --type build`
