### PR TITLE
fix(adapters): correct decorator order in ChatToolFunctionDefinition

### DIFF
--- a/python/beeai_framework/adapters/watsonx_orchestrate/_api.py
+++ b/python/beeai_framework/adapters/watsonx_orchestrate/_api.py
@@ -13,8 +13,8 @@ class ChatToolFunctionDefinition(BaseModel):
     name: str
     arguments: dict[str, Any]
 
-    @classmethod
     @field_validator("arguments", mode="before")
+    @classmethod
     def parse_arguments(cls, value: Any) -> Any:
         if isinstance(value, str):
             try:


### PR DESCRIPTION
### Which issue(s) does this pull-request address?

Closes: [#1233](https://github.com/i-am-bee/beeai-framework/issues/1233)

### Description

Fixed the decorator ordering in `ChatToolFunctionDefinition` class within the watsonx Orchestrate adapter. The `@field_validator` decorator must come before `@classmethod` in Pydantic v2 for proper validation functionality.

**Problem:** When watsonx Orchestrate sends tool call requests, the `arguments` field comes as a JSON string instead of a dict object. The existing validator was attempting to parse this string, but due to incorrect decorator ordering, the validation was failing with a 422 error.

**Solution:** Reordered the decorators so `@field_validator("arguments", mode="before")` comes before `@classmethod`, which is the correct syntax for Pydantic v2.

**Impact:** This fix enables proper integration between BeeAI agents and IBM watsonx Orchestrate, allowing tool calls to be parsed correctly.

### Checklist

#### General
- [x] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [x] Code quality checks pass: `mise check` (`mise fix` to auto-fix)

#### Testing
- [x] Unit tests pass: `mise test:unit`
- [ ] E2E tests pass: `mise test:e2e` - Not run locally (requires Ollama with llama3.1:8b and granite3.3:8b)
- [x] Tests are included (for bug fixes or new features) - N/A: This is a decorator order fix, existing tests cover functionality

#### Documentation
- [x] Documentation is updated - N/A: No documentation changes needed for internal fix
- [ ] Embedme embeds code examples in docs. To update after edits, run: Python `mise docs:fix`
