### PR TITLE
fix(adapters): initialize tool_choice in LiteLLM chat adapter

### DIFF
--- a/python/beeai_framework/adapters/litellm/chat.py
+++ b/python/beeai_framework/adapters/litellm/chat.py
@@ -7,6 +7,9 @@ from collections.abc import AsyncGenerator
 from itertools import chain
 from typing import Any, Self
 
+from pydantic import BaseModel, InstanceOf
+from beeai_framework.tools.tool import AnyTool
+
 if not os.getenv("LITELLM_LOCAL_MODEL_COST_MAP", None):
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
 
@@ -208,6 +211,7 @@ class LiteLLMChatModel(ChatModel, ABC):
             set(self.supported_params),
         )
 
+        tool_choice: dict[str, Any] | str | None | InstanceOf[AnyTool] = input.tool_choice
         if input.tool_choice == "none" and input.tool_choice not in self._tool_choice_support:
             tool_choice = None
             tools = []

--- a/python/beeai_framework/adapters/litellm/chat.py
+++ b/python/beeai_framework/adapters/litellm/chat.py
@@ -47,7 +47,7 @@ from beeai_framework.backend.utils import parse_broken_json
 from beeai_framework.cache.null_cache import NullCache
 from beeai_framework.context import RunContext
 from beeai_framework.logger import Logger
-from beeai_framework.tools.tool import Tool, AnyTool
+from beeai_framework.tools.tool import AnyTool, Tool
 from beeai_framework.utils.dicts import exclude_keys, exclude_none, include_keys, set_attr_if_none
 from beeai_framework.utils.strings import to_json
 

--- a/python/beeai_framework/adapters/litellm/chat.py
+++ b/python/beeai_framework/adapters/litellm/chat.py
@@ -19,7 +19,7 @@ from litellm import (  # type: ignore
     get_supported_openai_params,
 )
 from litellm.types.utils import StreamingChoices
-from pydantic import BaseModel, InstanceOf
+from pydantic import BaseModel
 from typing_extensions import Unpack
 
 from beeai_framework.adapters.litellm.utils import litellm_debug, to_strict_json_schema
@@ -208,7 +208,7 @@ class LiteLLMChatModel(ChatModel, ABC):
             set(self.supported_params),
         )
 
-        tool_choice: dict[str, Any] | str | None | InstanceOf[AnyTool] = input.tool_choice
+        tool_choice: dict[str, Any] | str | AnyTool | None = input.tool_choice
         if input.tool_choice == "none" and input.tool_choice not in self._tool_choice_support:
             tool_choice = None
             tools = []
@@ -219,7 +219,7 @@ class LiteLLMChatModel(ChatModel, ABC):
         elif input.tool_choice not in self._tool_choice_support:
             tool_choice = None
 
-        if input.response_format is not None:
+        if input.response_format:
             tools = []
             tool_choice = None
 

--- a/python/beeai_framework/adapters/litellm/chat.py
+++ b/python/beeai_framework/adapters/litellm/chat.py
@@ -7,9 +7,6 @@ from collections.abc import AsyncGenerator
 from itertools import chain
 from typing import Any, Self
 
-from pydantic import BaseModel, InstanceOf
-from beeai_framework.tools.tool import AnyTool
-
 if not os.getenv("LITELLM_LOCAL_MODEL_COST_MAP", None):
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
 
@@ -22,7 +19,7 @@ from litellm import (  # type: ignore
     get_supported_openai_params,
 )
 from litellm.types.utils import StreamingChoices
-from pydantic import BaseModel
+from pydantic import BaseModel, InstanceOf
 from typing_extensions import Unpack
 
 from beeai_framework.adapters.litellm.utils import litellm_debug, to_strict_json_schema
@@ -50,7 +47,7 @@ from beeai_framework.backend.utils import parse_broken_json
 from beeai_framework.cache.null_cache import NullCache
 from beeai_framework.context import RunContext
 from beeai_framework.logger import Logger
-from beeai_framework.tools.tool import Tool
+from beeai_framework.tools.tool import Tool, AnyTool
 from beeai_framework.utils.dicts import exclude_keys, exclude_none, include_keys, set_attr_if_none
 from beeai_framework.utils.strings import to_json
 


### PR DESCRIPTION
### Description

Initialize `tool_choice` with `input.tool_choice` before conditional overrides to prevent undefined variable when tool_choice is supported but doesn't match specific conditions.

### Checklist

#### General
- [x] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [x] Code quality checks pass: `mise check` (`mise fix` to auto-fix)

#### Testing
- [x] Unit tests pass: `mise test:unit`
- [x] E2E tests pass: `mise test:e2e`
- [ ] Tests are included (for bug fixes or new features)

#### Documentation
- [ ] Documentation is updated
- [ ] Embedme embeds code examples in docs. To update after edits, run: Python `mise docs:fix`
