### PR TITLE
feat(adapters): Exposing timeout parameter of the OpenAI API

### DIFF
--- a/python/beeai_framework/adapters/openai/backend/chat.py
+++ b/python/beeai_framework/adapters/openai/backend/chat.py
@@ -31,6 +31,7 @@ class OpenAIChatModel(LiteLLMChatModel):
         api_key: str | None = None,
         base_url: str | None = None,
         text_completion: bool | None = False,
+        timeout: float | int | None = None,
         **kwargs: Unpack[ChatModelKwargs],
     ) -> None:
         """
@@ -40,6 +41,7 @@ class OpenAIChatModel(LiteLLMChatModel):
             model_id: The ID of the OpenAI model to use. If not provided,
                 it falls back to the OPENAI_CHAT_MODEL environment variable,
                 and then defaults to 'gpt-4o'.
+            timeout: HTTP request timeout in seconds for API calls.
             **kwargs: A dictionary of settings to configure the provider.
         """
         super().__init__(
@@ -48,6 +50,8 @@ class OpenAIChatModel(LiteLLMChatModel):
             **kwargs,
         )
         self._assert_setting_value("api_key", api_key, envs=["OPENAI_API_KEY"])
+        if timeout is not None:
+            self._settings["timeout"] = timeout
         self._assert_setting_value(
             "base_url", base_url, envs=["OPENAI_API_BASE"], aliases=["api_base"], allow_empty=True
         )

--- a/python/beeai_framework/backend/chat.py
+++ b/python/beeai_framework/backend/chat.py
@@ -234,6 +234,11 @@ class ChatModelOptions(RunnableOptions, total=False):
     Tool to invoke when the model makes a malformed tool call (for example, when it forgets the name of a tool).
     """
 
+    timeout: float | int | None
+    """
+    HTTP request timeout in seconds for the underlying API call.
+    """
+
 
 _ChatModelKwargsAdapter = TypeAdapter(ChatModelKwargs)
 
@@ -513,6 +518,7 @@ class ChatModel(Runnable[ChatModelOutput]):
             presence_penalty: Controls how much the model penalizes previously generated tokens
             seed: Controls deterministic sampling
             signal: The chat model abort signal
+            timeout: HTTP request timeout in seconds for the underlying API call
             context: A dictionary that can be used to pass additional context to the chat model
 
         Returns:

--- a/python/tests/backend/test_chatmodel.py
+++ b/python/tests/backend/test_chatmodel.py
@@ -200,3 +200,39 @@ def test_chat_model_from(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("AZURE_API_VERSION", "version")
     azure_openai_chat_model = ChatModel.from_name("azure_openai:gpt-4o")
     assert isinstance(azure_openai_chat_model, AzureOpenAIChatModel)
+
+
+@pytest.mark.unit
+def test_chat_model_timeout_constructor() -> None:
+    model = OpenAIChatModel("gpt-4o", api_key="test", timeout=30)
+    assert model._settings["timeout"] == 30
+
+
+@pytest.mark.unit
+def test_chat_model_timeout_default_none() -> None:
+    model = OpenAIChatModel("gpt-4o", api_key="test")
+    assert "timeout" not in model._settings
+
+
+@pytest.mark.unit
+def test_chat_model_timeout_in_transform_input() -> None:
+    model = OpenAIChatModel("gpt-4o", api_key="test", timeout=45)
+    model_input = ChatModelInput(messages=[UserMessage("hello")])
+    result = model._transform_input(model_input)
+    assert result["timeout"] == 45
+
+
+@pytest.mark.unit
+def test_chat_model_timeout_per_request_override() -> None:
+    model = OpenAIChatModel("gpt-4o", api_key="test", timeout=30)
+    model_input = ChatModelInput(messages=[UserMessage("hello")], timeout=90)
+    result = model._transform_input(model_input)
+    assert result["timeout"] == 90
+
+
+@pytest.mark.unit
+def test_chat_model_timeout_absent_when_unset() -> None:
+    model = OpenAIChatModel("gpt-4o", api_key="test")
+    model_input = ChatModelInput(messages=[UserMessage("hello")])
+    result = model._transform_input(model_input)
+    assert "timeout" not in result


### PR DESCRIPTION
### Which issue(s) does this pull-request address?

<!--
Please include a link to an issue in the tracker.  The issue describes the problem to be solved.  If there is no issue raised for this PR then either raise one with a summary and description of the problem or add a summary and description of the problem here
-->

Closes: #1426

### Description

The `timeout` parameter from litellm is now exposed by `OpenAIChatModel`.  The value can be supplied either when the model is initialized, or as part of the input.

Tests are included, those were produced by claude. I could do the same of other chat models, although that could be a problem given https://github.com/BerriAI/litellm/issues/8373


### Checklist

#### General
- [x] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [x] Code quality checks pass: `mise check` (`mise fix` to auto-fix)

#### Testing
- [x] Unit tests pass: `mise test:unit`
- [x] E2E tests pass: `mise test:e2e` (I've tried, but tests failed even without my changes)
- [x] Tests are included (for bug fixes or new features)

#### Documentation
- [x] Documentation is updated
- [x] Embedme embeds code examples in docs. To update after edits, run: Python `mise docs:fix`
