### PR TITLE
Fixed Python README.md example from response.answer to response.last_message

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -105,7 +105,7 @@ async def main() -> None:
 
     try:
         response = await main_agent.run(question, expected_output="Helpful and clear response.")
-        print("Agent:", response.answer.text)
+        print("Agent:", response.last_message.text)
     except FrameworkError as err:
         print("Error:", err.explain())
 


### PR DESCRIPTION
### Which issue(s) does this pull-request address?

https://github.com/i-am-bee/beeai-framework/issues/1173

Closes: #1173 

### Description

- Updated response.answer.text to response.last_message.text in README example
- Aligns with new BeeAI Framework API structure where RequirementAgentOutput uses last_message property instead of answer attribute.
