### PR TITLE
fix(internals): avoid recursion errors when handling empty JSON Schma objects

### DIFF
--- a/python/beeai_framework/utils/models.py
+++ b/python/beeai_framework/utils/models.py
@@ -154,15 +154,11 @@ class JSONSchemaModel(ABC, BaseModel):
             )
 
         properties = schema.get("properties", {})
-        updated_config = {**cls.model_config}
-        # additionalProperties is True by default so we allow extra fields
-        updated_config.update({"extra": "allow"})
+        updated_config = ConfigDict(**cls.model_config)
+        updated_config["extra"] = "allow" if schema.get("additionalProperties") else "forbid"
 
-        if not properties:
+        if not properties and schema.get("type") != "object":
             properties["root"] = schema
-
-        if schema.get("additionalProperties", None) is False:
-            updated_config.update({"extra": "forbid"})
 
         for param_name, param in properties.items():
             fields[param_name] = create_field(param_name, param)

--- a/python/tests/utils/test_json_schema.py
+++ b/python/tests/utils/test_json_schema.py
@@ -193,6 +193,20 @@ def test_schema_with_additional_properties(schema_with_additional_properties: di
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("additional_properties", [True, False])
+def test_empty_object_schema(additional_properties: bool) -> None:
+    schema = {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": additional_properties,
+        "properties": {},
+        "type": "object",
+    }
+
+    model = JSONSchemaModel.create("test_empty_object", schema)
+    assert model.model_json_schema()
+
+
+@pytest.mark.unit
 def test_json_schema_model(test_json_schema: dict[str, list[str] | str | Any]) -> None:
     model = JSONSchemaModel.create("test_json_schema", test_json_schema)
     assert model.model_json_schema()


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review and complete the sections below.
-->

### Which issue(s) does this pull-request address?

<!--
Please include a link to an issue in the tracker.  The issue describes the problem to be solved.  If there is no issue raised for this PR then either raise one with a summary and description of the problem or add a summary and description of the problem here
-->

Ref: #928

### Description

<!-- Provide a description of the change, pay special attention to describing any breaking changes.  The description describes the resolution to the problem described in the linked issue (or to the problem outlined in this PR). -->

### Checklist

#### General
- [ ] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [ ] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [ ] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [ ] Code quality checks pass: `mise check` (`mise fix` to auto-fix)

#### Testing
- [ ] Unit tests pass: `mise test:unit`
- [ ] E2E tests pass: `mise test:e2e`
- [ ] Tests are included (for bug fixes or new features)

#### Documentation
- [ ] Documentation is updated
- [ ] Embedme embeds code examples in docs. To update after edits, run: Python `mise docs:fix`
