### PR TITLE
docs: change RAG icon on documentation

### DIFF
--- a/docs/modules/rag.mdx
+++ b/docs/modules/rag.mdx
@@ -1,7 +1,7 @@
 ---
 title: "RAG"
 description: "Build intelligent agents that combine retrieval with generation for enhanced AI capabilities"
-icon: "search"
+icon: "folder-check"
 ---
 
 ## Overview


### PR DESCRIPTION
The originally chosen icon from Lucide is not available on Mintlify, swapping to an existing one