### PR TITLE
refactor!: introduce runnable interface 

### DIFF
--- a/python/beeai_framework/agents/__init__.py
+++ b/python/beeai_framework/agents/__init__.py
@@ -14,6 +14,6 @@
 
 from beeai_framework.agents.base import AnyAgent, BaseAgent
 from beeai_framework.agents.errors import AgentError
-from beeai_framework.agents.types import AgentExecutionConfig, AgentMeta, BaseAgentRunOptions
+from beeai_framework.agents.types import AgentExecutionConfig, AgentMeta, AgentRunOutput
 
-__all__ = ["AgentError", "AgentExecutionConfig", "AgentMeta", "AnyAgent", "BaseAgent", "BaseAgentRunOptions"]
+__all__ = ["AgentError", "AgentExecutionConfig", "AgentMeta", "AgentRunOutput", "AnyAgent", "BaseAgent"]

--- a/python/beeai_framework/agents/__init__.py
+++ b/python/beeai_framework/agents/__init__.py
@@ -14,6 +14,6 @@
 
 from beeai_framework.agents.base import AnyAgent, BaseAgent
 from beeai_framework.agents.errors import AgentError
-from beeai_framework.agents.types import AgentExecutionConfig, AgentMeta, AgentRunOutput
+from beeai_framework.agents.types import AgentContext, AgentMeta, AgentRunOutput
 
-__all__ = ["AgentError", "AgentExecutionConfig", "AgentMeta", "AgentRunOutput", "AnyAgent", "BaseAgent"]
+__all__ = ["AgentContext", "AgentError", "AgentMeta", "AgentRunOutput", "AnyAgent", "BaseAgent"]

--- a/python/beeai_framework/agents/base.py
+++ b/python/beeai_framework/agents/base.py
@@ -21,7 +21,7 @@ from pydantic import BaseModel
 from typing_extensions import TypeVar
 
 from beeai_framework.agents.errors import AgentError
-from beeai_framework.agents.types import AgentExecutionConfig, AgentMeta, AgentRunOutput
+from beeai_framework.agents.types import AgentContext, AgentMeta, AgentRunOutput
 from beeai_framework.backend.message import UserMessage
 from beeai_framework.context import Run, RunContext, RunMiddlewareType
 from beeai_framework.emitter import Emitter
@@ -32,7 +32,7 @@ from beeai_framework.utils.models import ModelLike
 
 Input = TypeVar("Input", bound=str | UserMessage | ModelLike, default=str)
 Output = TypeVar("Output", bound=BaseModel, default=AgentRunOutput)
-Config = TypeVar("Config", bound=AgentExecutionConfig, default=AgentExecutionConfig)
+Config = TypeVar("Config", bound=AgentContext, default=AgentContext)
 
 
 class BaseAgent(Runnable[Input, Output, Config]):

--- a/python/beeai_framework/agents/experimental/agent.py
+++ b/python/beeai_framework/agents/experimental/agent.py
@@ -18,7 +18,7 @@ from typing import Any
 from pydantic import BaseModel
 from typing_extensions import TypeVar
 
