### PR TITLE
fix: implement retry for embeddings

### DIFF
--- a/python/beeai_framework/backend/errors.py
+++ b/python/beeai_framework/backend/errors.py
@@ -55,7 +55,7 @@ class EmbeddingModelError(BackendError):
         cause: Exception | None = None,
         context: dict[str, Any] | None = None,
     ) -> None:
-        super().__init__(message, is_fatal=True, is_retryable=False, cause=cause, context=context)
+        super().__init__(message, is_fatal=True, is_retryable=True, cause=cause, context=context)
 
     @classmethod
     def ensure(


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review and complete the sections below.
-->

### Which issue(s) does this pull-request address?

Implement `max_retries` for embeddings. 

### Checklist

#### General
- [x] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [x] Code quality checks pass: `mise check` (`mise fix` to auto-fix)

#### Testing
- [ ] Unit tests pass: `mise test:unit`
- [ ] E2E tests pass: `mise test:e2e`
- [ ] Tests are included (for bug fixes or new features)

#### Documentation
- [ ] Documentation is updated
- [ ] Embedme embeds code examples in docs. To update after edits, run: Python `mise docs:fix`
