### PR TITLE
feat: upgrade MiniMax default model to M3 (with Python/TypeScript provider)

### DIFF
--- a/docs-old/modules/backend.mdx
+++ b/docs-old/modules/backend.mdx
@@ -39,6 +39,7 @@ The following table depicts supported providers. Each provider requires specific
 | Google Gemini  |  ✅  | ✅        | GEMINI_CHAT_MODEL<br/>**GEMINI_API_KEY**<br/>GEMINI_API_HEADERS |
 | MistralAI      |  ✅  | ✅        | MISTRALAI_CHAT_MODEL<br/>MISTRALAI_EMBEDDING_MODEL<br />**MISTRALAI_API_KEY**<br />MISTRALAI_API_BASE |
 | Transformers   |  ✅  | ✅        | TRANSFORMERS_CHAT_MODEL<br/>HF_TOKEN|
+| MiniMax        |  ✅  | ❌        | MINIMAX_CHAT_MODEL<br/>**MINIMAX_API_KEY**<br/>MINIMAX_API_BASE<br/>MINIMAX_API_HEADERS |
 
 <Tip>
 If you don't see your provider raise an issue [here](https://github.com/i-am-bee/beeai-framework/issues).

--- a/docs/src/content/docs/modules/backend.mdx
+++ b/docs/src/content/docs/modules/backend.mdx
@@ -37,6 +37,7 @@ The following table depicts supported providers. Each provider requires specific
 | Google Gemini  |  ✅  | ✅        | GEMINI_CHAT_MODEL<br/>**GEMINI_API_KEY**<br/>GEMINI_API_HEADERS |
 | MistralAI      |  ✅  | ✅        | MISTRALAI_CHAT_MODEL<br/>MISTRALAI_EMBEDDING_MODEL<br />**MISTRALAI_API_KEY**<br />MISTRALAI_API_BASE |
 | Transformers   |  ✅  | ✅        | TRANSFORMERS_CHAT_MODEL<br/>HF_TOKEN|
+| MiniMax        |  ✅  | ❌        | MINIMAX_CHAT_MODEL<br/>**MINIMAX_API_KEY**<br/>MINIMAX_API_BASE<br/>MINIMAX_API_HEADERS |
 
 <Tip>
 If you don't see your provider raise an issue [here](https://github.com/i-am-bee/beeai-framework/issues).

--- a/python/beeai_framework/adapters/minimax/__init__.py
+++ b/python/beeai_framework/adapters/minimax/__init__.py
@@ -1,0 +1,6 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+from beeai_framework.adapters.minimax.backend.chat import MiniMaxChatModel
+
+__all__ = ["MiniMaxChatModel"]

--- a/python/beeai_framework/adapters/minimax/backend/__init__.py
+++ b/python/beeai_framework/adapters/minimax/backend/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0

--- a/python/beeai_framework/adapters/minimax/backend/chat.py
+++ b/python/beeai_framework/adapters/minimax/backend/chat.py
@@ -1,0 +1,70 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from typing_extensions import Unpack
+
+from beeai_framework.adapters.litellm import LiteLLMChatModel, utils
+from beeai_framework.backend.chat import ChatModelKwargs
+from beeai_framework.backend.constants import ProviderName
+from beeai_framework.logger import Logger
+
+logger = Logger(__name__)
+
+MINIMAX_API_BASE = "https://api.minimax.io/v1"
+
+
+class MiniMaxChatModel(LiteLLMChatModel):
+    """
+    A chat model implementation for the MiniMax provider, leveraging LiteLLM.
+
+    MiniMax provides an OpenAI-compatible API. This adapter routes requests
+    through LiteLLM's OpenAI provider with the MiniMax base URL.
+
+    Available models include MiniMax-M2.7, MiniMax-M2.7-highspeed,
+    MiniMax-M2.5, and MiniMax-M2.5-highspeed.
+    """
+
+    @property
+    def provider_id(self) -> ProviderName:
+        """The provider ID for MiniMax."""
+        return "minimax"
+
+    def __init__(
+        self,
+        model_id: str | None = None,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        **kwargs: Unpack[ChatModelKwargs],
+    ) -> None:
+        """
+        Initializes the MinimaxChatModel.
+
+        Args:
+            model_id: The ID of the MiniMax model to use. If not provided,
+                it falls back to the MINIMAX_CHAT_MODEL environment variable,
+                and then defaults to 'MiniMax-M2.7'.
+            api_key: The MiniMax API key. Falls back to MINIMAX_API_KEY env var.
+            base_url: The MiniMax API base URL. Falls back to MINIMAX_API_BASE
+                env var, then defaults to 'https://api.minimax.io/v1'.
+            **kwargs: Additional settings to configure the provider.
+        """
+        super().__init__(
+            model_id if model_id else os.getenv("MINIMAX_CHAT_MODEL", "MiniMax-M2.7"),
+            provider_id="openai",
+            **kwargs,
+        )
+
+        self._assert_setting_value("api_key", api_key, envs=["MINIMAX_API_KEY"])
+        self._assert_setting_value(
+            "base_url",
+            base_url,
+            envs=["MINIMAX_API_BASE"],
+            aliases=["api_base"],
+            allow_empty=True,
+            fallback=MINIMAX_API_BASE,
+        )
+        self._settings["extra_headers"] = utils.parse_extra_headers(
+            self._settings.get("extra_headers"), os.getenv("MINIMAX_API_HEADERS")
+        )

