### PR TITLE
fix(internals): fix serialization of sets

### DIFF
--- a/python/beeai_framework/utils/strings.py
+++ b/python/beeai_framework/utils/strings.py
@@ -59,7 +59,8 @@ def to_json_serializable(input: Any, *, exclude_none: bool = False) -> Any:
     elif isinstance(input, dict):
         return {k: apply_child(v) for k, v in input.items() if v is not None} if exclude_none else input
     elif isinstance(input, set):
-        return {apply_child(v) for v in input}
+        # set is not JSON serializable, convert to list
+        return [apply_child(v) for v in input]
     elif isinstance(input, str | bool | int | float):
         return input
     else:


### PR DESCRIPTION
### Description

Sets are not JSON serializable, so running `to_json(set())` ends with an infinite recursion.
I'm not sure if converting to a list is the best solution - is it ok that `from_json(to_json(set())) != set()`?

<!-- Provide a description of the change, pay special attention to describing any breaking changes.  The description describes the resolution to the problem described in the linked issue (or to the problem outlined in this PR). -->

### Checklist

#### General
- [x] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [x] Code quality checks pass: `mise check` (`mise fix` to auto-fix)

#### Testing
- [x] Unit tests pass: `mise test:unit`
- [ ] E2E tests pass: `mise test:e2e`
- [ ] Tests are included (for bug fixes or new features)

#### Documentation
- [ ] Documentation is updated
- [ ] Embedme embeds code examples in docs. To update after edits, run: Python `mise docs:fix`
