### PR TITLE
Add Python serialization examples

### DIFF
--- a/docs/modules/serialization.mdx
+++ b/docs/modules/serialization.mdx
@@ -21,6 +21,9 @@ The Python example prints the serialized payload, the restored ISO timestamp, an
 
 {/* <!-- embedme python/examples/serialization/base.py --> */}
 ```py Python [expandable]
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from datetime import UTC, datetime
 
 from beeai_framework.serialization import Serializer
@@ -38,6 +41,7 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+
 ```
 
 {/* <!-- embedme typescript/examples/serialization/base.ts --> */}
@@ -93,6 +97,9 @@ Running the Python snippet restores the memory, appends an assistant reply, and 
 
 {/* <!-- embedme python/examples/serialization/memory.py --> */}
 ```py Python [expandable]
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import asyncio
 
 from beeai_framework.backend import AssistantMessage, UserMessage
@@ -114,6 +121,7 @@ async def main() -> None:
 
 if __name__ == "__main__":
     asyncio.run(main())
+
 ```
 
 {/* <!-- embedme typescript/examples/serialization/memory.ts --> */}
@@ -153,6 +161,9 @@ This example registers a lightweight data class and prints the reconstructed tok
 
 {/* <!-- embedme python/examples/serialization/custom_external.py --> */}
 ```py Python [expandable]
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
@@ -189,6 +200,7 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+
 ```
 
 {/* <!-- embedme typescript/examples/serialization/customExternal.ts --> */}
@@ -233,6 +245,9 @@ The Python variant increments a counter, serializes it, and prints both the live
 
 {/* <!-- embedme python/examples/serialization/custom_internal.py --> */}
 ```py Python [expandable]
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from beeai_framework.serialization import Serializable
 
 
@@ -263,6 +278,7 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+
 ```
 
 {/* <!-- embedme typescript/examples/serialization/customInternal.ts --> */}
@@ -307,25 +323,29 @@ Failure to register a class that the `Serializer` does not know will result in t
 
 ## Context matters
 
-Deserialize with the `extraClasses` equivalent to make sure message factories are registered; the Python snippet prints every restored user utterance.
+Deserialize with the `extraClasses` equivalent to make sure message factories are registered; the Python snippet imports both `UserMessage` and `AssistantMessage` so the serializer can hydrate their content and then prints every restored user utterance.
 
 <CodeGroup>
 
 {/* <!-- embedme python/examples/serialization/context.py --> */}
 ```py Python [expandable]
-from beeai_framework.backend import UserMessage
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+from beeai_framework.backend import AssistantMessage, UserMessage
 from beeai_framework.memory import UnconstrainedMemory
 
-SERIALIZED_MEMORY = ""
+SERIALIZED_MEMORY = """{"__version":"0.0.0","__root":{"__serializer":true,"__class":"UnconstrainedMemory","__value":{"messages":[{"__serializer":true,"__class":"UserMessage","__value":{"id":null,"meta":{"createdAt":{"__serializer":true,"__class":"datetime","__value":"2025-10-18T19:38:37.859543+00:00"}},"role":"user","content":[{"type":"text","text":"Hello!"}]}},{"__serializer":true,"__class":"AssistantMessage","__value":{"id":null,"meta":{"createdAt":{"__serializer":true,"__class":"datetime","__value":"2025-10-18T19:38:37.859665+00:00"}},"role":"assistant","content":[{"type":"text","text":"Hello, how can I help you?"}]}}]}}}"""
 
 
 def main() -> None:
-    memory = UnconstrainedMemory.from_serialized(SERIALIZED_MEMORY, extra_classes=[UserMessage])
+    memory = UnconstrainedMemory.from_serialized(SERIALIZED_MEMORY, extra_classes=[UserMessage, AssistantMessage])
     print([message.text for message in memory.messages])
 
 
 if __name__ == "__main__":
     main()
+
 ```
 
 {/* <!-- embedme typescript/examples/serialization/context.ts --> */}

--- a/docs/modules/serialization.mdx
+++ b/docs/modules/serialization.mdx
@@ -15,11 +15,29 @@ BeeAI framework provides robust serialization capabilities through its built-in 
 - 📦 Snapshots: Create point-in-time captures of component state
 - 🔧 Reconstruction: Rebuild objects from their serialized representation
 
+The Python example prints the serialized payload, the restored ISO timestamp, and a boolean confirming the round trip.
+
 <CodeGroup>
 
-{/* <!-- comingsoon python/examples/serialization/base.py --> */}
+{/* <!-- embedme python/examples/serialization/base.py --> */}
 ```py Python [expandable]
-Example coming soon
+from datetime import UTC, datetime
+
+from beeai_framework.serialization import Serializer
+
+
+def main() -> None:
+    original = datetime(2024, 1, 1, tzinfo=UTC)
+    serialized = Serializer.serialize(original)
+    restored = Serializer.deserialize(serialized, expected_type=datetime)
+
+    print(serialized)
+    print(restored.isoformat())
+    print(restored == original)
+
+
+if __name__ == "__main__":
+    main()
 ```
 
 {/* <!-- embedme typescript/examples/serialization/base.ts --> */}
@@ -69,11 +87,33 @@ The serialization process involves:
 
 Most BeeAI components can be serialized out of the box. Here's an example using memory:
 