--- a/python/beeai_framework/adapters/minimax/backend/chat.py
+++ b/python/beeai_framework/adapters/minimax/backend/chat.py
@@ -21,8 +21,8 @@ class MiniMaxChatModel(LiteLLMChatModel):
     MiniMax provides an OpenAI-compatible API. This adapter routes requests
     through LiteLLM's OpenAI provider with the MiniMax base URL.
 
-    Available models include MiniMax-M2.7, MiniMax-M2.7-highspeed,
-    MiniMax-M2.5, and MiniMax-M2.5-highspeed.
+    Available models include MiniMax-M3 (default), MiniMax-M2.7,
+    and MiniMax-M2.7-highspeed.
     """
 
     @property
@@ -44,14 +44,14 @@ class MiniMaxChatModel(LiteLLMChatModel):
         Args:
             model_id: The ID of the MiniMax model to use. If not provided,
                 it falls back to the MINIMAX_CHAT_MODEL environment variable,
-                and then defaults to 'MiniMax-M2.7'.
+                and then defaults to 'MiniMax-M3'.
             api_key: The MiniMax API key. Falls back to MINIMAX_API_KEY env var.
             base_url: The MiniMax API base URL. Falls back to MINIMAX_API_BASE
                 env var, then defaults to 'https://api.minimax.io/v1'.
             **kwargs: Additional settings to configure the provider.
         """
         super().__init__(
-            model_id if model_id else os.getenv("MINIMAX_CHAT_MODEL", "MiniMax-M2.7"),
+            model_id if model_id else os.getenv("MINIMAX_CHAT_MODEL", "MiniMax-M3"),
             provider_id="openai",
             **kwargs,
         )

--- a/python/beeai_framework/adapters/minimax/backend/chat.py
+++ b/python/beeai_framework/adapters/minimax/backend/chat.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+
 from typing_extensions import Unpack
 
 from beeai_framework.adapters.litellm import LiteLLMChatModel, utils

