### PR TITLE
fix: expose watsonx embedding model

### DIFF
--- a/python/beeai_framework/adapters/watsonx/__init__.py
+++ b/python/beeai_framework/adapters/watsonx/__init__.py
@@ -13,5 +13,6 @@
 # limitations under the License.
 
 from beeai_framework.adapters.watsonx.backend.chat import WatsonxChatModel
+from beeai_framework.adapters.watsonx.backend.embedding import WatsonxEmbeddingModel
 
-__all__ = ["WatsonxChatModel"]
+__all__ = ["WatsonxChatModel", "WatsonxEmbeddingModel"]


### PR DESCRIPTION
### Which issue(s) does this pull-request address?

I was using the watsonx embeddings support and realized that the `WatsonxEmbeddingModel` is not exposed for use by library users. 


### Description

Expose `WatsonxEmbeddingModel` from the watsonx backend module.

### Checklist

#### General
- [x] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [x] Linting passes: Python `poe lint` or `poe lint --fix` / TypeScript `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: Python `poe format` or `poe format --fix` / TypeScript: `yarn format` or `yarn format:fix`
- [x] Static type checks pass: Python `poe type-check`

#### Testing
- [x] Unit tests pass: Python `poe test --type unit` / TypeScript `yarn test:unit`
- [x] E2E tests pass: Python `poe test --type e2e` / TypeScript: `yarn test:e2e`
- [x] Integration tests pass: Python `poe test --type integration`
- [ ] Tests are included (for bug fixes or new features)

#### Documentation
- [ ] Documentation is updated
- [ ] Embedme embeds code examples in docs. To update after edits, run: Python `poe docs --type build`