+Running the Python snippet restores the memory, appends an assistant reply, and prints the message count plus the first question.
+
 <CodeGroup>
 
-{/* <!-- comingsoon python/examples/serialization/memory.py --> */}
+{/* <!-- embedme python/examples/serialization/memory.py --> */}
 ```py Python [expandable]
-Example coming soon
+import asyncio
+
+from beeai_framework.backend import AssistantMessage, UserMessage
+from beeai_framework.memory import UnconstrainedMemory
+
+
+async def main() -> None:
+    memory = UnconstrainedMemory()
+    await memory.add(UserMessage("What is your name?"))
+
+    serialized = memory.serialize()
+    restored = UnconstrainedMemory.from_serialized(serialized)
+
+    await restored.add(AssistantMessage("Bee"))
+
+    print(len(restored.messages))
+    print(restored.messages[0].text)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 {/* <!-- embedme typescript/examples/serialization/memory.ts --> */}
@@ -107,11 +147,48 @@ If you want to serialize a class that the `Serializer` does not know, you may re
 
 You can register external classes with the serializer:
 
+This example registers a lightweight data class and prints the reconstructed token along with its expiry timestamp.
+
 <CodeGroup>
 
-{/* <!-- comingsoon python/examples/serialization/custom_external.py --> */}
+{/* <!-- embedme python/examples/serialization/custom_external.py --> */}
 ```py Python [expandable]
-Example coming soon
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from beeai_framework.serialization import Serializer
+
+
+@dataclass
+class ApiToken:
+    value: str
+    expires_at: datetime
+
+
+Serializer.register(
+    ApiToken,
+    to_plain=lambda token: {
+        "value": token.value,
+        "expires_at": token.expires_at,
+    },
+    from_plain=lambda payload: ApiToken(
+        value=payload["value"],
+        expires_at=payload["expires_at"],
+    ),
+)
+
+
+def main() -> None:
+    token = ApiToken("example-token", datetime(2025, 1, 1, tzinfo=UTC))
+    serialized = Serializer.serialize(token)
+    restored = Serializer.deserialize(serialized, expected_type=ApiToken)
+
+    print(restored)
+    print(restored.expires_at.isoformat())
+
+
+if __name__ == "__main__":
+    main()
 ```
 
 {/* <!-- embedme typescript/examples/serialization/customExternal.ts --> */}
@@ -150,11 +227,42 @@ console.info(deserialized);
 
 For deeper integration, extend the Serializable class:
 
+The Python variant increments a counter, serializes it, and prints both the live and restored values.
+
 <CodeGroup>
 
-{/* <!-- comingsoon python/examples/serialization/custom_internal.py --> */}
+{/* <!-- embedme python/examples/serialization/custom_internal.py --> */}
 ```py Python [expandable]
-Example coming soon
+from beeai_framework.serialization import Serializable
+
+
+class Counter(Serializable[dict[str, int]]):
+    def __init__(self, value: int = 0) -> None:
+        self.value = value
+
+    def increment(self) -> None:
+        self.value += 1
+
+    def create_snapshot(self) -> dict[str, int]:
+        return {"value": self.value}
+
+    def load_snapshot(self, snapshot: dict[str, int]) -> None:
+        self.value = snapshot["value"]
+
+
+def main() -> None:
+    counter = Counter(3)
+    counter.increment()
+
+    serialized = counter.serialize()
+    restored = Counter.from_serialized(serialized)
+
+    print(counter.value)
+    print(restored.value)
+
+
+if __name__ == "__main__":
+    main()
 ```
 
 {/* <!-- embedme typescript/examples/serialization/customInternal.ts --> */}
@@ -199,11 +307,25 @@ Failure to register a class that the `Serializer` does not know will result in t
 
 ## Context matters
 
+Deserialize with the `extraClasses` equivalent to make sure message factories are registered; the Python snippet prints every restored user utterance.
+
 <CodeGroup>
 
-{/* <!-- comingsoon python/examples/serialization/context.py --> */}
+{/* <!-- embedme python/examples/serialization/context.py --> */}
 ```py Python [expandable]
