### PR TITLE
fix: remove mypy path in project config

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -89,7 +89,6 @@ all = [
 
 
 [tool.mypy]
-mypy_path = ["$MYPY_CONFIG_FILE_DIR/beeai_framework"]
 exclude = ["^build/$", "^examples/playground/"]
 check_untyped_defs = true
 plugins = ["pydantic.mypy"]


### PR DESCRIPTION
### Which issue(s) does this pull-request address?

When I've installed llama-index I was getting an error from mypy about a conflict in the workflows module:
```
[python:check:mypy] $ poetry run mypy --show-error-context --pretty .
beeai_framework/workflows/__init__.py: error: Source file found twice under different module names: "beeai_framework.workflows" and "workflows"
```
After careful evaluation I've traced the error to naming conflict in `mypy` between two `workflows` modules:
1. from llama_index package where a top-level workflows module exist
2. from beeai_framework.workflows

This is not a problem from python point of view, but would happen with every future conflict.

### Description

`mypy` will treat every module in its `mypy_path` path as both top and relative path module, i.e. for `workflows` in `$MYPY_CONFIG_FILE_DIR/beeai_framework` we get both `workflows` and `beeai_framework.workflows`

When `mypy_path` is removed all modules are treated as their relative versions, eliminating the error

### Testing
I've ran `poetry run mypy --show-error-context --pretty .` from the python folder both with and without the `mypy_path` parameter and got same amount of scanned source files (ran in fresh environment, with the llama-index installation)

```
poetry run mypy --show-error-context --pretty .
Success: no issues found in 357 source files
```