### PR TITLE
feat(mcp): make exclude_none configurable in MCPTool parameters

### DIFF
--- a/python/beeai_framework/tools/mcp/mcp.py
+++ b/python/beeai_framework/tools/mcp/mcp.py
@@ -37,6 +37,7 @@ __all__ = ["MCPClient", "MCPTool"]
 
 class MCPToolKwargs(TypedDict, total=False):
     smart_parsing: bool
+    exclude_none: bool
 
 
 class MCPTool(Tool[BaseModel, ToolRunOptions, JSONToolOutput]):
@@ -45,11 +46,13 @@ class MCPTool(Tool[BaseModel, ToolRunOptions, JSONToolOutput]):
     def __init__(self, session: ClientSession, tool: MCPToolInfo, **options: Unpack[MCPToolKwargs]) -> None:
         """Initialize MCPTool with client and tool configuration."""
         smart_parsing = options.pop("smart_parsing", True)
+        exclude_none = options.pop("exclude_none", True)
 
         super().__init__(dict(options))
         self._session = session
         self._tool = tool
         self._smart_parsing = smart_parsing
+        self._exclude_none = exclude_none
 
     @property
     def name(self) -> str:
@@ -74,7 +77,7 @@ class MCPTool(Tool[BaseModel, ToolRunOptions, JSONToolOutput]):
         """Execute the tool with given input."""
         logger.debug(f"Executing tool {self._tool.name} with input: {input_data}")
         result: CallToolResult = await self._session.call_tool(
-            name=self._tool.name, arguments=input_data.model_dump(exclude_none=True, exclude_unset=True)
+            name=self._tool.name, arguments=input_data.model_dump(exclude_none=self._exclude_none, exclude_unset=True)
         )
         logger.debug(f"Tool result: {result}")
 
@@ -119,7 +122,7 @@ class MCPTool(Tool[BaseModel, ToolRunOptions, JSONToolOutput]):
         return [MCPTool(session, tool, **options) for tool in tools_result.tools]
 
     async def clone(self) -> Self:
-        options = MCPToolKwargs(smart_parsing=self._smart_parsing)
+        options = MCPToolKwargs(smart_parsing=self._smart_parsing, exclude_none=self._exclude_none)
         options.update(self._options or {})  # type: ignore
 
         tool = self.__class__(

--- a/python/beeai_framework/tools/mcp/mcp.py
+++ b/python/beeai_framework/tools/mcp/mcp.py
@@ -46,7 +46,7 @@ class MCPTool(Tool[BaseModel, ToolRunOptions, JSONToolOutput]):
     def __init__(self, session: ClientSession, tool: MCPToolInfo, **options: Unpack[MCPToolKwargs]) -> None:
         """Initialize MCPTool with client and tool configuration."""
         smart_parsing = options.pop("smart_parsing", True)
-        exclude_none = options.pop("exclude_none", True)
+        exclude_none = options.pop("exclude_none", False)
 
         super().__init__(dict(options))
         self._session = session


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review and complete the sections below.
-->

### Which issue(s) does this pull-request address?

<!--
Please include a link to an issue in the tracker.  The issue describes the problem to be solved.  If there is no issue raised for this PR then either raise one with a summary and description of the problem or add a summary and description of the problem here
-->

Closes: #

### Description
This PR fixes an issue where explicitly provided `null` values in MCP tool arguments were being unintentionally dropped during serialization, leading to schema validation failures in downstream MCP servers.

#### Background

In `beeai_framework/tools/mcp/tool.py`, tool arguments were serialized using:
model_dump(exclude_none=True, exclude_unset=True)

<!-- Provide a description of the change, pay special attention to describing any breaking changes.  The description describes the resolution to the problem described in the linked issue (or to the problem outlined in this PR). -->
In `beeai_framework/tools/mcp/tool.py`, tool arguments were being dumped using `exclude_none=True`. If an LLM intentionally outputs `null` for an optional parameter—either to clear a field via a PATCH-style request or to satisfy a strict MCP server schema that requires the key to be present—Pydantic strips the key entirely. 
This causes valid tool calls to fail schema validation on external MCP servers (resulting in validation errors like those in #894) because the server receives `{}` instead of `{"target_field": null}`.

**The Solution:**
Removed `exclude_none=True` from the `model_dump()` call in the `_run` method. 
By relying solely on `exclude_unset=True`, we ensure that:
1. Default `None` values *not* generated by the LLM are still safely excluded.
2. Explicit `None`/`null` values *intentionally* generated by the LLM are preserved and sent to the MCP server.
#### General
- [x] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [x] Code quality checks pass: `mise check` (`mise fix` to auto-fix)

#### Testing
- [x] Unit tests pass: `mise test:unit`
- [ ] E2E tests pass: `mise test:e2e`
- [ ] Tests are included (for bug fixes or new features)

#### Documentation
- [ ] Documentation is updated
- [ ] Embedme embeds code examples in docs. To update after edits, run: Python `mise docs:fix`