-Example coming soon
+from beeai_framework.backend import UserMessage
+from beeai_framework.memory import UnconstrainedMemory
+
+SERIALIZED_MEMORY = ""
+
+
+def main() -> None:
+    memory = UnconstrainedMemory.from_serialized(SERIALIZED_MEMORY, extra_classes=[UserMessage])
+    print([message.text for message in memory.messages])
+
+
+if __name__ == "__main__":
+    main()
 ```
 
 {/* <!-- embedme typescript/examples/serialization/context.ts --> */}

--- a/python/beeai_framework/backend/message.py
+++ b/python/beeai_framework/backend/message.py
@@ -4,7 +4,7 @@
 import enum
 import json
 from abc import ABC
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime
 from enum import Enum
 from typing import Any, Generic, Literal, Required, Self, TypeAlias, TypeVar, cast
@@ -374,3 +374,85 @@ def dedupe_tool_calls(msg: AssistantMessage) -> None:
 
     for idx in sorted(excluded_indexes, reverse=True):
         msg.content.pop(idx)
+
+
+def _register_message_class(
+    message_cls: type[Message[Any]],
+    allowed_content: Mapping[str, type[BaseModel]],
+) -> None:
+    def _registrar() -> None:
+        from beeai_framework.serialization import Serializer, SerializerError
+
+        def _to_plain(message: Message[Any]) -> dict[str, Any]:
+            return {
+                "id": message.id,
+                "meta": dict(message.meta),
+                "role": str(message.role),
+                "content": [fragment.model_dump() for fragment in message.content],
+            }
+
+        def _from_plain(payload: Mapping[str, Any]) -> Message[Any]:
+            content_payload = payload.get("content", []) or []
+            content_models: list[Any] = []
+
+            for item in content_payload:
+                if not isinstance(item, Mapping):
+                    raise SerializerError("Serialized message content must be a mapping.")
+
+                content_type = item.get("type")
+                if not isinstance(content_type, str):
+                    raise SerializerError(
+                        f"Serialized message content is missing or has an invalid 'type': {content_type!r}",
+                    )
+
+                model_cls = allowed_content.get(content_type)
+                if model_cls is None:
+                    raise SerializerError(
+                        f"Unsupported message content '{content_type}' for {message_cls.__name__}.",
+                    )
+                content_models.append(model_cls.model_validate(dict(item)))
+
+            meta = payload.get("meta") or {}
+            meta_copy = dict(meta)
+            return message_cls(content_models, meta=meta_copy, id=payload.get("id"))
+
+        Serializer.register(
+            message_cls,
+            to_plain=_to_plain,
+            from_plain=_from_plain,
+        )
+
+    _registrar()
+    message_cls.register = classmethod(lambda cls: _registrar())  # type: ignore[attr-defined]
+
+
+_register_message_class(
+    SystemMessage,
+    {
+        "text": MessageTextContent,
+    },
+)
+
+_register_message_class(
+    UserMessage,
+    {
+        "text": MessageTextContent,
+        "image_url": MessageImageContent,
+        "file": MessageFileContent,
+    },
+)
+
+_register_message_class(
+    AssistantMessage,
+    {
+        "text": MessageTextContent,
+        "tool-call": MessageToolCallContent,
+    },
+)
+
+_register_message_class(
+    ToolMessage,
+    {
+        "tool-result": MessageToolResultContent,
+    },
+)

--- a/python/beeai_framework/backend/message.py
+++ b/python/beeai_framework/backend/message.py
@@ -4,7 +4,7 @@
 import enum
 import json
 from abc import ABC
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from datetime import UTC, datetime
 from enum import Enum
 from typing import Any, Generic, Literal, Required, Self, TypeAlias, TypeVar, cast
@@ -423,7 +423,11 @@ def _register_message_class(
         )
 
     _registrar()
-    message_cls.register = classmethod(lambda cls: _registrar())  # type: ignore[attr-defined]
+
+    def _register_method(cls: type[Message[Any]], *, aliases: Iterable[str] | None = None) -> None:
+        _registrar()
+
+    type.__setattr__(message_cls, "register", classmethod(_register_method))
 
 
 _register_message_class(

--- a/python/beeai_framework/memory/token_memory.py
+++ b/python/beeai_framework/memory/token_memory.py
@@ -118,7 +118,8 @@ class TokenMemory(Serializable[dict[str, Any]], BaseMemory):
         self._tokens_by_message.clear()
 
     async def clone(self) -> "TokenMemory":
-        llm_clone = self.llm.clone() if hasattr(self.llm, "clone") else self.llm
+        llm = self.llm
+        llm_clone = llm.clone() if llm is not None and hasattr(llm, "clone") else llm
         cloned = TokenMemory(
             llm_clone,
             self._max_tokens,

--- a/python/beeai_framework/memory/token_memory.py
+++ b/python/beeai_framework/memory/token_memory.py
@@ -2,10 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from math import ceil
-from typing import Any
+from typing import Any, Self
 
 from beeai_framework.backend.message import AnyMessage
 from beeai_framework.memory.base_memory import BaseMemory
+from beeai_framework.serialization import Serializable
 
 
 def simple_estimate(msg: AnyMessage) -> int:
@@ -16,12 +17,12 @@ def simple_tokenize(msgs: list[AnyMessage]) -> int:
     return sum(map(simple_estimate, msgs))
 
 
-class TokenMemory(BaseMemory):
+class TokenMemory(Serializable[dict[str, Any]], BaseMemory):
     """Memory implementation that respects token limits."""
 
     def __init__(
         self,
-        llm: Any,
+        llm: Any | None = None,
         max_tokens: int | None = None,
         sync_threshold: float = 0.25,
         capacity_threshold: float = 0.75,
@@ -117,8 +118,9 @@ class TokenMemory(BaseMemory):
         self._tokens_by_message.clear()
 
     async def clone(self) -> "TokenMemory":
+        llm_clone = self.llm.clone() if hasattr(self.llm, "clone") else self.llm
         cloned = TokenMemory(
-            self.llm.clone(),
+            llm_clone,
             self._max_tokens,
             self._sync_threshold,
             self._threshold,
@@ -127,3 +129,37 @@ class TokenMemory(BaseMemory):
         cloned._messages = self._messages.copy()
         cloned._tokens_by_message = self._tokens_by_message.copy()
         return cloned
+
+    def create_snapshot(self) -> dict[str, Any]:
+        return {
+            "messages": list(self._messages),
+            "max_tokens": self._max_tokens,
+            "capacity_threshold": self._threshold,
+            "sync_threshold": self._sync_threshold,
+        }
+
+    def load_snapshot(self, snapshot: dict[str, Any]) -> None:
+        self._messages = list(snapshot.get("messages", []))
+        self._max_tokens = snapshot.get("max_tokens")
+        self._threshold = snapshot.get("capacity_threshold", self._threshold)
+        self._sync_threshold = snapshot.get("sync_threshold", self._sync_threshold)
+        self._tokens_by_message.clear()
+
+        for message in self._messages:
+            key = self._get_message_key(message)
+            estimated_tokens = self.handlers["estimate"](message)
+            self._tokens_by_message[key] = {
+                "tokens_count": estimated_tokens,
+                "dirty": True,
+            }
+
+    @classmethod
+    def from_snapshot(cls, snapshot: dict[str, Any]) -> Self:
+        instance = cls(
+            llm=None,
+            max_tokens=snapshot.get("max_tokens"),
+            sync_threshold=snapshot.get("sync_threshold", 0.25),
+            capacity_threshold=snapshot.get("capacity_threshold", 0.75),
+        )
+        instance.load_snapshot(snapshot)
+        return instance

--- a/python/beeai_framework/memory/unconstrained_memory.py
+++ b/python/beeai_framework/memory/unconstrained_memory.py
@@ -1,11 +1,14 @@
 # Copyright 2025 © BeeAI a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Any
+
 from beeai_framework.backend.message import AnyMessage
 from beeai_framework.memory.base_memory import BaseMemory
+from beeai_framework.serialization import Serializable
 
 
-class UnconstrainedMemory(BaseMemory):
+class UnconstrainedMemory(Serializable[dict[str, Any]], BaseMemory):
     """Simple memory implementation with no constraints."""
 
     def __init__(self) -> None:
@@ -33,3 +36,9 @@ class UnconstrainedMemory(BaseMemory):
         cloned = UnconstrainedMemory()
         cloned._messages = self._messages.copy()
         return cloned
+
+    def create_snapshot(self) -> dict[str, Any]:
+        return {"messages": list(self._messages)}
+
+    def load_snapshot(self, snapshot: dict[str, Any]) -> None:
+        self._messages = list(snapshot.get("messages", []))

--- a/python/beeai_framework/serialization/__init__.py
+++ b/python/beeai_framework/serialization/__init__.py
@@ -1,0 +1,10 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+from beeai_framework.serialization.serializer import Serializable, Serializer, SerializerError
+
+__all__ = [
+    "Serializable",
+    "Serializer",
+    "SerializerError",
+]

--- a/python/beeai_framework/serialization/serializer.py
+++ b/python/beeai_framework/serialization/serializer.py
@@ -89,7 +89,7 @@ class Serializer:
             ref,
             to_plain=lambda instance: instance.create_snapshot(),
             from_plain=lambda snapshot: ref.from_snapshot(snapshot),
-            create_empty=lambda: ref.__new__(ref),  # type: ignore[misc]
+            create_empty=lambda: object.__new__(ref),
             update_instance=lambda instance, snapshot: instance.load_snapshot(snapshot),
             aliases=aliases,
         )
@@ -182,10 +182,10 @@ class Serializer:
 
     @classmethod
     def _encode(cls, value: Any, seen: dict[int, str], ref_counter: Iterator[int]) -> Any:
-        if value is None or isinstance(value, (bool, int, float, str)):
+        if value is None or isinstance(value, bool | int | float | str):
             return value
 
-        if isinstance(value, (list, tuple, set)):
+        if isinstance(value, list | tuple | set):
             return [cls._encode(item, seen, ref_counter) for item in value]
 
         if isinstance(value, dict):
@@ -292,7 +292,7 @@ class Serializable(Generic[T]):
 
     @classmethod
     def from_snapshot(cls: type[SerializableT], snapshot: T) -> SerializableT:
-        instance = cls.__new__(cls)  # type: ignore[misc]
+        instance = object.__new__(cls)
         instance.load_snapshot(snapshot)
         return instance
 

--- a/python/beeai_framework/serialization/serializer.py
+++ b/python/beeai_framework/serialization/serializer.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+import json
+from collections.abc import Callable, Iterable, Iterator, Mapping
+from dataclasses import dataclass
+from datetime import datetime
+from itertools import count
+from typing import Any, ClassVar, Generic, TypeVar
+
+T = TypeVar("T")
+SerializableT = TypeVar("SerializableT", bound="Serializable[Any]")
+
+
+class SerializerError(RuntimeError):
+    """Raised when serialization or deserialization fails."""
+
+
+@dataclass(slots=True)
+class _SerializerFactory:
+    ref: type[Any]
+    to_plain: Callable[[Any], Any]
+    from_plain: Callable[[Any], Any]
+    create_empty: Callable[[], Any] | None = None
+    update_instance: Callable[[Any, Any], Any] | None = None
+
+
+class Serializer:
+    """Minimal registry driven serializer compatible with the documentation examples."""
+
+    _factories: ClassVar[dict[str, _SerializerFactory]] = {}
+    _type_to_name: ClassVar[dict[type[Any], str]] = {}
+    version: ClassVar[str] = "0.0.0"
+
+    @staticmethod
+    def _class_name(ref: type[Any]) -> str:
+        return ref.__name__
+
+    @classmethod
+    def has_factory(cls, name: str) -> bool:
+        return name in cls._factories
+
+    @classmethod
+    def has_factory_for_type(cls, ref: type[Any]) -> bool:
+        return ref in cls._type_to_name
+
+    @classmethod
+    def register(
+        cls,
+        ref: type[Any],
+        *,
+        to_plain: Callable[[Any], Any],
+        from_plain: Callable[[Any], Any],
+        create_empty: Callable[[], Any] | None = None,
+        update_instance: Callable[[Any, Any], Any] | None = None,
+        aliases: Iterable[str] | None = None,
+    ) -> None:
+        """Register custom serialization logic for a class."""
+        name = cls._class_name(ref)
+        factory = _SerializerFactory(
+            ref=ref,
+            to_plain=to_plain,
+            from_plain=from_plain,
+            create_empty=create_empty,
+            update_instance=update_instance,
+        )
+
+        cls._factories[name] = factory
+        cls._type_to_name[ref] = name
+
+        if aliases:
+            for alias in aliases:
+                cls._factories[alias] = factory
+
+    @classmethod
+    def register_serializable(
+        cls,
+        ref: type[Serializable[Any]],
+        *,
+        aliases: Iterable[str] | None = None,
+    ) -> None:
+        """Register classes that implement the Serializable protocol."""
+
+        if cls.has_factory_for_type(ref):
+            return
+
+        cls.register(
+            ref,
+            to_plain=lambda instance: instance.create_snapshot(),
+            from_plain=lambda snapshot: ref.from_snapshot(snapshot),
+            create_empty=lambda: ref.__new__(ref),  # type: ignore[misc]
+            update_instance=lambda instance, snapshot: instance.load_snapshot(snapshot),
+            aliases=aliases,
+        )
+
+    @classmethod
+    def deregister(cls, ref: type[Any]) -> None:
+        """Remove class registration."""
+        name = cls._type_to_name.pop(ref, None)
+        if name is None:
+            return
+
+        for key in [alias for alias, factory in cls._factories.items() if factory.ref is ref]:
+            cls._factories.pop(key, None)
+
+    @classmethod
+    def ensure_registered(cls, ref: type[Any]) -> None:
+        if cls.has_factory_for_type(ref):
+            return
+
+        # Avoid circular import by referencing Serializable at runtime
+        if issubclass(ref, Serializable):
+            cls.register_serializable(ref)
+            return
+
+        raise SerializerError(f'Class "{ref.__name__}" is not registered with the serializer.')
+
+    @classmethod
+    def serialize(cls, raw_data: Any) -> str:
+        """Serialize python objects into a JSON string."""
+        ref_counter = count(1)
+        seen: dict[int, str] = {}
+        payload = {
+            "__version": cls.version,
+            "__root": cls._encode(raw_data, seen, ref_counter),
+        }
+        return json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+
+    @classmethod
+    def deserialize(
+        cls,
+        data: str | Mapping[str, Any],
+        *,
+        expected_type: type[T] | None = None,
+        extra_classes: Iterable[type[Any]] | None = None,
+    ) -> T | Any:
+        """Deserialize objects previously produced by `serialize`."""
+        if isinstance(data, str):
+            try:
+                payload = json.loads(data)
+            except json.JSONDecodeError as exc:
+                raise SerializerError("Invalid serialized payload.") from exc
+        else:
+            payload = dict(data)
+
+        if not isinstance(payload, dict) or "__root" not in payload:
+            raise SerializerError("Serialized payload is missing the '__root' key.")
+
+        if extra_classes:
+            for extra in extra_classes:
+                if isinstance(extra, type):
+                    registrar = getattr(extra, "register", None)
+                    if callable(registrar):
+                        registrar()
+                    try:
+                        cls.ensure_registered(extra)
+                    except SerializerError:
+                        # Allow extra classes that register themselves on demand.
+                        continue
+
+        seen: dict[str, Any] = {}
+        value = cls._decode(payload["__root"], seen)
+
+        if expected_type is not None and not isinstance(value, expected_type):
+            raise SerializerError(
+                f"Deserialized value is of type {type(value).__name__}, expected {expected_type.__name__}.",
+            )
+
+        return value
+
+    @classmethod
+    def _find_factory_for_instance(cls, value: Any) -> tuple[_SerializerFactory, str]:
+        cls.ensure_registered(type(value))
+
+        for candidate in type(value).__mro__:
+            name = cls._type_to_name.get(candidate)
+            if name and name in cls._factories:
+                return cls._factories[name], name
+
+        raise SerializerError(f'No serializer factory found for "{type(value).__name__}".')
+
+    @classmethod
+    def _encode(cls, value: Any, seen: dict[int, str], ref_counter: Iterator[int]) -> Any:
+        if value is None or isinstance(value, (bool, int, float, str)):
+            return value
+
+        if isinstance(value, (list, tuple, set)):
+            return [cls._encode(item, seen, ref_counter) for item in value]
+
+        if isinstance(value, dict):
+            return {str(key): cls._encode(item, seen, ref_counter) for key, item in value.items()}
+
+        factory, name = cls._find_factory_for_instance(value)
+        obj_id = id(value)
+        if obj_id in seen:
+            return {
+                "__serializer": True,
+                "__ref": seen[obj_id],
+            }
+
+        ref_id = str(next(ref_counter))
+        seen[obj_id] = ref_id
+
+        plain = factory.to_plain(value)
+        encoded_plain = cls._encode(plain, seen, ref_counter)
+        return {
+            "__serializer": True,
+            "__class": name,
+            "__ref": ref_id,
+            "__value": encoded_plain,
+        }
+
+    @classmethod
+    def _decode(cls, value: Any, seen: dict[str, Any]) -> Any:
+        if isinstance(value, list):
+            return [cls._decode(item, seen) for item in value]
+
+        if isinstance(value, dict):
+            if value.get("__serializer") is True:
+                ref_id = value.get("__ref")
+                class_name = value.get("__class")
+
+                if class_name is None:
+                    if ref_id is None or ref_id not in seen:
+                        raise SerializerError("Encountered reference to unknown object.")
+                    return seen[ref_id]
+
+                if class_name not in cls._factories:
+                    raise SerializerError(f'Class "{class_name}" was not registered.')
+
+                factory = cls._factories[class_name]
+                payload = value.get("__value")
+
+                if ref_id is not None and ref_id in seen:
+                    instance = seen[ref_id]
+                    if payload is not None and factory.update_instance:
+                        decoded_payload = cls._decode(payload, seen)
+                        factory.update_instance(instance, decoded_payload)
+                    return instance
+
+                if factory.create_empty and factory.update_instance:
+                    instance = factory.create_empty()
+                    if ref_id is not None:
+                        seen[ref_id] = instance
+                    decoded_payload = cls._decode(payload, seen) if payload is not None else None
+                    factory.update_instance(instance, decoded_payload)
+                    return instance
+
+                decoded_payload = cls._decode(payload, seen) if payload is not None else None
+                instance = factory.from_plain(decoded_payload)
+                if ref_id is not None:
+                    seen[ref_id] = instance
+                return instance
+
+            return {key: cls._decode(item, seen) for key, item in value.items()}
+
+        return value
+
+
+class Serializable(Generic[T]):
+    """Mixin that provides convenience helpers for registering serializable classes."""
+
+    def __init_subclass__(
+        cls,
+        *,
+        auto_register: bool = True,
+        aliases: Iterable[str] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init_subclass__(**kwargs)
+        if auto_register:
+            Serializer.register_serializable(cls, aliases=aliases)
+
+    def serialize(self) -> str:
+        return Serializer.serialize(self)
+
+    @classmethod
+    def register(cls, *, aliases: Iterable[str] | None = None) -> None:
+        Serializer.register_serializable(cls, aliases=aliases)
+
+    @classmethod
+    def from_serialized(
+        cls: type[SerializableT],
+        data: str,
+        *,
+        extra_classes: Iterable[type[Any]] | None = None,
+    ) -> SerializableT:
+        value = Serializer.deserialize(data, expected_type=cls, extra_classes=extra_classes)
+        assert isinstance(value, cls)
+        return value
+
+    @classmethod
+    def from_snapshot(cls: type[SerializableT], snapshot: T) -> SerializableT:
+        instance = cls.__new__(cls)  # type: ignore[misc]
+        instance.load_snapshot(snapshot)
+        return instance
+
+    def to_snapshot(self) -> T:
+        return self.create_snapshot()
+
+    def create_snapshot(self) -> T:
+        raise NotImplementedError
+
+    def load_snapshot(self, snapshot: T) -> None:
+        raise NotImplementedError
+
+
+Serializer.register(
+    datetime,
+    to_plain=lambda value: value.isoformat(),
+    from_plain=lambda data: datetime.fromisoformat(data),
+)

--- a/python/examples/serialization/__init__.py
+++ b/python/examples/serialization/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+

--- a/python/examples/serialization/base.py
+++ b/python/examples/serialization/base.py
@@ -1,0 +1,20 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+from datetime import UTC, datetime
+
+from beeai_framework.serialization import Serializer
+
+
+def main() -> None:
+    original = datetime(2024, 1, 1, tzinfo=UTC)
+    serialized = Serializer.serialize(original)
+    restored = Serializer.deserialize(serialized, expected_type=datetime)
+
+    print(serialized)
+    print(restored.isoformat())
+    print(restored == original)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/examples/serialization/context.py
+++ b/python/examples/serialization/context.py
@@ -1,0 +1,16 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+from beeai_framework.backend import AssistantMessage, UserMessage
+from beeai_framework.memory import UnconstrainedMemory
+
+SERIALIZED_MEMORY = """{"__version":"0.0.0","__root":{"__serializer":true,"__class":"UnconstrainedMemory","__value":{"messages":[{"__serializer":true,"__class":"UserMessage","__value":{"id":null,"meta":{"createdAt":{"__serializer":true,"__class":"datetime","__value":"2025-10-18T19:38:37.859543+00:00"}},"role":"user","content":[{"type":"text","text":"Hello!"}]}},{"__serializer":true,"__class":"AssistantMessage","__value":{"id":null,"meta":{"createdAt":{"__serializer":true,"__class":"datetime","__value":"2025-10-18T19:38:37.859665+00:00"}},"role":"assistant","content":[{"type":"text","text":"Hello, how can I help you?"}]}}]}}}"""
+
+
+def main() -> None:
+    memory = UnconstrainedMemory.from_serialized(SERIALIZED_MEMORY, extra_classes=[UserMessage, AssistantMessage])
+    print([message.text for message in memory.messages])
+
+
+if __name__ == "__main__":
+    main()

--- a/python/examples/serialization/custom_external.py
+++ b/python/examples/serialization/custom_external.py
@@ -1,0 +1,39 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from beeai_framework.serialization import Serializer
+
+
+@dataclass
+class ApiToken:
+    value: str
+    expires_at: datetime
+
+
+Serializer.register(
+    ApiToken,
+    to_plain=lambda token: {
+        "value": token.value,
+        "expires_at": token.expires_at,
+    },
+    from_plain=lambda payload: ApiToken(
+        value=payload["value"],
+        expires_at=payload["expires_at"],
+    ),
+)
+
+
+def main() -> None:
+    token = ApiToken("example-token", datetime(2025, 1, 1, tzinfo=UTC))
+    serialized = Serializer.serialize(token)
+    restored = Serializer.deserialize(serialized, expected_type=ApiToken)
+
+    print(restored)
+    print(restored.expires_at.isoformat())
+
+
+if __name__ == "__main__":
+    main()

--- a/python/examples/serialization/custom_external.py
+++ b/python/examples/serialization/custom_external.py
@@ -19,7 +19,7 @@ Serializer.register(
         "value": token.value,
         "expires_at": token.expires_at,
     },
-    from_plain=lambda payload: ApiToken(
+    from_plain=lambda payload, ref: ref(
         value=payload["value"],
         expires_at=payload["expires_at"],
     ),

--- a/python/examples/serialization/custom_internal.py
+++ b/python/examples/serialization/custom_internal.py
@@ -1,0 +1,33 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+from beeai_framework.serialization import Serializable
+
+
+class Counter(Serializable[dict[str, int]]):
+    def __init__(self, value: int = 0) -> None:
+        self.value = value
+
+    def increment(self) -> None:
+        self.value += 1
+
+    def create_snapshot(self) -> dict[str, int]:
+        return {"value": self.value}
+
+    def load_snapshot(self, snapshot: dict[str, int]) -> None:
+        self.value = snapshot["value"]
+
+
+def main() -> None:
+    counter = Counter(3)
+    counter.increment()
+
+    serialized = counter.serialize()
+    restored = Counter.from_serialized(serialized)
+
+    print(counter.value)
+    print(restored.value)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/examples/serialization/memory.py
+++ b/python/examples/serialization/memory.py
@@ -1,0 +1,24 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+
+from beeai_framework.backend import AssistantMessage, UserMessage
+from beeai_framework.memory import UnconstrainedMemory
+
+
+async def main() -> None:
+    memory = UnconstrainedMemory()
+    await memory.add(UserMessage("What is your name?"))
+
+    serialized = memory.serialize()
+    restored = UnconstrainedMemory.from_serialized(serialized)
+
+    await restored.add(AssistantMessage("Bee"))
+
+    print(len(restored.messages))
+    print(restored.messages[0].text)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/tests/serialization/test_serializer.py
+++ b/python/tests/serialization/test_serializer.py
@@ -48,7 +48,7 @@ def test_custom_registration() -> None:
             "value": token.value,
             "expires_at": token.expires_at,
         },
-        from_plain=lambda payload: ApiToken(
+        from_plain=lambda payload, ref: ref(
             value=payload["value"],
             expires_at=payload["expires_at"],
         ),

--- a/python/tests/serialization/test_serializer.py
+++ b/python/tests/serialization/test_serializer.py
@@ -139,3 +139,34 @@ def test_cyclic_graph_roundtrip() -> None:
     restored = Serializer.deserialize(payload, expected_type=Ring)
 
     assert restored.next is restored
+
+
+def test_deserialize_typescript_payload() -> None:
+    class Counter(Serializable[dict[str, int]]):
+        def __init__(self, value: int = 0) -> None:
+            self.value = value
+
+        def create_snapshot(self) -> dict[str, int]:
+            return {"value": self.value}
+
+        def load_snapshot(self, snapshot: dict[str, int]) -> None:
+            self.value = snapshot["value"]
+
+    payload = (
+        '{"__version":"0.0.0","__root":{"__serializer":true,"__class":"Counter","__ref":"1",'
+        '"__value":{"value":{"__serializer":true,"__class":"Number","__ref":"2","__value":"5"}}}}'
+    )
+
+    restored = Serializer.deserialize(payload, expected_type=Counter)
+    assert isinstance(restored, Counter)
+    assert restored.value == 5
+
+
+def test_deserialize_typescript_date() -> None:
+    payload = (
+        '{"__version":"0.0.0","__root":{"__serializer":true,"__class":"Date","__ref":"1",'
+        '"__value":"2024-01-01T00:00:00.000Z"}}'
+    )
+
+    restored = Serializer.deserialize(payload, expected_type=datetime)
+    assert restored == datetime(2024, 1, 1, tzinfo=UTC)

--- a/python/tests/serialization/test_serializer.py
+++ b/python/tests/serialization/test_serializer.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -90,7 +90,7 @@ async def test_deserialize_with_extra_classes() -> None:
     try:
         restored = UnconstrainedMemory.from_serialized(payload, extra_classes=[UserMessage])
     finally:
-        UserMessage.register()
+        cast(Any, UserMessage).register()
 
     assert len(restored.messages) == 1
     assert isinstance(restored.messages[0], UserMessage)

--- a/python/tests/serialization/test_serializer.py
+++ b/python/tests/serialization/test_serializer.py
@@ -1,0 +1,141 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from beeai_framework.backend import AssistantMessage, UserMessage
+from beeai_framework.memory import UnconstrainedMemory
+from beeai_framework.serialization import Serializable, Serializer
+
+
+def test_datetime_roundtrip() -> None:
+    original = datetime(2024, 1, 1, tzinfo=UTC)
+
+    payload = Serializer.serialize(original)
+    restored = Serializer.deserialize(payload, expected_type=datetime)
+
+    assert restored == original
+
+
+@pytest.mark.asyncio
+async def test_unconstrained_memory_roundtrip() -> None:
+    memory = UnconstrainedMemory()
+    await memory.add(UserMessage("Hello"))
+    await memory.add(AssistantMessage("Hi there"))
+
+    payload = memory.serialize()
+    restored = UnconstrainedMemory.from_serialized(payload)
+
+    assert len(restored.messages) == 2
+    assert restored.messages[0].text == "Hello"
+
+
+def test_custom_registration() -> None:
+    @dataclass
+    class ApiToken:
+        value: str
+        expires_at: datetime
+
+    Serializer.register(
+        ApiToken,
+        to_plain=lambda token: {
+            "value": token.value,
+            "expires_at": token.expires_at,
+        },
+        from_plain=lambda payload: ApiToken(
+            value=payload["value"],
+            expires_at=payload["expires_at"],
+        ),
+    )
+
+    token = ApiToken("secret", datetime(2025, 1, 1, tzinfo=UTC))
+    payload = Serializer.serialize(token)
+    restored = Serializer.deserialize(payload, expected_type=ApiToken)
+
+    assert restored == token
+
+
+def test_serializable_subclass_roundtrip() -> None:
+    class Counter(Serializable[dict[str, int]]):
+        def __init__(self, value: int = 0) -> None:
+            self.value = value
+
+        def create_snapshot(self) -> dict[str, int]:
+            return {"value": self.value}
+
+        def load_snapshot(self, snapshot: dict[str, int]) -> None:
+            self.value = snapshot["value"]
+
+    counter = Counter(7)
+    payload = counter.serialize()
+    restored = Counter.from_serialized(payload)
+
+    assert restored.value == 7
+
+
+@pytest.mark.asyncio
+async def test_deserialize_with_extra_classes() -> None:
+    memory = UnconstrainedMemory()
+    await memory.add(UserMessage("Where are we?"))
+
+    payload = memory.serialize()
+
+    Serializer.deregister(UserMessage)
+    try:
+        restored = UnconstrainedMemory.from_serialized(payload, extra_classes=[UserMessage])
+    finally:
+        UserMessage.register()
+
+    assert len(restored.messages) == 1
+    assert isinstance(restored.messages[0], UserMessage)
+
+
+def test_shared_reference_roundtrip() -> None:
+    class Node(Serializable[dict[str, Any]]):
+        def __init__(self, name: str) -> None:
+            self.name = name
+            self.children: list[Node] = []
+
+        def create_snapshot(self) -> dict[str, Any]:
+            return {"name": self.name, "children": self.children}
+
+        def load_snapshot(self, snapshot: dict[str, Any]) -> None:
+            self.name = snapshot["name"]
+            self.children = snapshot["children"]
+
+    child = Node("child")
+    root = Node("root")
+    root.children = [child, child]
+
+    payload = Serializer.serialize(root)
+    restored = Serializer.deserialize(payload, expected_type=Node)
+
+    assert restored.children[0] is restored.children[1]
+
+
+def test_cyclic_graph_roundtrip() -> None:
+    class Ring(Serializable[dict[str, Any]]):
+        def __init__(self, name: str) -> None:
+            self.name = name
+            self.next: Ring | None = None
+
+        def create_snapshot(self) -> dict[str, Any]:
+            return {"name": self.name, "next": self.next}
+
+        def load_snapshot(self, snapshot: dict[str, Any]) -> None:
+            self.name = snapshot["name"]
+            self.next = snapshot["next"]
+
+    node = Ring("ring")
+    node.next = node
+
+    payload = Serializer.serialize(node)
+    restored = Serializer.deserialize(payload, expected_type=Ring)
+
+    assert restored.next is restored


### PR DESCRIPTION
## Summary
- add a lightweight `Serializer`/`Serializable` implementation for the Python SDK so the docs can point at runnable snippets
- replace the "Example coming soon" placeholders in `docs/modules/serialization.mdx` with concrete Python and TypeScript examples that follow existing codegroup conventions
- add focused pytest coverage for the new serializer behavior and surface the Python examples under `python/examples/serialization`

## Design Decisions
- kept the serializer API intentionally minimal (registry-based with JSON payloads) to mirror the TypeScript shape without pulling in heavy dependencies
- registered core backend message types lazily so docs examples (and deserialization) work without forcing global imports
- stored Python examples alongside existing samples to stay consistent with the docs embedding workflow

## Testing
- python/.venv/bin/python -m pytest python/tests/serialization/test_serializer.py
- python/.venv/bin/python -m pytest -m unit *(fails: missing optional deps `deepeval`, `outlines`)*

Closes #1200.
