### PR TITLE
fix(mcp): preserve explicit null values in tool arguments

### DIFF
--- a/python/beeai_framework/tools/mcp/mcp.py
+++ b/python/beeai_framework/tools/mcp/mcp.py
@@ -74,7 +74,7 @@ class MCPTool(Tool[BaseModel, ToolRunOptions, JSONToolOutput]):
         """Execute the tool with given input."""
         logger.debug(f"Executing tool {self._tool.name} with input: {input_data}")
         result: CallToolResult = await self._session.call_tool(
-            name=self._tool.name, arguments=input_data.model_dump(exclude_none=True, exclude_unset=True)
+            name=self._tool.name, arguments=input_data.model_dump(exclude_unset=True)
         )
         logger.debug(f"Tool result: {result}")
 

--- a/python/beeai_framework/tools/tool.py
+++ b/python/beeai_framework/tools/tool.py
@@ -39,6 +39,10 @@ TOutput = TypeVar("TOutput", bound=ToolOutput, default=ToolOutput)
 
 
 class Tool(Generic[TInput, TRunOptions, TOutput], ABC):
+    """
+    Base class for all tools in the BeeAI framework.
+    Handles tool initialization, input validation, execution, and caching.
+    """
     def __init__(self, options: dict[str, Any] | None = None) -> None:
         self._options: dict[str, Any] | None = options or None
         self._cache = self.options.get("cache", NullCache[TOutput]()) if self.options else NullCache[TOutput]()
@@ -257,6 +261,9 @@ def tool(
     with_context: bool = False,
     emitter: Emitter | None = None,
 ) -> AnyTool | Callable[[TFunction], AnyTool]:
+    """
+    Decorator to easily create a Tool instance from a standard Python function.
+    """
     def create_tool(fn: TFunction) -> AnyTool:
         tool_name = name or fn.__name__
         tool_description = description or inspect.getdoc(fn)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review and complete the sections below.
-->

### Which issue(s) does this pull-request address?

<!--
Please include a link to an issue in the tracker.  The issue describes the problem to be solved.  If there is no issue raised for this PR then either raise one with a summary and description of the problem or add a summary and description of the problem here
-->

Closes: #

### Description
This PR fixes an issue where explicitly provided `null` values in MCP tool arguments were being unintentionally dropped during serialization, leading to schema validation failures in downstream MCP servers.

#### Background

In `beeai_framework/tools/mcp/tool.py`, tool arguments were serialized using:
model_dump(exclude_none=True, exclude_unset=True)

<!-- Provide a description of the change, pay special attention to describing any breaking changes.  The description describes the resolution to the problem described in the linked issue (or to the problem outlined in this PR). -->
In `beeai_framework/tools/mcp/tool.py`, tool arguments were being dumped using `exclude_none=True`. If an LLM intentionally outputs `null` for an optional parameter—either to clear a field via a PATCH-style request or to satisfy a strict MCP server schema that requires the key to be present—Pydantic strips the key entirely. 
This causes valid tool calls to fail schema validation on external MCP servers (resulting in validation errors like those in #894) because the server receives `{}` instead of `{"target_field": null}`.

**The Solution:**
Removed `exclude_none=True` from the `model_dump()` call in the `_run` method. 
By relying solely on `exclude_unset=True`, we ensure that:
1. Default `None` values *not* generated by the LLM are still safely excluded.
2. Explicit `None`/`null` values *intentionally* generated by the LLM are preserved and sent to the MCP server.
#### General
- [x] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [x] Code quality checks pass: `mise check` (`mise fix` to auto-fix)

#### Testing
- [x] Unit tests pass: `mise test:unit`
- [ ] E2E tests pass: `mise test:e2e`
- [ ] Tests are included (for bug fixes or new features)

#### Documentation
- [ ] Documentation is updated
- [ ] Embedme embeds code examples in docs. To update after edits, run: Python `mise docs:fix`