-from beeai_framework.agents import AgentError, AgentExecutionConfig, AgentMeta
+from beeai_framework.agents import AgentContext, AgentError, AgentMeta
 from beeai_framework.agents.base import BaseAgent
 from beeai_framework.agents.experimental._utils import _create_system_message
 from beeai_framework.agents.experimental.events import (
@@ -67,7 +67,7 @@ RequirementAgentRequirement = Requirement[RequirementAgentRunState]
 TOutput = TypeVar("TOutput", bound=BaseModel, default=FinalAnswerToolSchema)
 
 
-class RequirementAgent(BaseAgent[str, RequirementAgentRunOutput, AgentExecutionConfig]):
+class RequirementAgent(BaseAgent[str, RequirementAgentRunOutput, AgentContext]):
     def __init__(
         self,
         *,
@@ -110,8 +110,8 @@ class RequirementAgent(BaseAgent[str, RequirementAgentRunOutput, AgentExecutionC
         self._meta = AgentMeta(name=name or "", description=description or "", tools=self._tools)
         self.middlewares.extend(middlewares or [])
 
-    def run(self, input: str, config: AgentExecutionConfig | None = None) -> Run[RequirementAgentRunOutput[TOutput]]:
-        run_config = config or AgentExecutionConfig(max_retries_per_step=3)
+    def run(self, input: str, context: AgentContext | None = None) -> Run[RequirementAgentRunOutput[TOutput]]:
+        run_config = context or AgentContext(max_retries_per_step=3)
 
         async def init_state() -> tuple[RequirementAgentRunState, UserMessage | None]:
             state = RequirementAgentRunState(

--- a/python/beeai_framework/agents/experimental/types.py
+++ b/python/beeai_framework/agents/experimental/types.py
@@ -18,6 +18,7 @@ from typing import Annotated, Any, Generic
 from pydantic import BaseModel, ConfigDict, Field, InstanceOf
 from typing_extensions import TypeVar
 
+from beeai_framework.agents import AgentRunOutput
 from beeai_framework.agents.experimental.prompts import (
     RequirementAgentSystemPrompt,
     RequirementAgentSystemPromptInput,
@@ -86,27 +87,9 @@ class RequirementAgentRunState(BaseModel):
 TAnswer = TypeVar("TAnswer", bound=BaseModel, default=Any)
 
 
-class RequirementAgentRunOutput(BaseModel, Generic[TAnswer]):
-    answer: InstanceOf[AssistantMessage]
+class RequirementAgentRunOutput(AgentRunOutput, Generic[TAnswer]):
     answer_structured: TAnswer
-    memory: InstanceOf[BaseMemory]
     state: RequirementAgentRunState
-
-    @property
-    def result(self) -> AssistantMessage:
-        """
-        This property is provided for compatibility reasons only.
-        Use 'answer' instead.
-        """
-        return self.answer
-
-    @result.setter
-    def result(self, value: AssistantMessage) -> None:
-        """
-        This setter is provided for compatibility reasons only.
-        Sets the 'answer' attribute.
-        """
-        self.answer = value
 
 
 class RequirementAgentRequest(BaseModel):

--- a/python/beeai_framework/agents/react/agent.py
+++ b/python/beeai_framework/agents/react/agent.py
@@ -40,7 +40,7 @@ from beeai_framework.agents.react.types import (
     ReActAgentTemplatesKeys,
 )
 from beeai_framework.agents.types import (
-    AgentExecutionConfig,
+    AgentContext,
     AgentMeta,
 )
 from beeai_framework.backend.chat import ChatModel
@@ -52,7 +52,7 @@ from beeai_framework.template import PromptTemplate
 from beeai_framework.tools.tool import AnyTool
 
 
-class ReActAgent(BaseAgent[str, ReActAgentRunOutput, AgentExecutionConfig]):
+class ReActAgent(BaseAgent[str, ReActAgentRunOutput, AgentContext]):
     _runner: Callable[..., BaseRunner]
 
     def __init__(
@@ -62,7 +62,7 @@ class ReActAgent(BaseAgent[str, ReActAgentRunOutput, AgentExecutionConfig]):
         memory: BaseMemory,
         meta: AgentMeta | None = None,
         templates: dict[ReActAgentTemplatesKeys, PromptTemplate[Any] | ReActAgentTemplateFactory] | None = None,
-        execution: AgentExecutionConfig | None = None,
+        execution: AgentContext | None = None,
         stream: bool = True,
     ) -> None:
         super().__init__()
@@ -112,8 +112,8 @@ class ReActAgent(BaseAgent[str, ReActAgentRunOutput, AgentExecutionConfig]):
             extra_description="\n".join(extra_description) if len(tools) > 0 else None,
         )
 
-    def run(self, input: str, config: AgentExecutionConfig | None = None) -> Run[ReActAgentRunOutput]:
-        run_config = config or self._input.execution or AgentExecutionConfig()
+    def run(self, input: str, context: AgentContext | None = None) -> Run[ReActAgentRunOutput]:
+        run_config = context or self._input.execution or AgentContext()
 
         async def handler(context: RunContext) -> ReActAgentRunOutput:
             runner = self._runner(
@@ -182,7 +182,7 @@ class ReActAgent(BaseAgent[str, ReActAgentRunOutput, AgentExecutionConfig]):
                         ),
                     )
 
-            if input is not None:
+            if input:
                 await self._input.memory.add(
                     UserMessage(content=input, meta=MessageMeta({"createdAt": context.created_at}))
                 )

--- a/python/beeai_framework/agents/react/runners/base.py
+++ b/python/beeai_framework/agents/react/runners/base.py
@@ -18,7 +18,7 @@ from typing import Any, Self
 
 from pydantic import BaseModel, InstanceOf
 
-from beeai_framework.agents import AgentError, AgentExecutionConfig
+from beeai_framework.agents import AgentContext, AgentError
 from beeai_framework.agents.react.events import react_agent_event_types
 from beeai_framework.agents.react.types import (
     ReActAgentInput,
@@ -64,7 +64,7 @@ class ReActAgentRunnerToolInput(BaseModel):
 
 
 class BaseRunner(ABC):
-    def __init__(self, input: ReActAgentInput, options: AgentExecutionConfig, run: RunContext) -> None:
+    def __init__(self, input: ReActAgentInput, options: AgentContext, run: RunContext) -> None:
         self._input = input
         self._options = options
         self._memory: BaseMemory | None = None

--- a/python/beeai_framework/agents/react/runners/default/runner.py
+++ b/python/beeai_framework/agents/react/runners/default/runner.py
@@ -223,11 +223,7 @@ class DefaultRunner(BaseRunner):
                 raw=output, state=ReActAgentIterationResult.model_validate(parser.final_state, strict=False)
             )
 
-        if self._options and self._options.execution and self._options.execution.max_retries_per_step:
-            max_retries = self._options.execution.max_retries_per_step
-        else:
-            max_retries = 0
-
+        max_retries = self._options.max_retries_per_step if self._options else 0
         return await Retryable(
             RetryableInput(
                 on_retry=on_retry,
@@ -296,11 +292,7 @@ class DefaultRunner(BaseRunner):
                     output=StringToolOutput(self.templates.tool_error.render({"reason": err.explain()})),
                 )
 
-        if self._options and self._options.execution and self._options.execution.max_retries_per_step:
-            max_retries = self._options.execution.max_retries_per_step
-        else:
-            max_retries = 0
-
+        max_retries = self._options.max_retries_per_step if self._options else 0
         return await Retryable(
             RetryableInput(
                 on_error=on_error,

--- a/python/beeai_framework/agents/react/runners/granite/runner.py
+++ b/python/beeai_framework/agents/react/runners/granite/runner.py
@@ -73,7 +73,7 @@ class GraniteRunner(DefaultRunner):
         run.emitter.on("update", on_update, EmitterOptions(is_blocking=True))
 
     def _create_parser(self) -> LinePrefixParser:
-        tool_names = create_strenum("ToolsEnum", [tool.name for tool in self._input.tools])
+        tool_names = create_strenum("ToolsEnum", [tool.name for tool in self._input.tools] if self._input.tools else [])
 
         return LinePrefixParser(
             nodes={

--- a/python/beeai_framework/agents/react/runners/granite/runner.py
+++ b/python/beeai_framework/agents/react/runners/granite/runner.py
@@ -14,6 +14,7 @@
 
 from typing import Any
 
+from beeai_framework.agents import AgentExecutionConfig
 from beeai_framework.agents.react.events import ReActAgentUpdateEvent
 from beeai_framework.agents.react.runners.default.prompts import ToolNoResultsTemplate, UserEmptyPromptTemplate
 from beeai_framework.agents.react.runners.default.runner import DefaultRunner
@@ -29,7 +30,6 @@ from beeai_framework.agents.react.runners.granite.prompts import (
 from beeai_framework.agents.react.types import (
     ReActAgentInput,
     ReActAgentIterationResult,
-    ReActAgentRunOptions,
     ReActAgentTemplates,
 )
 from beeai_framework.backend.message import MessageToolResultContent, ToolMessage
@@ -45,7 +45,7 @@ from beeai_framework.utils.strings import create_strenum
 class GraniteRunner(DefaultRunner):
     use_native_tool_calling: bool = True
 
-    def __init__(self, input: ReActAgentInput, options: ReActAgentRunOptions, run: RunContext) -> None:
+    def __init__(self, input: ReActAgentInput, options: AgentExecutionConfig, run: RunContext) -> None:
         super().__init__(input, options, run)
 
         async def on_update(data: ReActAgentUpdateEvent, event: EventMeta) -> None:

--- a/python/beeai_framework/agents/react/runners/granite/runner.py
+++ b/python/beeai_framework/agents/react/runners/granite/runner.py
@@ -14,7 +14,7 @@
 
 from typing import Any
 
-from beeai_framework.agents import AgentExecutionConfig
+from beeai_framework.agents import AgentContext
 from beeai_framework.agents.react.events import ReActAgentUpdateEvent
 from beeai_framework.agents.react.runners.default.prompts import ToolNoResultsTemplate, UserEmptyPromptTemplate
 from beeai_framework.agents.react.runners.default.runner import DefaultRunner
@@ -45,7 +45,7 @@ from beeai_framework.utils.strings import create_strenum
 class GraniteRunner(DefaultRunner):
     use_native_tool_calling: bool = True
 
-    def __init__(self, input: ReActAgentInput, options: AgentExecutionConfig, run: RunContext) -> None:
+    def __init__(self, input: ReActAgentInput, options: AgentContext, run: RunContext) -> None:
         super().__init__(input, options, run)
 
         async def on_update(data: ReActAgentUpdateEvent, event: EventMeta) -> None:

--- a/python/beeai_framework/agents/react/types.py
+++ b/python/beeai_framework/agents/react/types.py
@@ -17,7 +17,7 @@ from typing import Annotated, Any
 
 from pydantic import BaseModel, InstanceOf
 
-from beeai_framework.agents import AgentExecutionConfig, AgentMeta, AgentRunOutput
+from beeai_framework.agents import AgentContext, AgentMeta, AgentRunOutput
 from beeai_framework.agents.react.runners.default.prompts import (
     AssistantPromptTemplateInput,
     SchemaErrorTemplateInput,
@@ -32,7 +32,7 @@ from beeai_framework.agents.react.runners.default.prompts import (
 from beeai_framework.backend.chat import ChatModel
 from beeai_framework.backend.types import ChatModelOutput
 from beeai_framework.memory.base_memory import BaseMemory
-from beeai_framework.runnable import RunnableConfig
+from beeai_framework.runnable import RunnableContext
 from beeai_framework.template import PromptTemplate
 from beeai_framework.tools.tool import AnyTool
 from beeai_framework.utils.strings import to_json
@@ -46,8 +46,8 @@ class ReActAgentIterationMeta(BaseModel):
     iteration: int
 
 
-class ReActAgentRunOptions(RunnableConfig):
-    execution: AgentExecutionConfig | None = None
+class ReActAgentRunOptions(RunnableContext):
+    execution: AgentContext | None = None
 
 
 class ReActAgentIterationResult(BaseModel):
@@ -98,5 +98,5 @@ class ReActAgentInput(BaseModel):
     memory: InstanceOf[BaseMemory]
     meta: InstanceOf[AgentMeta] | None = None
     templates: dict[ReActAgentTemplatesKeys, InstanceOf[PromptTemplate[Any]] | ReActAgentTemplateFactory] | None = None
-    execution: AgentExecutionConfig | None = None
+    execution: AgentContext | None = None
     stream: bool = True

--- a/python/beeai_framework/agents/react/types.py
+++ b/python/beeai_framework/agents/react/types.py
@@ -94,8 +94,8 @@ ReActAgentTemplatesKeys = Annotated[str, lambda v: v in ReActAgentTemplates.mode
 
 class ReActAgentInput(BaseModel):
     llm: InstanceOf[ChatModel]
-    tools: list[InstanceOf[AnyTool]]
-    memory: InstanceOf[BaseMemory]
+    tools: list[InstanceOf[AnyTool]] | None = None
+    memory: InstanceOf[BaseMemory] | None = None
     meta: InstanceOf[AgentMeta] | None = None
     templates: dict[ReActAgentTemplatesKeys, InstanceOf[PromptTemplate[Any]] | ReActAgentTemplateFactory] | None = None
     execution: AgentContext | None = None

--- a/python/beeai_framework/agents/react/types.py
+++ b/python/beeai_framework/agents/react/types.py
@@ -17,6 +17,7 @@ from typing import Annotated, Any
 
 from pydantic import BaseModel, InstanceOf
 
+from beeai_framework.agents import AgentExecutionConfig, AgentMeta, AgentRunOutput
 from beeai_framework.agents.react.runners.default.prompts import (
     AssistantPromptTemplateInput,
     SchemaErrorTemplateInput,
@@ -28,11 +29,10 @@ from beeai_framework.agents.react.runners.default.prompts import (
     UserEmptyPromptTemplateInput,
     UserPromptTemplateInput,
 )
-from beeai_framework.agents.types import AgentExecutionConfig, AgentMeta, BaseAgentRunOptions
-from beeai_framework.backend import AssistantMessage
 from beeai_framework.backend.chat import ChatModel
 from beeai_framework.backend.types import ChatModelOutput
 from beeai_framework.memory.base_memory import BaseMemory
+from beeai_framework.runnable import RunnableConfig
 from beeai_framework.template import PromptTemplate
 from beeai_framework.tools.tool import AnyTool
 from beeai_framework.utils.strings import to_json
@@ -46,7 +46,7 @@ class ReActAgentIterationMeta(BaseModel):
     iteration: int
 
 
-class ReActAgentRunOptions(BaseAgentRunOptions):
+class ReActAgentRunOptions(RunnableConfig):
     execution: AgentExecutionConfig | None = None
 
 
@@ -72,10 +72,8 @@ class ReActAgentRunIteration(BaseModel):
     state: InstanceOf[ReActAgentIterationResult]
 
 
-class ReActAgentRunOutput(BaseModel):
-    result: InstanceOf[AssistantMessage]
+class ReActAgentRunOutput(AgentRunOutput):
     iterations: list[ReActAgentRunIteration]
-    memory: InstanceOf[BaseMemory]
 
 
 class ReActAgentTemplates(BaseModel):

--- a/python/beeai_framework/agents/tool_calling/agent.py
+++ b/python/beeai_framework/agents/tool_calling/agent.py
@@ -18,7 +18,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field, create_model
 
-from beeai_framework.agents import AgentError, AgentExecutionConfig
+from beeai_framework.agents import AgentContext, AgentError
 from beeai_framework.agents.base import BaseAgent
 from beeai_framework.agents.tool_calling.events import (
     ToolCallingAgentStartEvent,
@@ -86,8 +86,8 @@ class ToolCallingAgent(BaseAgent):
         self._tool_call_checker = tool_call_checker
         self._final_answer_as_tool = final_answer_as_tool
 
-    def run(self, input: str, config: AgentExecutionConfig | None = None) -> Run[ToolCallingAgentRunOutput]:
-        run_config = config or AgentExecutionConfig()
+    def run(self, input: str, context: AgentContext | None = None) -> Run[ToolCallingAgentRunOutput]:
+        run_config = context or AgentContext()
 
         async def handler(run_context: RunContext) -> ToolCallingAgentRunOutput:
             state = ToolCallingAgentRunState(memory=UnconstrainedMemory(), result=None, iteration=0)

--- a/python/beeai_framework/agents/tool_calling/types.py
+++ b/python/beeai_framework/agents/tool_calling/types.py
@@ -17,6 +17,7 @@ from typing import Annotated, Any
 
 from pydantic import BaseModel, Field, InstanceOf
 
+from beeai_framework.agents import AgentRunOutput
 from beeai_framework.agents.tool_calling.prompts import (
     ToolCallingAgentCycleDetectionPrompt,
     ToolCallingAgentCycleDetectionPromptInput,
@@ -49,11 +50,7 @@ class ToolCallingAgentTemplates(BaseModel):
 
 ToolCallingAgentTemplateFactory = Callable[[InstanceOf[PromptTemplate[Any]]], InstanceOf[PromptTemplate[Any]]]
 ToolCallingAgentTemplatesKeys = Annotated[str, lambda v: v in ToolCallingAgentTemplates.model_fields]
-
-
-class ToolCallingAgentRunOutput(BaseModel):
-    result: InstanceOf[AssistantMessage]
-    memory: InstanceOf[BaseMemory]
+ToolCallingAgentRunOutput = AgentRunOutput
 
 
 class ToolCallingAgentRunState(BaseModel):

--- a/python/beeai_framework/agents/types.py
+++ b/python/beeai_framework/agents/types.py
@@ -16,12 +16,12 @@ from pydantic import BaseModel, ConfigDict, Field, InstanceOf
 
 from beeai_framework.backend import AssistantMessage
 from beeai_framework.memory import BaseMemory
-from beeai_framework.runnable import RunnableConfig
+from beeai_framework.runnable import RunnableContext
 from beeai_framework.tools.tool import AnyTool
 
 
-class AgentExecutionConfig(RunnableConfig):
-    """An agent's execution configuration."""
+class AgentContext(RunnableContext):
+    """An agent's execution context."""
 
     context: str | None = None
     """

--- a/python/beeai_framework/agents/types.py
+++ b/python/beeai_framework/agents/types.py
@@ -12,24 +12,73 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pydantic import BaseModel, InstanceOf
+from pydantic import BaseModel, ConfigDict, Field, InstanceOf
 
+from beeai_framework.backend import AssistantMessage
+from beeai_framework.memory import BaseMemory
+from beeai_framework.runnable import RunnableConfig
 from beeai_framework.tools.tool import AnyTool
-from beeai_framework.utils import AbortSignal
 
 
-class BaseAgentRunOptions(BaseModel):
-    signal: AbortSignal | None = None
+class AgentExecutionConfig(RunnableConfig):
+    """An agent's execution configuration."""
 
+    context: str | None = None
+    """
+    Additional piece of context to be passed to the model.
+    """
 
-class AgentExecutionConfig(BaseModel):
-    total_max_retries: int | None = None
-    max_retries_per_step: int | None = None
-    max_iterations: int | None = None
+    expected_output: str | type[BaseModel] | None = None
+    """
+    Instruction for steering the agent towards an expected output format.
+    This can be a Pydantic model for structured output decoding and validation.
+    """
+
+    total_max_retries: int = 3
+    """
+    Maximum number of model retries.
+    """
+
+    max_retries_per_step: int = 20
+    """
+    Maximum number of model retries per step.
+    """
+
+    max_iterations: int = 10
+    """
+    Maximum number of iterations.
+    """
 
 
 class AgentMeta(BaseModel):
+    """An agent's metadata."""
+
     name: str
     description: str
     tools: list[InstanceOf[AnyTool]]
     extra_description: str | None = None
+
+
+class AgentRunOutput(BaseModel):
+    """An agent's execution output."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    answer: InstanceOf[AssistantMessage] = Field(alias="result")
+    memory: InstanceOf[BaseMemory]
+
+    @property
+    def result(self) -> AssistantMessage:
+        """
+        This property is provided for compatibility reasons only.
+        Use 'answer' instead.
+        """
+        return self.answer
+
+    @result.setter
+    def result(self, value: AssistantMessage) -> None:
+        """
+        This setter is provided for compatibility reasons only.
+        Sets the 'answer' attribute.
+        """
+        self.answer = value

--- a/python/beeai_framework/runnable.py
+++ b/python/beeai_framework/runnable.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 from abc import ABC, abstractmethod
-from typing import Generic
+from typing import Any, Generic
 
 from pydantic import BaseModel
 from typing_extensions import TypeVar
 
-from beeai_framework.backend.message import UserMessage
+from beeai_framework.backend import AnyMessage
 from beeai_framework.context import Run
 from beeai_framework.utils import AbortSignal
 from beeai_framework.utils.models import ModelLike
@@ -31,13 +31,25 @@ class RunnableContext(BaseModel):
     signal: AbortSignal | None = None
 
 
-Input = TypeVar("Input", bound=str | UserMessage | ModelLike)
+Input = TypeVar("Input", bound=str | AnyMessage | list[AnyMessage])
 Output = TypeVar("Output", bound=str | ModelLike)
-Config = TypeVar("Config", bound=RunnableContext)
+Context = TypeVar("Context", bound=RunnableContext)
 
 
-class Runnable(Generic[Input, Output, Config], ABC):
+class Runnable(Generic[Input, Context, Output], ABC):
     """A unit of work that can be invoked using a stable interface."""
 
     @abstractmethod
-    def run(self, input: Input, context: Config | None = None) -> Run[Output]: ...
+    def run(self, input: Input, context: Context | None = None, **kwargs: Any) -> Run[Output]:
+        """Invoke the runnable on a single input to produce an output.
+
+        Args:
+            input: The input to the runnable
+            context: Context to be used when invoking the runnable.
+                The context object supports predefined attributes to
+                be used in conjunction with the runnable invocation.
+
+        Returns:
+            The output of the runnable.
+        """
+        pass

--- a/python/beeai_framework/runnable.py
+++ b/python/beeai_framework/runnable.py
@@ -1,0 +1,43 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import ABC, abstractmethod
+from typing import Generic
+
+from pydantic import BaseModel
+from typing_extensions import TypeVar
+
+from beeai_framework.backend.message import UserMessage
+from beeai_framework.context import Run
+from beeai_framework.utils import AbortSignal
+from beeai_framework.utils.models import ModelLike
+
+
+class RunnableConfig(BaseModel):
+    """Configuration and runtime metadata for a Runnable."""
+
+    """The runnable's abort signal data"""
+    signal: AbortSignal | None = None
+
+
+Input = TypeVar("Input", bound=str | UserMessage | ModelLike)
+Output = TypeVar("Output", bound=str | ModelLike)
+Config = TypeVar("Config", bound=RunnableConfig)
+
+
+class Runnable(Generic[Input, Output, Config], ABC):
+    """A unit of work that can be invoked using a stable interface."""
+
+    @abstractmethod
+    def run(self, input: Input, config: Config | None = None) -> Run[Output]: ...

--- a/python/beeai_framework/runnable.py
+++ b/python/beeai_framework/runnable.py
@@ -24,7 +24,7 @@ from beeai_framework.utils import AbortSignal
 from beeai_framework.utils.models import ModelLike
 
 
-class RunnableConfig(BaseModel):
+class RunnableContext(BaseModel):
     """Configuration and runtime metadata for a Runnable."""
 
     """The runnable's abort signal data"""
@@ -33,11 +33,11 @@ class RunnableConfig(BaseModel):
 
 Input = TypeVar("Input", bound=str | UserMessage | ModelLike)
 Output = TypeVar("Output", bound=str | ModelLike)
-Config = TypeVar("Config", bound=RunnableConfig)
+Config = TypeVar("Config", bound=RunnableContext)
 
 
 class Runnable(Generic[Input, Output, Config], ABC):
     """A unit of work that can be invoked using a stable interface."""
 
     @abstractmethod
-    def run(self, input: Input, config: Config | None = None) -> Run[Output]: ...
+    def run(self, input: Input, context: Config | None = None) -> Run[Output]: ...

--- a/python/beeai_framework/tools/handoff.py
+++ b/python/beeai_framework/tools/handoff.py
@@ -58,7 +58,7 @@ class HandoffTool(Tool[HandoffSchema, ToolRunOptions, StringToolOutput]):
         target: AnyAgent = await self._target.clone()  # type: ignore
         target.memory.reset()
         await target.memory.add_many(memory.messages)
-        response = await target.run(prompt=input.task)
+        response = await target.run(input.task)
         return StringToolOutput(response.result.text)
 
     def _create_emitter(self) -> Emitter:

--- a/python/beeai_framework/utils/models.py
+++ b/python/beeai_framework/utils/models.py
@@ -16,18 +16,19 @@ from abc import ABC
 from collections.abc import Generator, Sequence
 from contextlib import suppress
 from logging import Logger
-from typing import Any, Literal, Optional, TypeVar, Union
+from typing import Any, Literal, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, GetJsonSchemaHandler, RootModel, create_model
 from pydantic.fields import FieldInfo
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import CoreSchema, SchemaValidator
+from typing_extensions import TypeVar
 
 from beeai_framework.utils.dicts import remap_key
 
 logger = Logger(__name__)
 
-T = TypeVar("T", bound=BaseModel)
+T = TypeVar("T", bound=BaseModel, default=BaseModel)
 ModelLike = Union[T, dict[str, Any]]  # noqa: UP007
 
 
@@ -117,7 +118,7 @@ class JSONSchemaModel(ABC, BaseModel):
             else:
                 target_type: type | Any = type_mapping.get(param.get("type"))  # type: ignore[arg-type]
                 if is_optional:
-                    target_type = Optional[target_type] if target_type else type(None)  # noqa: UP007
+                    target_type = Optional[target_type] if target_type else type(None)  # noqa UP007
 
                 if isinstance(param.get("const"), str):
                     target_type = Literal[param["const"]]

--- a/python/beeai_framework/workflows/agent/agent.py
+++ b/python/beeai_framework/workflows/agent/agent.py
@@ -19,7 +19,7 @@ from typing import Any, Self, overload
 
 from pydantic import BaseModel, InstanceOf
 
-from beeai_framework.agents import AgentExecutionConfig, AgentMeta
+from beeai_framework.agents import AgentContext, AgentMeta
 from beeai_framework.agents.base import AnyAgent
 from beeai_framework.agents.experimental import RequirementAgent, RequirementAgentRunOutput
 from beeai_framework.agents.tool_calling import ToolCallingAgentRunOutput
@@ -93,7 +93,7 @@ class AgentWorkflow:
         llm: ChatModel,
         instructions: str | None = None,
         tools: list[InstanceOf[AnyTool]] | None = None,
-        execution: AgentExecutionConfig | None = None,
+        execution: AgentContext | None = None,
         save_intermediate_steps: bool = True,
         meta: AgentMeta | None = None,
         tool_call_checker: ToolCallCheckerConfig | bool | None = None,
@@ -111,7 +111,7 @@ class AgentWorkflow:
         llm: ChatModel | None = None,
         instructions: str | None = None,
         tools: list[InstanceOf[AnyTool]] | None = None,
-        execution: AgentExecutionConfig | None = None,
+        execution: AgentContext | None = None,
         save_intermediate_steps: bool = True,
         meta: AgentMeta | None = None,
         tool_call_checker: ToolCallCheckerConfig | bool | None = None,
@@ -154,11 +154,11 @@ class AgentWorkflow:
             run_input = state.inputs.pop(0).model_copy() if state.inputs else AgentWorkflowInput()
             state.current_input = run_input
             agent = await create_agent(memory.as_read_only())
-            run_config = execution or AgentExecutionConfig()
+            run_config = execution or AgentContext()
             run_config.context = run_input.context
             run_config.expected_output = run_input.expected_output
             run_output: ToolCallingAgentRunOutput | RequirementAgentRunOutput = await agent.run(
-                run_input.prompt, config=run_config
+                run_input.prompt, context=run_config
             )
 
             state.final_answer = (

--- a/python/docs/agents.md
+++ b/python/docs/agents.md
@@ -45,7 +45,7 @@ BeeAI framework provides multiple agent implementations for different use cases.
 
 > [!TIP]
 >
-> Check out our new experimental [`RequirementAgent`](./experimental/requirement_agent.md) that combines the power of LLMs, tools, and requirements, all wrapped in a declarative interface. 
+> Check out our new experimental [`RequirementAgent`](./experimental/requirement_agent.md) that combines the power of LLMs, tools, and requirements, all wrapped in a declarative interface.
 > This approach will soon become a default building block for building agents and will replace the others.
 
 ### ReAct Agent
@@ -462,11 +462,12 @@ import traceback
 from pydantic import BaseModel, Field, InstanceOf
 
 from beeai_framework.adapters.ollama import OllamaChatModel
-from beeai_framework.agents import AgentMeta, BaseAgent, BaseAgentRunOptions
+from beeai_framework.agents import AgentMeta, BaseAgent
 from beeai_framework.backend import AnyMessage, AssistantMessage, ChatModel, SystemMessage, UserMessage
 from beeai_framework.context import Run, RunContext
 from beeai_framework.emitter import Emitter
 from beeai_framework.errors import FrameworkError
+from beeai_framework.runnable import RunnableConfig
 from beeai_framework.memory import BaseMemory, UnconstrainedMemory
 
 
@@ -479,7 +480,7 @@ class RunInput(BaseModel):
     message: InstanceOf[AnyMessage]
 
 
-class CustomAgentRunOptions(BaseAgentRunOptions):
+class CustomAgentRunOptions(RunnableConfig):
     max_retries: int | None = None
 
 

--- a/python/examples/agents/experimental/human.py
+++ b/python/examples/agents/experimental/human.py
@@ -2,6 +2,8 @@ import asyncio
 import sys
 import traceback
 
+from dotenv import load_dotenv
+
 from beeai_framework.adapters.ollama import OllamaChatModel
 from beeai_framework.agents import AgentExecutionConfig
 from beeai_framework.agents.react import ReActAgent
@@ -10,6 +12,8 @@ from beeai_framework.memory import TokenMemory
 from beeai_framework.tools.weather import OpenMeteoTool
 from examples.helpers.io import ConsoleReader
 from examples.tools.experimental.human import HumanTool
+
+load_dotenv()
 
 
 async def main() -> None:
@@ -36,8 +40,8 @@ async def main() -> None:
         # Run the agent and observe events
         response = (
             await agent.run(
-                prompt=prompt,
-                execution=AgentExecutionConfig(max_retries_per_step=3, total_max_retries=10, max_iterations=20),
+                prompt,
+                config=AgentExecutionConfig(max_retries_per_step=3, total_max_retries=10, max_iterations=20),
             )
             .on(
                 "update",

--- a/python/examples/agents/experimental/human.py
+++ b/python/examples/agents/experimental/human.py
@@ -5,7 +5,7 @@ import traceback
 from dotenv import load_dotenv
 
 from beeai_framework.adapters.ollama import OllamaChatModel
-from beeai_framework.agents import AgentExecutionConfig
+from beeai_framework.agents import AgentContext
 from beeai_framework.agents.react import ReActAgent
 from beeai_framework.errors import FrameworkError
 from beeai_framework.memory import TokenMemory
@@ -41,7 +41,7 @@ async def main() -> None:
         response = (
             await agent.run(
                 prompt,
-                config=AgentExecutionConfig(max_retries_per_step=3, total_max_retries=10, max_iterations=20),
+                context=AgentContext(max_retries_per_step=3, total_max_retries=10, max_iterations=20),
             )
             .on(
                 "update",

--- a/python/examples/agents/experimental/requirement/complex.py
+++ b/python/examples/agents/experimental/requirement/complex.py
@@ -1,6 +1,9 @@
 import asyncio
 import math
 
+from dotenv import load_dotenv
+
+from beeai_framework.agents import AgentExecutionConfig
 from beeai_framework.agents.experimental import RequirementAgent
 from beeai_framework.agents.experimental.prompts import (
     RequirementAgentSystemPrompt,
@@ -20,6 +23,8 @@ from beeai_framework.tools import AnyTool, Tool
 from beeai_framework.tools.search.wikipedia import WikipediaTool
 from beeai_framework.tools.think import ThinkTool
 from beeai_framework.tools.weather import OpenMeteoTool
+
+load_dotenv()
 
 
 class RepeatIfEmptyRequirement(Requirement[RequirementAgentRunState]):
@@ -81,9 +86,11 @@ async def main() -> None:
 
     response = await agent.run(
         "What to do in Boston?",
-        context="I already visited Freedom Trail.",
-        # one can pass a Pydantic model to get a structured output
-        expected_output="Detailed plan on what to do from morning to evening, split in sections each with a time range.",
+        config=AgentExecutionConfig(
+            context="I already visited Freedom Trail.",
+            # one can pass a Pydantic model to get a structured output
+            expected_output="Detailed plan on what to do from morning to evening, split in sections each with a time range.",
+        ),
     ).middleware(GlobalTrajectoryMiddleware())
 
     print(response.answer.text)

--- a/python/examples/agents/experimental/requirement/complex.py
+++ b/python/examples/agents/experimental/requirement/complex.py
@@ -3,7 +3,7 @@ import math
 
 from dotenv import load_dotenv
 
-from beeai_framework.agents import AgentExecutionConfig
+from beeai_framework.agents import AgentContext
 from beeai_framework.agents.experimental import RequirementAgent
 from beeai_framework.agents.experimental.prompts import (
     RequirementAgentSystemPrompt,
@@ -86,7 +86,7 @@ async def main() -> None:
 
     response = await agent.run(
         "What to do in Boston?",
-        config=AgentExecutionConfig(
+        context=AgentContext(
             context="I already visited Freedom Trail.",
             # one can pass a Pydantic model to get a structured output
             expected_output="Detailed plan on what to do from morning to evening, split in sections each with a time range.",

--- a/python/examples/agents/experimental/requirement/custom_requirement.py
+++ b/python/examples/agents/experimental/requirement/custom_requirement.py
@@ -1,5 +1,7 @@
 import asyncio
 
+from dotenv import load_dotenv
+
 from beeai_framework.agents.experimental import RequirementAgent
 from beeai_framework.agents.experimental.requirements import Requirement, Rule
 from beeai_framework.agents.experimental.requirements.requirement import run_with_context
@@ -8,6 +10,8 @@ from beeai_framework.backend import AssistantMessage, ChatModel
 from beeai_framework.context import RunContext
 from beeai_framework.middleware.trajectory import GlobalTrajectoryMiddleware
 from beeai_framework.tools.search.duckduckgo import DuckDuckGoSearchTool
+
+load_dotenv()
 
 
 class PrematureStopRequirement(Requirement[RequirementAgentRunState]):

--- a/python/examples/agents/experimental/requirement/demo.py
+++ b/python/examples/agents/experimental/requirement/demo.py
@@ -1,5 +1,7 @@
 import asyncio
 
+from dotenv import load_dotenv
+
 from beeai_framework.agents.experimental import RequirementAgent
 from beeai_framework.agents.experimental.requirements.conditional import ConditionalRequirement
 from beeai_framework.backend import ChatModel
@@ -7,6 +9,8 @@ from beeai_framework.middleware.trajectory import GlobalTrajectoryMiddleware
 from beeai_framework.tools.search.duckduckgo import DuckDuckGoSearchTool
 from beeai_framework.tools.think import ThinkTool
 from beeai_framework.tools.weather import OpenMeteoTool
+
+load_dotenv()
 
 
 async def main() -> None:

--- a/python/examples/agents/experimental/requirement/multi_agent.py
+++ b/python/examples/agents/experimental/requirement/multi_agent.py
@@ -2,6 +2,9 @@ import asyncio
 import sys
 import traceback
 
+from dotenv import load_dotenv
+
+from beeai_framework.agents import AgentExecutionConfig
 from beeai_framework.agents.experimental import RequirementAgent
 from beeai_framework.agents.experimental.requirements import Requirement
 from beeai_framework.agents.experimental.requirements.ask_permission import AskPermissionRequirement
@@ -16,6 +19,8 @@ from beeai_framework.tools.search.wikipedia import WikipediaTool
 from beeai_framework.tools.think import ThinkTool
 from beeai_framework.tools.weather import OpenMeteoTool
 from examples.helpers.io import ConsoleReader
+
+load_dotenv()
 
 reader = ConsoleReader()
 
@@ -117,7 +122,10 @@ async def main() -> None:
         try:
             reader.write("✅", "Processing with travel advisor agent")
             response = await travel_advisor.run(
-                prompt, expected_output="Detailed trip plan for a given destination. Formated as markdown."
+                prompt,
+                config=AgentExecutionConfig(
+                    expected_output="Detailed trip plan for a given destination. Formated as markdown."
+                ),
             ).middleware(GlobalTrajectoryMiddleware(excluded=[Requirement]))  # log tracejtory
             reader.write("✅", "Response received from agent")
             reader.write("🤖 Travel Advisor:\n", response.answer.text)

--- a/python/examples/agents/experimental/requirement/multi_agent.py
+++ b/python/examples/agents/experimental/requirement/multi_agent.py
@@ -4,7 +4,7 @@ import traceback
 
 from dotenv import load_dotenv
 
-from beeai_framework.agents import AgentExecutionConfig
+from beeai_framework.agents import AgentContext
 from beeai_framework.agents.experimental import RequirementAgent
 from beeai_framework.agents.experimental.requirements import Requirement
 from beeai_framework.agents.experimental.requirements.ask_permission import AskPermissionRequirement
@@ -123,7 +123,7 @@ async def main() -> None:
             reader.write("✅", "Processing with travel advisor agent")
             response = await travel_advisor.run(
                 prompt,
-                config=AgentExecutionConfig(
+                context=AgentContext(
                     expected_output="Detailed trip plan for a given destination. Formated as markdown."
                 ),
             ).middleware(GlobalTrajectoryMiddleware(excluded=[Requirement]))  # log tracejtory

--- a/python/examples/agents/experimental/requirement/react.py
+++ b/python/examples/agents/experimental/requirement/react.py
@@ -1,5 +1,7 @@
 import asyncio
 
+from dotenv import load_dotenv
+
 from beeai_framework.agents.experimental import RequirementAgent
 from beeai_framework.agents.experimental.requirements.conditional import ConditionalRequirement
 from beeai_framework.backend import ChatModel
@@ -8,6 +10,8 @@ from beeai_framework.tools import Tool
 from beeai_framework.tools.search.wikipedia import WikipediaTool
 from beeai_framework.tools.think import ThinkTool
 from beeai_framework.tools.weather import OpenMeteoTool
+
+load_dotenv()
 
 
 async def main() -> None:

--- a/python/examples/agents/experimental/requirement/structured_output.py
+++ b/python/examples/agents/experimental/requirement/structured_output.py
@@ -3,7 +3,7 @@ import asyncio
 from dotenv import load_dotenv
 from pydantic import BaseModel, Field
 
-from beeai_framework.agents import AgentExecutionConfig
+from beeai_framework.agents import AgentContext
 from beeai_framework.agents.experimental import RequirementAgent
 from beeai_framework.backend import ChatModel
 from beeai_framework.middleware.trajectory import GlobalTrajectoryMiddleware
@@ -25,7 +25,7 @@ async def main() -> None:
     Characters = to_list_model(Character, Field(min_length=5, max_length=5))  # noqa: N806
 
     response = await agent.run(
-        "Generate fictional characters", config=AgentExecutionConfig(expected_output=Characters)
+        "Generate fictional characters", context=AgentContext(expected_output=Characters)
     ).middleware(GlobalTrajectoryMiddleware())
     for index, character in response.answer_structured:
         print("Index:", index)

--- a/python/examples/agents/experimental/requirement/structured_output.py
+++ b/python/examples/agents/experimental/requirement/structured_output.py
@@ -1,11 +1,15 @@
 import asyncio
 
+from dotenv import load_dotenv
 from pydantic import BaseModel, Field
 
+from beeai_framework.agents import AgentExecutionConfig
 from beeai_framework.agents.experimental import RequirementAgent
 from beeai_framework.backend import ChatModel
 from beeai_framework.middleware.trajectory import GlobalTrajectoryMiddleware
 from beeai_framework.utils.models import to_list_model
+
+load_dotenv()
 
 
 async def main() -> None:
@@ -20,9 +24,9 @@ async def main() -> None:
 
     Characters = to_list_model(Character, Field(min_length=5, max_length=5))  # noqa: N806
 
-    response = await agent.run("Generate fictional characters", expected_output=Characters).middleware(
-        GlobalTrajectoryMiddleware()
-    )
+    response = await agent.run(
+        "Generate fictional characters", config=AgentExecutionConfig(expected_output=Characters)
+    ).middleware(GlobalTrajectoryMiddleware())
     for index, character in response.answer_structured:
         print("Index:", index)
         print("-> Full Name:", character.first_name, character.last_name)

--- a/python/examples/agents/experimental/requirement/text_output.py
+++ b/python/examples/agents/experimental/requirement/text_output.py
@@ -2,7 +2,7 @@ import asyncio
 
 from dotenv import load_dotenv
 
-from beeai_framework.agents import AgentExecutionConfig
+from beeai_framework.agents import AgentContext
 from beeai_framework.agents.experimental import RequirementAgent
 from beeai_framework.backend import ChatModel
 from beeai_framework.middleware.trajectory import GlobalTrajectoryMiddleware
@@ -17,7 +17,7 @@ async def main() -> None:
         # pass the task
         "Write a step-by-step tutorial on how to bake bread.",
         # nudge the model to format an output
-        config=AgentExecutionConfig(
+        context=AgentContext(
             expected_output="The output should be an ordered list of steps. Each step should be ideally one sentence."
         ),
     ).middleware(GlobalTrajectoryMiddleware())  # log intermediate steps

--- a/python/examples/agents/experimental/requirement/text_output.py
+++ b/python/examples/agents/experimental/requirement/text_output.py
@@ -1,8 +1,13 @@
 import asyncio
 
+from dotenv import load_dotenv
+
+from beeai_framework.agents import AgentExecutionConfig
 from beeai_framework.agents.experimental import RequirementAgent
 from beeai_framework.backend import ChatModel
 from beeai_framework.middleware.trajectory import GlobalTrajectoryMiddleware
+
+load_dotenv()
 
 
 async def main() -> None:
@@ -12,7 +17,9 @@ async def main() -> None:
         # pass the task
         "Write a step-by-step tutorial on how to bake bread.",
         # nudge the model to format an output
-        expected_output="The output should be an ordered list of steps. Each step should be ideally one sentence.",
+        config=AgentExecutionConfig(
+            expected_output="The output should be an ordered list of steps. Each step should be ideally one sentence."
+        ),
     ).middleware(GlobalTrajectoryMiddleware())  # log intermediate steps
 
     print(response.answer.text)

--- a/python/examples/agents/granite.py
+++ b/python/examples/agents/granite.py
@@ -2,6 +2,8 @@ import asyncio
 import sys
 import traceback
 
+from dotenv import load_dotenv
+
 from beeai_framework.agents import AgentExecutionConfig
 from beeai_framework.agents.react import ReActAgent, ReActAgentRunOutput
 from beeai_framework.backend import ChatModel
@@ -10,6 +12,8 @@ from beeai_framework.memory import UnconstrainedMemory
 from beeai_framework.tools.search.duckduckgo import DuckDuckGoSearchTool
 from beeai_framework.tools.weather import OpenMeteoTool
 from examples.helpers.io import ConsoleReader
+
+load_dotenv()
 
 
 async def main() -> None:
@@ -25,7 +29,7 @@ async def main() -> None:
 
     for prompt in reader:
         output: ReActAgentRunOutput = await agent.run(
-            prompt=prompt, execution=AgentExecutionConfig(total_max_retries=2, max_retries_per_step=3, max_iterations=8)
+            prompt, config=AgentExecutionConfig(total_max_retries=2, max_retries_per_step=3, max_iterations=8)
         ).on(
             "update",
             lambda data, event: reader.write(f"Agent({data.update.key}) 🤖 : ", data.update.parsed_value),

--- a/python/examples/agents/granite.py
+++ b/python/examples/agents/granite.py
@@ -4,7 +4,7 @@ import traceback
 
 from dotenv import load_dotenv
 
-from beeai_framework.agents import AgentExecutionConfig
+from beeai_framework.agents import AgentContext
 from beeai_framework.agents.react import ReActAgent, ReActAgentRunOutput
 from beeai_framework.backend import ChatModel
 from beeai_framework.errors import FrameworkError
@@ -29,7 +29,7 @@ async def main() -> None:
 
     for prompt in reader:
         output: ReActAgentRunOutput = await agent.run(
-            prompt, config=AgentExecutionConfig(total_max_retries=2, max_retries_per_step=3, max_iterations=8)
+            prompt, context=AgentContext(total_max_retries=2, max_retries_per_step=3, max_iterations=8)
         ).on(
             "update",
             lambda data, event: reader.write(f"Agent({data.update.key}) 🤖 : ", data.update.parsed_value),

--- a/python/examples/agents/react.py
+++ b/python/examples/agents/react.py
@@ -105,8 +105,8 @@ async def main() -> None:
     for prompt in reader:
         # Run agent with the prompt
         response = await agent.run(
-            prompt=prompt,
-            execution=AgentExecutionConfig(max_retries_per_step=3, total_max_retries=10, max_iterations=20),
+            prompt,
+            config=AgentExecutionConfig(max_retries_per_step=3, total_max_retries=10, max_iterations=20),
         ).on("*", process_agent_events, EmitterOptions(match_nested=False))
 
         reader.write("Agent 🤖 : ", response.result.text)

--- a/python/examples/agents/react.py
+++ b/python/examples/agents/react.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from dotenv import load_dotenv
 
-from beeai_framework.agents import AgentExecutionConfig
+from beeai_framework.agents import AgentContext
 from beeai_framework.agents.react import ReActAgent
 from beeai_framework.backend import ChatModel, ChatModelParameters
 from beeai_framework.emitter import EmitterOptions, EventMeta
@@ -106,7 +106,7 @@ async def main() -> None:
         # Run agent with the prompt
         response = await agent.run(
             prompt,
-            config=AgentExecutionConfig(max_retries_per_step=3, total_max_retries=10, max_iterations=20),
+            context=AgentContext(max_retries_per_step=3, total_max_retries=10, max_iterations=20),
         ).on("*", process_agent_events, EmitterOptions(match_nested=False))
 
         reader.write("Agent 🤖 : ", response.result.text)

--- a/python/examples/agents/react_advanced.py
+++ b/python/examples/agents/react_advanced.py
@@ -7,7 +7,7 @@ from dotenv import load_dotenv
 from pydantic import BaseModel
 
 from beeai_framework.adapters.ollama import OllamaChatModel
-from beeai_framework.agents import AgentExecutionConfig
+from beeai_framework.agents import AgentContext
 from beeai_framework.agents.react import ReActAgent
 from beeai_framework.emitter import Emitter, EmitterOptions, EventMeta
 from beeai_framework.errors import FrameworkError
@@ -108,9 +108,13 @@ async def main() -> None:
 
     for prompt in reader:
         response = await agent.run(
-            prompt=prompt,
-            execution=AgentExecutionConfig(max_retries_per_step=3, total_max_retries=10, max_iterations=20),
-            signal=AbortSignal.timeout(2 * 60 * 1000),
+            prompt,
+            context=AgentContext(
+                max_retries_per_step=3,
+                total_max_retries=10,
+                max_iterations=20,
+                signal=AbortSignal.timeout(2 * 60 * 1000),
+            ),
         ).observe(observer)
 
         reader.write("Agent 🤖 : ", response.result.text)

--- a/python/examples/agents/requirements.txt
+++ b/python/examples/agents/requirements.txt
@@ -1,2 +1,3 @@
 wikipedia-api
 langchain_community
+duckduckgo-search

--- a/python/examples/agents/simple.py
+++ b/python/examples/agents/simple.py
@@ -2,12 +2,16 @@ import asyncio
 import sys
 import traceback
 
+from dotenv import load_dotenv
+
 from beeai_framework.agents.react import ReActAgent, ReActAgentRunOutput
 from beeai_framework.backend import ChatModel
 from beeai_framework.errors import FrameworkError
 from beeai_framework.memory import UnconstrainedMemory
 from beeai_framework.tools.search.duckduckgo import DuckDuckGoSearchTool
 from beeai_framework.tools.weather import OpenMeteoTool
+
+load_dotenv()
 
 
 async def main() -> None:

--- a/python/examples/agents/tool_calling_structured.py
+++ b/python/examples/agents/tool_calling_structured.py
@@ -6,7 +6,7 @@ import traceback
 from dotenv import load_dotenv
 from pydantic import BaseModel
 
-from beeai_framework.agents import AgentExecutionConfig
+from beeai_framework.agents import AgentContext
 from beeai_framework.agents.tool_calling import (
     ToolCallingAgent,
     ToolCallingAgentStartEvent,
@@ -71,7 +71,7 @@ async def main() -> None:
     # Main interaction loop with user input
     for prompt in reader:
         reader.write("ℹ️ ", "enter a location for which you would like to get the weather forecast")
-        response = await agent.run(prompt, config=AgentExecutionConfig(expected_output=WeatherForecatModel)).on(
+        response = await agent.run(prompt, context=AgentContext(expected_output=WeatherForecatModel)).on(
             "*",
             log_intermediate_steps,
         )

--- a/python/examples/agents/tool_calling_structured.py
+++ b/python/examples/agents/tool_calling_structured.py
@@ -6,6 +6,7 @@ import traceback
 from dotenv import load_dotenv
 from pydantic import BaseModel
 
+from beeai_framework.agents import AgentExecutionConfig
 from beeai_framework.agents.tool_calling import (
     ToolCallingAgent,
     ToolCallingAgentStartEvent,
@@ -70,7 +71,7 @@ async def main() -> None:
     # Main interaction loop with user input
     for prompt in reader:
         reader.write("ℹ️ ", "enter a location for which you would like to get the weather forecast")
-        response = await agent.run(prompt, expected_output=WeatherForecatModel).on(
+        response = await agent.run(prompt, config=AgentExecutionConfig(expected_output=WeatherForecatModel)).on(
             "*",
             log_intermediate_steps,
         )

--- a/python/examples/integrations/langgraph_example.py
+++ b/python/examples/integrations/langgraph_example.py
@@ -19,7 +19,7 @@ from langchain_ollama import ChatOllama
 from langgraph.prebuilt import create_react_agent
 from pydantic import BaseModel, InstanceOf
 
-from beeai_framework.agents import AgentExecutionConfig
+from beeai_framework.agents import AgentContext
 from beeai_framework.agents.react import ReActAgent
 from beeai_framework.backend import AnyMessage, AssistantMessage, ChatModel, Role, UserMessage
 from beeai_framework.errors import FrameworkError
@@ -49,7 +49,7 @@ async def main() -> None:
         agent = ReActAgent(
             llm=ChatModel.from_name("ollama:llama3.1"), tools=[DuckDuckGoSearchTool()], memory=state.memory
         )
-        response = await agent.run(execution=AgentExecutionConfig(max_iterations=5))
+        response = await agent.run("", context=AgentContext(max_iterations=5))
         state.answer = response.result.text
         return Workflow.END
 

--- a/python/examples/memory/agent_memory.py
+++ b/python/examples/memory/agent_memory.py
@@ -2,7 +2,7 @@ import asyncio
 import sys
 import traceback
 
-from beeai_framework.agents import AgentExecutionConfig
+from beeai_framework.agents import AgentContext
 from beeai_framework.agents.react import ReActAgent
 from beeai_framework.backend import AssistantMessage, ChatModel, UserMessage
 from beeai_framework.errors import FrameworkError
@@ -34,8 +34,8 @@ async def main() -> None:
     agent = create_agent()
 
     response = await agent.run(
-        prompt=user_input,
-        execution=AgentExecutionConfig(max_retries_per_step=3, total_max_retries=10, max_iterations=20),
+        input=user_input,
+        context=AgentContext(max_retries_per_step=3, total_max_retries=10, max_iterations=20),
     )
     print(f"Received response: {response}")
 

--- a/python/examples/tools/decorator.py
+++ b/python/examples/tools/decorator.py
@@ -6,7 +6,7 @@ from urllib.parse import quote
 
 import requests
 
-from beeai_framework.agents import AgentExecutionConfig
+from beeai_framework.agents import AgentContext
 from beeai_framework.agents.react import ReActAgent
 from beeai_framework.backend import ChatModel
 from beeai_framework.errors import FrameworkError
@@ -51,7 +51,7 @@ async def main() -> None:
 
     agent = ReActAgent(llm=chat_model, tools=[basic_calculator], memory=UnconstrainedMemory())
 
-    result = await agent.run("What is the square root of 36?", execution=AgentExecutionConfig(total_max_retries=10))
+    result = await agent.run("What is the square root of 36?", context=AgentContext(total_max_retries=10))
 
     print(result.result.text)
 

--- a/python/examples/tools/mcp_agent.py
+++ b/python/examples/tools/mcp_agent.py
@@ -9,7 +9,7 @@ from dotenv import load_dotenv
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
-from beeai_framework.agents import AgentExecutionConfig
+from beeai_framework.agents import AgentContext
 from beeai_framework.agents.react import ReActAgent
 from beeai_framework.backend import ChatModel, ChatModelParameters
 from beeai_framework.emitter import Emitter, EventMeta
@@ -95,8 +95,8 @@ async def main() -> None:
         for prompt in reader:
             # Run agent with the prompt
             response = await agent.run(
-                prompt=prompt,
-                execution=AgentExecutionConfig(max_retries_per_step=3, total_max_retries=10, max_iterations=20),
+                prompt,
+                context=AgentContext(max_retries_per_step=3, total_max_retries=10, max_iterations=20),
             ).observe(observer)
 
             reader.write("Agent 🤖 : ", response.result.text)

--- a/python/examples/tools/mcp_slack_agent.py
+++ b/python/examples/tools/mcp_slack_agent.py
@@ -8,7 +8,7 @@ from dotenv import load_dotenv
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
-from beeai_framework.agents import AgentExecutionConfig
+from beeai_framework.agents import AgentContext
 from beeai_framework.agents.tool_calling import ToolCallingAgent
 from beeai_framework.backend import ChatModel, ChatModelParameters
 from beeai_framework.emitter import EventMeta
@@ -89,8 +89,8 @@ async def main() -> None:
 
         # Run agent with the prompt
         response = await agent.run(
-            prompt="Post the current temperature in Prague to the '#bee-playground-xxx' Slack channel.",
-            execution=AgentExecutionConfig(max_retries_per_step=3, total_max_retries=10, max_iterations=20),
+            "Post the current temperature in Prague to the '#bee-playground-xxx' Slack channel.",
+            context=AgentContext(max_retries_per_step=3, total_max_retries=10, max_iterations=20),
         ).on("*", print_events)
 
         print("Agent 🤖 : ", response.result.text)

--- a/python/examples/workflows/multi_agents.py
+++ b/python/examples/workflows/multi_agents.py
@@ -2,6 +2,8 @@ import asyncio
 import sys
 import traceback
 
+from dotenv import load_dotenv
+
 from beeai_framework.backend import ChatModel
 from beeai_framework.emitter import EmitterOptions
 from beeai_framework.errors import FrameworkError
@@ -9,6 +11,8 @@ from beeai_framework.tools.search.wikipedia import WikipediaTool
 from beeai_framework.tools.weather import OpenMeteoTool
 from beeai_framework.workflows.agent import AgentWorkflow, AgentWorkflowInput
 from examples.helpers.io import ConsoleReader
+
+load_dotenv()
 
 
 async def main() -> None:

--- a/python/examples/workflows/multi_agents_simple.py
+++ b/python/examples/workflows/multi_agents_simple.py
@@ -2,6 +2,8 @@ import asyncio
 import sys
 import traceback
 
+from dotenv import load_dotenv
+
 from beeai_framework.backend import ChatModel
 from beeai_framework.emitter import EmitterOptions
 from beeai_framework.errors import FrameworkError
@@ -9,6 +11,8 @@ from beeai_framework.tools.search.wikipedia import WikipediaTool
 from beeai_framework.tools.weather import OpenMeteoTool
 from beeai_framework.workflows.agent import AgentWorkflow, AgentWorkflowInput
 from examples.helpers.io import ConsoleReader
+
+load_dotenv()
 
 
 async def main() -> None:

--- a/python/tests/runners/test_default_runner.py
+++ b/python/tests/runners/test_default_runner.py
@@ -15,7 +15,7 @@
 
 import pytest
 
-from beeai_framework.agents import AgentExecutionConfig
+from beeai_framework.agents import AgentContext
 from beeai_framework.agents.react.runners.base import ReActAgentRunnerToolInput
 from beeai_framework.agents.react.runners.default.runner import DefaultRunner
 from beeai_framework.agents.react.types import (
@@ -45,7 +45,7 @@ async def test_runner_init() -> None:
         llm=llm,
         tools=[OpenMeteoTool()],
         memory=TokenMemory(llm),
-        execution=AgentExecutionConfig(max_iterations=10, max_retries_per_step=3, total_max_retries=10),
+        execution=AgentContext(max_iterations=10, max_retries_per_step=3, total_max_retries=10),
     )
     # TODO Figure out run
     runner = DefaultRunner(input=input, options=ReActAgentRunOptions(execution=input.execution, signal=None), run=None)  # type: ignore


### PR DESCRIPTION
### Which issue(s) does this pull-request address?

This PR introduces a `Runnable` interface to unify _runnables_ in the BeeAI Framework. 
Closes: # draft

### Description

BeeAI implements many objects that can be invoked with a `run` method. However, the arguments, argument names, and argument types of each of these methods are not uniform across objects, even for objects of the same kind. Moreover, in some places, this interface is loosely defined. For example, `BaseAgent` defines:

```Python
TOutput = TypeVar("TOutput", bound=BaseModel)

class BaseAgent(ABC, Generic[TOutput]):
    ...
    
    @abstractmethod
    def run(self, *args: Any, **kwargs: Any) -> Run[TOutput]:
        pass
```

Arbitrary args and kwargs provide great flexibility but lack explicitness (the function signature doesn't clearly show nor document the accepted parameters) and limit type checking. To remedy this issue, this PR introduces a new `Runnable` interface that defines explicit types for `input`, `output`, and execution `configuration` for runnable objects.

```Python
Input = TypeVar("Input", bound=str | UserMessage | ModelLike)
Output = TypeVar("Output", bound=str | ModelLike)
Config = TypeVar("Config", bound=RunnableConfig)

class Runnable(Generic[Input, Output, Config], ABC):
    """A unit of work that can be invoked using a stable interface."""

    @abstractmethod
    def run(self, input: Input, config: Config | None = None) -> Run[Output]: ...
```

The runnable configuration object is a Pydantic model that defines interruption signals for the runnable.

```Python
class RunnableConfig(BaseModel):
    """Configuration and runtime metadata for a Runnable."""

    """The runnable's abort signal data"""
    signal: AbortSignal | None = None
```

With this new construct, we can now refactor different classes in BeeAI to unify how they are invoked. The result is a better user experience when developing with the framework. For example, developers who learn how to invoke a `TookCallingAgent` or `AgentWorkflow`, also know how to invoke a `RequirementsAgent`. Furthermore, the types and semantics of the arguments passed to the run methods of these objects are stable. 

While refactoring the existing agent classes, this PR also refactored the code to unify and remove duplicate model definitions. The `BaseAgent` class subclasses `Runnable`:

```Python
Input = TypeVar("Input", bound=str | UserMessage | ModelLike, default=str)
Output = TypeVar("Output", bound=BaseModel, default=AgentRunOutput)
Config = TypeVar("Config", bound=AgentExecutionConfig, default=AgentExecutionConfig)

class BaseAgent(Runnable[Input, Output, Config]): ...
```

and defines a default runnable configuration that specifies uniform parameters across all agents:

```Python
class AgentExecutionConfig(RunnableConfig):
    """An agent's execution configuration."""

    context: str | None = None
    """
    Additional piece of context to be passed to the model.
    """

    expected_output: str | type[BaseModel] | None = None
    """
    Instruction for steering the agent towards an expected output format.
    This can be a Pydantic model for structured output decoding and validation.
    """

    total_max_retries: int = 3
    """
    Maximum number of model retries.
    """

    max_retries_per_step: int = 20
    """
    Maximum number of model retries per step.
    """

    max_iterations: int = 10
    """
    Maximum number of iterations.
    """
```

along with a backwards-compatible base output object:

```Python
class AgentRunOutput(BaseModel):
    """An agent's execution output."""

    model_config = ConfigDict(populate_by_name=True)

    answer: InstanceOf[AssistantMessage] = Field(alias="result")
    memory: InstanceOf[BaseMemory]

    @property
    def result(self) -> AssistantMessage:
        """
        This property is provided for compatibility reasons only.
        Use 'answer' instead.
        """
        return self.answer

    @result.setter
    def result(self, value: AssistantMessage) -> None:
        """
        This setter is provided for compatibility reasons only.
        Sets the 'answer' attribute.
        """
        self.answer = value
```

### Discussion

- [ ] Requirements agent introduced a new field `answer` that replaces the former `result` field. Should we refactor the code to use answer across, and mark result as deprecated?
- [ ] The input to the `run` interface is now named `input`. This used to be referred to as `prompt` in the code (even though not explicitly defined in the interface). Any preferences on whether the input argument should be named input vs prompt?
- [ ] Workflows should also be made runnables
- [ ] Currently, the agent workflow object has a run interface that takes a list of inputs to the internal node agents. Maybe this list parameter should be a field in runnable configuration for this object. 
- [ ] Workflows should now be able to compose with any runnables
- [ ] ChatModel should also be made a runnable

### Checklist

#### General
- [x] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [ ] Code quality checks pass: `mise check` (`mise fix` to auto-fix)

#### Testing
- [x] Unit tests pass: `mise test:unit`
- [ ] E2E tests pass: `mise test:e2e`
- [ ] Tests are included (for bug fixes or new features)

#### Documentation
- [ ] Documentation is updated
- [ ] Embedme embeds code examples in docs. To update after edits, run: Python `mise docs:fix`