--- a/python/beeai_framework/backend/constants.py
+++ b/python/beeai_framework/backend/constants.py
@@ -24,6 +24,7 @@ ProviderName = Literal[
     "transformers",
     "deepseek",
     "qwen",
+    "minimax",
 ]
 ProviderHumanName = Literal[
     "AgentStack",
@@ -44,6 +45,7 @@ ProviderHumanName = Literal[
     "Transformers",
     "Deepseek",
     "Qwen",
+    "MiniMax",
 ]
 
 ModelTypes = Literal["embedding", "chat"]
@@ -95,4 +97,5 @@ BackendProviders = {
     "Transformers": ProviderDef(name="Transformers", module="transformers", aliases=["Transformers", "transformers"]),
     "Deepseek": ProviderDef(name="Deepseek", module="deepseek", aliases=["deepseek"]),
     "Qwen": ProviderDef(name="Qwen", module="qwen", aliases=["qwen", "dashscope"]),
+    "MiniMax": ProviderDef(name="MiniMax", module="minimax", aliases=["minimax"]),
 }

--- a/python/examples/backend/providers/minimax.py
+++ b/python/examples/backend/providers/minimax.py
@@ -1,0 +1,101 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+
+from dotenv import load_dotenv
+from pydantic import BaseModel, Field
+
+from beeai_framework.adapters.minimax import MiniMaxChatModel
+from beeai_framework.backend import ChatModel, ChatModelNewTokenEvent, UserMessage
+from beeai_framework.emitter import EventMeta
+from beeai_framework.errors import AbortError
+from beeai_framework.parsers.field import ParserField
+from beeai_framework.parsers.line_prefix import LinePrefixParser, LinePrefixParserNode
+from beeai_framework.utils import AbortSignal
+
+
+async def minimax_from_name() -> None:
+    llm = ChatModel.from_name("minimax:MiniMax-M2.7")
+    user_message = UserMessage("what states are part of New England?")
+    response = await llm.run([user_message])
+    print(response.get_text_content())
+
+
+async def minimax_sync() -> None:
+    llm = MiniMaxChatModel("MiniMax-M2.7")
+    user_message = UserMessage("what is the capital of Massachusetts?")
+    response = await llm.run([user_message])
+    print(response.get_text_content())
+
+
+async def minimax_stream() -> None:
+    llm = MiniMaxChatModel("MiniMax-M2.7")
+    user_message = UserMessage("How many islands make up the country of Cape Verde?")
+    response = await llm.run([user_message], stream=True)
+    print(response.get_text_content())
+
+
+async def minimax_stream_abort() -> None:
+    llm = MiniMaxChatModel("MiniMax-M2.7")
+    user_message = UserMessage("What is the smallest of the Cape Verde islands?")
+
+    try:
+        response = await llm.run([user_message], stream=True, signal=AbortSignal.timeout(0.5))
+
+        if response is not None:
+            print(response.get_text_content())
+        else:
+            print("No response returned.")
+    except AbortError as err:
+        print(f"Aborted: {err}")
+
+
+async def minimax_structure() -> None:
+    class TestSchema(BaseModel):
+        answer: str = Field(description="your final answer")
+
+    llm = MiniMaxChatModel("MiniMax-M2.7")
+    user_message = UserMessage("How many islands make up the country of Cape Verde?")
+    response = await llm.run([user_message], response_format=TestSchema)
+    print(response.output_structured)
+
+
+async def minimax_stream_parser() -> None:
+    llm = MiniMaxChatModel("MiniMax-M2.7")
+
+    parser = LinePrefixParser(
+        nodes={
+            "test": LinePrefixParserNode(
+                prefix="Prefix: ", field=ParserField.from_type(str), is_start=True, is_end=True
+            )
+        }
+    )
+
+    async def on_new_token(data: ChatModelNewTokenEvent, event: EventMeta) -> None:
+        await parser.add(chunk=data.value.get_text_content())
+
+    user_message = UserMessage("Produce 3 lines each starting with 'Prefix: ' followed by a sentence and a new line.")
+    await llm.run([user_message], stream=True).observe(lambda emitter: emitter.on("new_token", on_new_token))
+    result = await parser.end()
+    print(result)
+
+
+async def main() -> None:
+    print("*" * 10, "minimax_from_name")
+    await minimax_from_name()
+    print("*" * 10, "minimax_sync")
+    await minimax_sync()
+    print("*" * 10, "minimax_stream")
+    await minimax_stream()
+    print("*" * 10, "minimax_stream_abort")
+    await minimax_stream_abort()
+    print("*" * 10, "minimax_structure")
+    await minimax_structure()
+    print("*" * 10, "minimax_stream_parser")
+    await minimax_stream_parser()
+
+
+if __name__ == "__main__":
+    load_dotenv()
+    asyncio.run(main())

--- a/python/examples/backend/providers/minimax.py
+++ b/python/examples/backend/providers/minimax.py
@@ -16,28 +16,28 @@ from beeai_framework.utils import AbortSignal
 
 
 async def minimax_from_name() -> None:
-    llm = ChatModel.from_name("minimax:MiniMax-M2.7")
+    llm = ChatModel.from_name("minimax:MiniMax-M3")
     user_message = UserMessage("what states are part of New England?")
     response = await llm.run([user_message])
     print(response.get_text_content())
 
 
 async def minimax_sync() -> None:
-    llm = MiniMaxChatModel("MiniMax-M2.7")
+    llm = MiniMaxChatModel("MiniMax-M3")
     user_message = UserMessage("what is the capital of Massachusetts?")
     response = await llm.run([user_message])
     print(response.get_text_content())
 
 
 async def minimax_stream() -> None:
-    llm = MiniMaxChatModel("MiniMax-M2.7")
+    llm = MiniMaxChatModel("MiniMax-M3")
     user_message = UserMessage("How many islands make up the country of Cape Verde?")
     response = await llm.run([user_message], stream=True)
     print(response.get_text_content())
 
 
 async def minimax_stream_abort() -> None:
-    llm = MiniMaxChatModel("MiniMax-M2.7")
+    llm = MiniMaxChatModel("MiniMax-M3")
     user_message = UserMessage("What is the smallest of the Cape Verde islands?")
 
     try:
@@ -55,14 +55,14 @@ async def minimax_structure() -> None:
     class TestSchema(BaseModel):
         answer: str = Field(description="your final answer")
 
-    llm = MiniMaxChatModel("MiniMax-M2.7")
+    llm = MiniMaxChatModel("MiniMax-M3")
     user_message = UserMessage("How many islands make up the country of Cape Verde?")
     response = await llm.run([user_message], response_format=TestSchema)
     print(response.output_structured)
 
 
 async def minimax_stream_parser() -> None:
-    llm = MiniMaxChatModel("MiniMax-M2.7")
+    llm = MiniMaxChatModel("MiniMax-M3")
 
     parser = LinePrefixParser(
         nodes={

--- a/python/tests/adapters/minimax/__init__.py
+++ b/python/tests/adapters/minimax/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0

--- a/python/tests/adapters/minimax/test_minimax_chat.py
+++ b/python/tests/adapters/minimax/test_minimax_chat.py
@@ -1,0 +1,111 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from beeai_framework.adapters.minimax.backend.chat import MINIMAX_API_BASE, MiniMaxChatModel
+from beeai_framework.backend.chat import ChatModel
+from beeai_framework.backend.constants import BackendProviders
+
+
+class TestMiniMaxProviderRegistration:
+    """Test that MiniMax is properly registered as a provider."""
+
+    def test_minimax_in_backend_providers(self) -> None:
+        assert "MiniMax" in BackendProviders
+        provider = BackendProviders["MiniMax"]
+        assert provider.name == "MiniMax"
+        assert provider.module == "minimax"
+        assert "minimax" in provider.aliases
+
+    def test_provider_def_has_correct_structure(self) -> None:
+        provider = BackendProviders["MiniMax"]
+        assert hasattr(provider, "name")
+        assert hasattr(provider, "module")
+        assert hasattr(provider, "aliases")
+
+
+class TestMiniMaxChatModelInit:
+    """Test MiniMaxChatModel initialization."""
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    def test_default_model_id(self) -> None:
+        model = MiniMaxChatModel()
+        assert model.model_id == "MiniMax-M2.7"
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    def test_custom_model_id(self) -> None:
+        model = MiniMaxChatModel("MiniMax-M2.5")
+        assert model.model_id == "MiniMax-M2.5"
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    def test_highspeed_model_id(self) -> None:
+        model = MiniMaxChatModel("MiniMax-M2.7-highspeed")
+        assert model.model_id == "MiniMax-M2.7-highspeed"
+
+    @patch.dict(
+        os.environ,
+        {"MINIMAX_API_KEY": "test-key-123", "MINIMAX_CHAT_MODEL": "MiniMax-M2.5-highspeed"},
+    )
+    def test_model_from_env(self) -> None:
+        model = MiniMaxChatModel()
+        assert model.model_id == "MiniMax-M2.5-highspeed"
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    def test_provider_id(self) -> None:
+        model = MiniMaxChatModel()
+        assert model.provider_id == "minimax"
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    def test_default_base_url(self) -> None:
+        model = MiniMaxChatModel()
+        assert model._settings.get("base_url") == MINIMAX_API_BASE
+
+    @patch.dict(
+        os.environ,
+        {"MINIMAX_API_KEY": "test-key-123", "MINIMAX_API_BASE": "https://custom.minimax.io/v1"},
+    )
+    def test_custom_base_url_from_env(self) -> None:
+        model = MiniMaxChatModel()
+        assert model._settings.get("base_url") == "https://custom.minimax.io/v1"
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    def test_custom_base_url_param(self) -> None:
+        model = MiniMaxChatModel(base_url="https://proxy.example.com/v1")
+        assert model._settings.get("base_url") == "https://proxy.example.com/v1"
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    def test_api_key_stored(self) -> None:
+        model = MiniMaxChatModel()
+        assert model._settings.get("api_key") == "test-key-123"
+
+    def test_missing_api_key_raises(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            # Remove any existing MINIMAX_API_KEY
+            os.environ.pop("MINIMAX_API_KEY", None)
+            with pytest.raises(ValueError, match="api_key.*required"):
+                MiniMaxChatModel()
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    def test_explicit_api_key(self) -> None:
+        model = MiniMaxChatModel(api_key="explicit-key")
+        assert model._settings.get("api_key") == "explicit-key"
+
+
+class TestMiniMaxModelLoading:
+    """Test that MiniMax models can be loaded via the factory method."""
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    def test_load_from_name(self) -> None:
+        model = ChatModel.from_name("minimax:MiniMax-M2.7")
+        assert isinstance(model, MiniMaxChatModel)
+        assert model.model_id == "MiniMax-M2.7"
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    def test_load_from_alias(self) -> None:
+        model = ChatModel.from_name("minimax:MiniMax-M2.5")
+        assert isinstance(model, MiniMaxChatModel)
+        assert model.model_id == "MiniMax-M2.5"

--- a/python/tests/adapters/minimax/test_minimax_chat.py
+++ b/python/tests/adapters/minimax/test_minimax_chat.py
@@ -34,12 +34,12 @@ class TestMiniMaxChatModelInit:
     @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
     def test_default_model_id(self) -> None:
         model = MiniMaxChatModel()
-        assert model.model_id == "MiniMax-M2.7"
+        assert model.model_id == "MiniMax-M3"
 
     @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
     def test_custom_model_id(self) -> None:
-        model = MiniMaxChatModel("MiniMax-M2.5")
-        assert model.model_id == "MiniMax-M2.5"
+        model = MiniMaxChatModel("MiniMax-M2.7")
+        assert model.model_id == "MiniMax-M2.7"
 
     @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
     def test_highspeed_model_id(self) -> None:
@@ -48,11 +48,11 @@ class TestMiniMaxChatModelInit:
 
     @patch.dict(
         os.environ,
-        {"MINIMAX_API_KEY": "test-key-123", "MINIMAX_CHAT_MODEL": "MiniMax-M2.5-highspeed"},
+        {"MINIMAX_API_KEY": "test-key-123", "MINIMAX_CHAT_MODEL": "MiniMax-M2.7-highspeed"},
     )
     def test_model_from_env(self) -> None:
         model = MiniMaxChatModel()
-        assert model.model_id == "MiniMax-M2.5-highspeed"
+        assert model.model_id == "MiniMax-M2.7-highspeed"
 
     @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
     def test_provider_id(self) -> None:
@@ -100,12 +100,12 @@ class TestMiniMaxModelLoading:
 
     @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
     def test_load_from_name(self) -> None:
-        model = ChatModel.from_name("minimax:MiniMax-M2.7")
+        model = ChatModel.from_name("minimax:MiniMax-M3")
         assert isinstance(model, MiniMaxChatModel)
-        assert model.model_id == "MiniMax-M2.7"
+        assert model.model_id == "MiniMax-M3"
 
     @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
     def test_load_from_alias(self) -> None:
-        model = ChatModel.from_name("minimax:MiniMax-M2.5")
+        model = ChatModel.from_name("minimax:MiniMax-M2.7")
         assert isinstance(model, MiniMaxChatModel)
-        assert model.model_id == "MiniMax-M2.5"
+        assert model.model_id == "MiniMax-M2.7"

--- a/python/tests/adapters/minimax/test_minimax_chat.py
+++ b/python/tests/adapters/minimax/test_minimax_chat.py
@@ -86,7 +86,7 @@ class TestMiniMaxChatModelInit:
         with patch.dict(os.environ, {}, clear=True):
             # Remove any existing MINIMAX_API_KEY
             os.environ.pop("MINIMAX_API_KEY", None)
-            with pytest.raises(ValueError, match="api_key.*required"):
+            with pytest.raises(ValueError, match=r"api_key.*required"):
                 MiniMaxChatModel()
 
     @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})

--- a/python/tests/adapters/minimax/test_minimax_integration.py
+++ b/python/tests/adapters/minimax/test_minimax_integration.py
@@ -1,0 +1,59 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests for MiniMax chat model.
+
+These tests require a valid MINIMAX_API_KEY environment variable.
+Run with: pytest tests/adapters/minimax/test_minimax_integration.py -v
+"""
+
+import os
+
+import pytest
+
+from beeai_framework.adapters.minimax.backend.chat import MiniMaxChatModel
+from beeai_framework.backend.message import UserMessage
+
+pytestmark = pytest.mark.skipif(
+    not os.getenv("MINIMAX_API_KEY"),
+    reason="MINIMAX_API_KEY not set",
+)
+
+
+@pytest.fixture
+def chat_model() -> MiniMaxChatModel:
+    return MiniMaxChatModel("MiniMax-M2.7")
+
+
+@pytest.fixture
+def highspeed_model() -> MiniMaxChatModel:
+    return MiniMaxChatModel("MiniMax-M2.7-highspeed")
+
+
+class TestMiniMaxIntegration:
+    """Integration tests that call the real MiniMax API."""
+
+    @pytest.mark.asyncio
+    async def test_simple_chat(self, chat_model: MiniMaxChatModel) -> None:
+        output = await chat_model.run(
+            [UserMessage("What is 2 + 2? Reply with just the number.")],
+        )
+        text = output.get_text_content()
+        assert "4" in text
+
+    @pytest.mark.asyncio
+    async def test_highspeed_model(self, highspeed_model: MiniMaxChatModel) -> None:
+        output = await highspeed_model.run(
+            [UserMessage("Say hello in one word.")],
+        )
+        text = output.get_text_content()
+        assert len(text) > 0
+
+    @pytest.mark.asyncio
+    async def test_streaming(self, chat_model: MiniMaxChatModel) -> None:
+        output = await chat_model.run(
+            [UserMessage("Count from 1 to 3.")],
+            stream=True,
+        )
+        text = output.get_text_content()
+        assert "1" in text

--- a/python/tests/adapters/minimax/test_minimax_integration.py
+++ b/python/tests/adapters/minimax/test_minimax_integration.py
@@ -22,7 +22,7 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.fixture
 def chat_model() -> MiniMaxChatModel:
-    return MiniMaxChatModel("MiniMax-M2.7")
+    return MiniMaxChatModel("MiniMax-M3")
 
 
 @pytest.fixture

--- a/python/tests/examples/test_examples.py
+++ b/python/tests/examples/test_examples.py
@@ -35,6 +35,7 @@ exclude = list(
             "backend/providers/langchain_compatible.py",
             "backend/providers/qwen.py" if os.getenv("DASHSCOPE_API_KEY") is None else None,
             "backend/providers/deepseek.py" if os.getenv("DEEPSEEK_CHAT_MODEL") is None else None,
+            "backend/providers/minimax.py" if os.getenv("MINIMAX_API_KEY") is None else None,
             "tools/mcp_agent.py" if os.getenv("SLACK_BOT_TOKEN") is None else None,
             "tools/mcp_tool_creation.py" if os.getenv("SLACK_BOT_TOKEN") is None else None,
             "tools/mcp_slack_agent.py" if os.getenv("SLACK_BOT_TOKEN") is None else None,

--- a/typescript/examples/backend/providers/minimax.ts
+++ b/typescript/examples/backend/providers/minimax.ts
@@ -1,0 +1,130 @@
+import "dotenv/config";
+import { MiniMaxChatModel } from "beeai-framework/adapters/minimax/backend/chat";
+import "dotenv/config.js";
+import { ToolMessage, UserMessage } from "beeai-framework/backend/message";
+import { ChatModel } from "beeai-framework/backend/chat";
+import { AbortError } from "beeai-framework/errors";
+import { z } from "zod";
+import { OpenMeteoTool } from "beeai-framework/tools/weather/openMeteo";
+
+const llm = new MiniMaxChatModel(
+  "MiniMax-M2.7",
+  // {},
+  // {
+  //   apiKey: "MINIMAX_API_KEY",
+  //   baseURL: "https://api.minimax.io/v1",
+  // },
+);
+
+llm.config({
+  parameters: {
+    temperature: 0.7,
+    maxTokens: 1024,
+    topP: 1,
+  },
+});
+
+async function minimaxFromName() {
+  const minimaxLLM = await ChatModel.fromName("minimax:MiniMax-M2.7");
+  const response = await minimaxLLM.create({
+    messages: [new UserMessage("what states are part of New England?")],
+  });
+  console.info(response.getTextContent());
+}
+
+async function minimaxSync() {
+  const response = await llm.create({
+    messages: [new UserMessage("what is the capital of Massachusetts?")],
+  });
+  console.info(response.getTextContent());
+}
+
+async function minimaxStream() {
+  const response = await llm.create({
+    messages: [new UserMessage("How many islands make up the country of Cape Verde?")],
+    stream: true,
+  });
+  console.info(response.getTextContent());
+}
+
+async function minimaxAbort() {
+  try {
+    const response = await llm.create({
+      messages: [new UserMessage("What is the smallest of the Cape Verde islands?")],
+      stream: true,
+      abortSignal: AbortSignal.timeout(5 * 1000),
+    });
+    console.info(response.getTextContent());
+  } catch (err) {
+    if (err instanceof AbortError) {
+      console.log("Aborted", { err });
+    }
+  }
+}
+
+async function minimaxStructure() {
+  const response = await llm.createStructure({
+    schema: z.object({
+      answer: z.string({ description: "your final answer" }),
+    }),
+    messages: [new UserMessage("How many islands make up the country of Cape Verde?")],
+  });
+  console.info(response.object);
+}
+
+async function minimaxToolCalling() {
+  const userMessage = new UserMessage(
+    `What is the current weather in Boston? Current date is ${new Date().toISOString().split("T")[0]}.`,
+  );
+  const weatherTool = new OpenMeteoTool({ retryOptions: { maxRetries: 3 } });
+  const response = await llm.create({
+    messages: [userMessage],
+    tools: [weatherTool],
+  });
+  const toolCallMsg = response.getToolCalls()[0];
+  console.debug(JSON.stringify(toolCallMsg));
+  const toolResponse = await weatherTool.run(toolCallMsg.input as any);
+  const toolResponseMsg = new ToolMessage({
+    type: "tool-result",
+    output: { type: "text", value: toolResponse.getTextContent() },
+    toolName: toolCallMsg.toolName,
+    toolCallId: toolCallMsg.toolCallId,
+  });
+  console.info(toolResponseMsg.toPlain());
+  const finalResponse = await llm.create({
+    messages: [userMessage, ...response.messages, toolResponseMsg],
+    tools: [],
+  });
+  console.info(finalResponse.getTextContent());
+}
+
+async function minimaxDebug() {
+  // Log every request
+  llm.emitter.match("*", (value, event) =>
+    console.debug(
+      `Time: ${event.createdAt.toISOString()}`,
+      `Event: ${event.name}`,
+      `Data: ${JSON.stringify(value)}`,
+    ),
+  );
+
+  const response = await llm.create({
+    messages: [new UserMessage("Hello world!")],
+  });
+  console.info(response.messages[0].toPlain());
+}
+
+console.info("minimaxFromName".padStart(25, "*"));
+await minimaxFromName();
+console.info("minimaxSync".padStart(25, "*"));
+await minimaxSync();
+console.info("minimaxStream".padStart(25, "*"));
+await minimaxStream();
+console.info("minimaxAbort".padStart(25, "*"));
+await minimaxAbort();
+console.info("minimaxStructure".padStart(25, "*"));
+await minimaxStructure();
+console.info("minimaxToolCalling".padStart(25, "*"));
+await minimaxToolCalling();
+console.info("minimaxDebug".padStart(25, "*"));
+await minimaxDebug();

--- a/typescript/examples/backend/providers/minimax.ts
+++ b/typescript/examples/backend/providers/minimax.ts
@@ -8,7 +8,7 @@ import { z } from "zod";
 import { OpenMeteoTool } from "beeai-framework/tools/weather/openMeteo";
 
 const llm = new MiniMaxChatModel(
-  "MiniMax-M2.7",
+  "MiniMax-M3",
   // {},
   // {
   //   apiKey: "MINIMAX_API_KEY",
@@ -25,7 +25,7 @@ llm.config({
 });
 
 async function minimaxFromName() {
-  const minimaxLLM = await ChatModel.fromName("minimax:MiniMax-M2.7");
+  const minimaxLLM = await ChatModel.fromName("minimax:MiniMax-M3");
   const response = await minimaxLLM.create({
     messages: [new UserMessage("what states are part of New England?")],
   });

--- a/typescript/src/adapters/minimax/backend/chat.ts
+++ b/typescript/src/adapters/minimax/backend/chat.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2025 © BeeAI a Series of LF Projects, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { OpenAIProvider } from "@ai-sdk/openai";
+import { MiniMaxClient, MiniMaxClientSettings } from "@/adapters/minimax/backend/client.js";
+import { VercelChatModel } from "@/adapters/vercel/backend/chat.js";
+import { getEnv } from "@/internals/env.js";
+import { ChatModelParameters } from "@/backend/chat.js";
+
+type MiniMaxParameters = Parameters<OpenAIProvider["chat"]>;
+export type MiniMaxChatModelId = NonNullable<MiniMaxParameters[0]>;
+
+export class MiniMaxChatModel extends VercelChatModel {
+  constructor(
+    modelId: MiniMaxChatModelId = getEnv("MINIMAX_CHAT_MODEL", "MiniMax-M2.7"),
+    parameters: ChatModelParameters = {},
+    client?: MiniMaxClient | MiniMaxClientSettings,
+  ) {
+    const model = MiniMaxClient.ensure(client).instance.chat(modelId);
+    super(model);
+    Object.assign(this.parameters, parameters ?? {});
+  }
+
+  static {
+    this.register();
+  }
+}

--- a/typescript/src/adapters/minimax/backend/chat.ts
+++ b/typescript/src/adapters/minimax/backend/chat.ts
@@ -14,7 +14,7 @@ export type MiniMaxChatModelId = NonNullable<MiniMaxParameters[0]>;
 
 export class MiniMaxChatModel extends VercelChatModel {
   constructor(
-    modelId: MiniMaxChatModelId = getEnv("MINIMAX_CHAT_MODEL", "MiniMax-M2.7"),
+    modelId: MiniMaxChatModelId = getEnv("MINIMAX_CHAT_MODEL", "MiniMax-M3"),
     parameters: ChatModelParameters = {},
     client?: MiniMaxClient | MiniMaxClientSettings,
   ) {

--- a/typescript/src/adapters/minimax/backend/client.ts
+++ b/typescript/src/adapters/minimax/backend/client.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2025 © BeeAI a Series of LF Projects, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createOpenAI, OpenAIProvider, OpenAIProviderSettings } from "@ai-sdk/openai";
+import { getEnv } from "@/internals/env.js";
+import { BackendClient } from "@/backend/client.js";
+import { parseHeadersFromEnv, vercelFetcher } from "@/adapters/vercel/backend/utils.js";
+
+const MINIMAX_API_BASE = "https://api.minimax.io/v1";
+
+export type MiniMaxClientSettings = OpenAIProviderSettings;
+
+export class MiniMaxClient extends BackendClient<MiniMaxClientSettings, OpenAIProvider> {
+  protected create(): OpenAIProvider {
+    return createOpenAI({
+      ...this.settings,
+      apiKey: this.settings?.apiKey || getEnv("MINIMAX_API_KEY"),
+      baseURL: this.settings?.baseURL || getEnv("MINIMAX_API_BASE", MINIMAX_API_BASE),
+      headers: {
+        ...parseHeadersFromEnv("MINIMAX_API_HEADERS"),
+        ...this.settings?.headers,
+      },
+      fetch: vercelFetcher(this.settings?.fetch),
+    });
+  }
+}

--- a/typescript/src/backend/constants.ts
+++ b/typescript/src/backend/constants.ts
@@ -34,6 +34,11 @@ export const BackendProviders = {
     module: "anthropic",
     aliases: [] as string[],
   },
+  MiniMax: {
+    name: "MiniMax",
+    module: "minimax",
+    aliases: ["minimax"] as string[],
+  },
 } as const;
 
 export type ProviderName = (typeof BackendProviders)[keyof typeof BackendProviders]["module"];

--- a/typescript/tests/e2e/adapters/minimax.test.ts
+++ b/typescript/tests/e2e/adapters/minimax.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2025 © BeeAI a Series of LF Projects, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { BackendProviders } from "@/backend/constants.js";
+import { MiniMaxChatModel } from "@/adapters/minimax/backend/chat.js";
+import { MiniMaxClient } from "@/adapters/minimax/backend/client.js";
+
+describe("MiniMax Provider Registration", () => {
+  it("should be registered in BackendProviders", () => {
+    expect(BackendProviders.MiniMax).toBeDefined();
+    expect(BackendProviders.MiniMax.name).toBe("MiniMax");
+    expect(BackendProviders.MiniMax.module).toBe("minimax");
+    expect(BackendProviders.MiniMax.aliases).toContain("minimax");
+  });
+});
+
+describe("MiniMaxClient", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("should create client with explicit settings", () => {
+    const client = new MiniMaxClient({
+      apiKey: "test-key",
+      baseURL: "https://api.minimax.io/v1",
+    });
+    expect(client).toBeDefined();
+    expect(client.instance).toBeDefined();
+  });
+
+  it("should create client from env vars", () => {
+    process.env.MINIMAX_API_KEY = "test-key-from-env";
+    const client = new MiniMaxClient({});
+    expect(client).toBeDefined();
+    expect(client.instance).toBeDefined();
+  });
+});
+
+describe("MiniMaxChatModel", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    process.env.MINIMAX_API_KEY = "test-api-key";
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("should instantiate with default model", () => {
+    const model = new MiniMaxChatModel();
+    expect(model).toBeInstanceOf(MiniMaxChatModel);
+    expect(model.modelId).toBe("MiniMax-M2.7");
+  });
+
+  it("should instantiate with custom model id", () => {
+    const model = new MiniMaxChatModel("MiniMax-M2.5");
+    expect(model).toBeInstanceOf(MiniMaxChatModel);
+    expect(model.modelId).toBe("MiniMax-M2.5");
+  });
+
+  it("should accept highspeed model", () => {
+    const model = new MiniMaxChatModel("MiniMax-M2.7-highspeed");
+    expect(model).toBeInstanceOf(MiniMaxChatModel);
+    expect(model.modelId).toBe("MiniMax-M2.7-highspeed");
+  });
+
+  it("should use env var for model id", () => {
+    process.env.MINIMAX_CHAT_MODEL = "MiniMax-M2.5-highspeed";
+    const model = new MiniMaxChatModel();
+    expect(model.modelId).toBe("MiniMax-M2.5-highspeed");
+  });
+
+  it("should accept custom parameters", () => {
+    const model = new MiniMaxChatModel("MiniMax-M2.7", { temperature: 0.5 });
+    expect(model).toBeInstanceOf(MiniMaxChatModel);
+  });
+
+  it("should accept custom client settings", () => {
+    const model = new MiniMaxChatModel("MiniMax-M2.7", {}, {
+      apiKey: "custom-key",
+      baseURL: "https://proxy.example.com/v1",
+    });
+    expect(model).toBeInstanceOf(MiniMaxChatModel);
+  });
+});

--- a/typescript/tests/e2e/adapters/minimax.test.ts
+++ b/typescript/tests/e2e/adapters/minimax.test.ts
@@ -60,13 +60,13 @@ describe("MiniMaxChatModel", () => {
   it("should instantiate with default model", () => {
     const model = new MiniMaxChatModel();
     expect(model).toBeInstanceOf(MiniMaxChatModel);
-    expect(model.modelId).toBe("MiniMax-M2.7");
+    expect(model.modelId).toBe("MiniMax-M3");
   });
 
   it("should instantiate with custom model id", () => {
-    const model = new MiniMaxChatModel("MiniMax-M2.5");
+    const model = new MiniMaxChatModel("MiniMax-M2.7");
     expect(model).toBeInstanceOf(MiniMaxChatModel);
-    expect(model.modelId).toBe("MiniMax-M2.5");
+    expect(model.modelId).toBe("MiniMax-M2.7");
   });
 
   it("should accept highspeed model", () => {
@@ -76,18 +76,18 @@ describe("MiniMaxChatModel", () => {
   });
 
   it("should use env var for model id", () => {
-    process.env.MINIMAX_CHAT_MODEL = "MiniMax-M2.5-highspeed";
+    process.env.MINIMAX_CHAT_MODEL = "MiniMax-M2.7-highspeed";
     const model = new MiniMaxChatModel();
-    expect(model.modelId).toBe("MiniMax-M2.5-highspeed");
+    expect(model.modelId).toBe("MiniMax-M2.7-highspeed");
   });
 
   it("should accept custom parameters", () => {
-    const model = new MiniMaxChatModel("MiniMax-M2.7", { temperature: 0.5 });
+    const model = new MiniMaxChatModel("MiniMax-M3", { temperature: 0.5 });
     expect(model).toBeInstanceOf(MiniMaxChatModel);
   });
 
   it("should accept custom client settings", () => {
-    const model = new MiniMaxChatModel("MiniMax-M2.7", {}, {
+    const model = new MiniMaxChatModel("MiniMax-M3", {}, {
       apiKey: "custom-key",
       baseURL: "https://proxy.example.com/v1",
     });

--- a/typescript/tests/e2e/adapters/minimax.test.ts
+++ b/typescript/tests/e2e/adapters/minimax.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { BackendProviders } from "@/backend/constants.js";
 import { MiniMaxChatModel } from "@/adapters/minimax/backend/chat.js";
 import { MiniMaxClient } from "@/adapters/minimax/backend/client.js";
@@ -87,10 +87,14 @@ describe("MiniMaxChatModel", () => {
   });
 
   it("should accept custom client settings", () => {
-    const model = new MiniMaxChatModel("MiniMax-M3", {}, {
-      apiKey: "custom-key",
-      baseURL: "https://proxy.example.com/v1",
-    });
+    const model = new MiniMaxChatModel(
+      "MiniMax-M3",
+      {},
+      {
+        apiKey: "custom-key",
+        baseURL: "https://proxy.example.com/v1",
+      },
+    );
     expect(model).toBeInstanceOf(MiniMaxChatModel);
   });
 });

--- a/typescript/tests/examples/examples.test.ts
+++ b/typescript/tests/examples/examples.test.ts
@@ -58,6 +58,7 @@ const exclude: string[] = [
   !getEnv("GOOGLE_APPLICATION_CREDENTIALS") && ["examples/backend/providers/vertexai.ts"],
   !getEnv("ANTHROPIC_API_KEY") && ["examples/backend/providers/anthropic.ts"],
   !getEnv("XAI_API_KEY") && ["examples/backend/providers/xai.ts"],
+  !getEnv("MINIMAX_API_KEY") && ["examples/backend/providers/minimax.ts"],
   "examples/tools/custom/extending.ts", // DDG problems
 ]
   .filter(isTruthy)


### PR DESCRIPTION
## Summary
Upgrade the MiniMax LLM provider integration to use `MiniMax-M3` as the default model.

This builds on the original MiniMax provider added for both the Python and TypeScript SDKs. The latest **MiniMax-M3** model is now the default (512K context window, up to 128K output, supports image input). The previous defaults are kept as alternatives, and the older `M2.5` family is removed.

## Changes
- Set `MiniMax-M3` as the default model in both Python (`MiniMaxChatModel`) and TypeScript (`MiniMaxChatModel`) adapters
- Keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as alternative model IDs
- Remove `MiniMax-M2.5` / `MiniMax-M2.5-highspeed` references from tests, docstrings, and examples
- Update unit/e2e tests to assert M3 default and exercise M2.7 / M2.7-highspeed as the named alternatives
- Update examples (`python/examples/backend/providers/minimax.py`, `typescript/examples/backend/providers/minimax.ts`) to use M3 by default

## Why
`MiniMax-M3` is the latest generation of the MiniMax series:
- 512K context window
- Up to 128K output tokens
- Image input support (OpenAI-compatible)

Using M3 by default gives users the best out-of-the-box quality and context size while preserving M2.7 / M2.7-highspeed for users who still rely on them.

## Testing
- Python: unit tests updated (`python/tests/adapters/minimax/test_minimax_chat.py`) — default assertion now checks `MiniMax-M3`; integration test fixture uses M3 (skipped without `MINIMAX_API_KEY`)
- TypeScript: e2e tests updated (`typescript/tests/e2e/adapters/minimax.test.ts`) — default assertion now checks `MiniMax-M3`

No breaking change to the public API — only the default `model_id` and the supported model IDs in the docs/tests are updated.