### PR TITLE
fix: restrict Python version to <3.14 in PEP 621 metadata

### DIFF
--- a/python/beeai_framework/adapters/langchain/backend/document_loader.py
+++ b/python/beeai_framework/adapters/langchain/backend/document_loader.py
@@ -16,8 +16,8 @@ except ModuleNotFoundError as e:
 from beeai_framework.adapters.langchain.mappers.documents import lc_document_to_document
 from beeai_framework.backend.document_loader import DocumentLoader
 from beeai_framework.backend.types import Document
-from beeai_framework.utils.strings import validate_class_name
 from beeai_framework.logger import Logger
+from beeai_framework.utils.strings import validate_class_name
 
 logger = Logger(__name__)
 

--- a/python/beeai_framework/adapters/langchain/backend/text_splitter.py
+++ b/python/beeai_framework/adapters/langchain/backend/text_splitter.py
@@ -16,8 +16,8 @@ except ModuleNotFoundError as e:
 from beeai_framework.adapters.langchain.mappers.documents import document_to_lc_document, lc_document_to_document
 from beeai_framework.backend.text_splitter import TextSplitter
 from beeai_framework.backend.types import Document
-from beeai_framework.utils.strings import validate_class_name
 from beeai_framework.logger import Logger
+from beeai_framework.utils.strings import validate_class_name
 
 logger = Logger(__name__)
 

--- a/python/beeai_framework/adapters/langchain/backend/vector_store.py
+++ b/python/beeai_framework/adapters/langchain/backend/vector_store.py
@@ -20,8 +20,8 @@ except ModuleNotFoundError as e:
 from beeai_framework.adapters.langchain.mappers.documents import document_to_lc_document, lc_document_to_document
 from beeai_framework.backend.embedding import EmbeddingModel
 from beeai_framework.backend.vector_store import QueryLike, VectorStore
-from beeai_framework.utils.strings import validate_class_name
 from beeai_framework.logger import Logger
+from beeai_framework.utils.strings import validate_class_name
 
 logger = Logger(__name__)
 

--- a/python/beeai_framework/tools/tool.py
+++ b/python/beeai_framework/tools/tool.py
@@ -43,6 +43,7 @@ class Tool(Generic[TInput, TRunOptions, TOutput], ABC):
     Base class for all tools in the BeeAI framework.
     Handles tool initialization, input validation, execution, and caching.
     """
+
     def __init__(self, options: dict[str, Any] | None = None) -> None:
         self._options: dict[str, Any] | None = options or None
         self._cache = self.options.get("cache", NullCache[TOutput]()) if self.options else NullCache[TOutput]()
@@ -264,6 +265,7 @@ def tool(
     """
     Decorator to easily create a Tool instance from a standard Python function.
     """
+
     def create_tool(fn: TFunction) -> AnyTool:
         tool_name = name or fn.__name__
         tool_description = description or inspect.getdoc(fn)

--- a/python/beeai_framework/utils/strings.py
+++ b/python/beeai_framework/utils/strings.py
@@ -164,7 +164,7 @@ def is_valid_unicode_escape_sequence(s: str) -> bool:
         return False
 
 
-def validate_class_name(class_name: str) -> None:
+def validate_class_name(class_name: str | None) -> None:
     """Validate that a class name is a valid Python identifier and not a keyword to prevent injection."""
     if not class_name or not class_name.isidentifier() or keyword.iskeyword(class_name):
         raise ValueError(

--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -2654,7 +2654,7 @@ description = "Fast transfer of large files with the Hugging Face Hub."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "platform_machine == \"arm64\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"aarch64\""
+markers = "(sys_platform == \"darwin\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\") and (platform_machine == \"arm64\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"aarch64\")"
 files = [
     {file = "hf_xet-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:ceeefcd1b7aed4956ae8499e2199607765fbd1c60510752003b6cc0b8413b649"},
     {file = "hf_xet-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b70218dd548e9840224df5638fdc94bd033552963cfa97f9170829381179c813"},
@@ -10221,4 +10221,4 @@ wikipedia = ["wikipedia-api"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">= 3.11,<3.14"
-content-hash = "e8b96ead35154be4fc0a308caa6d57d053271385f9f8bc76d19937de4e16351d"
+content-hash = "35431a5e4107f5b7e78291c84567395747777bde8685d661b3580de3fc45a598"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -9,7 +9,7 @@ maintainers = [
     { name = "Tomas Dvorak", email = "toomas2d@gmail.com" },
     { name = "Lukáš Janeček", email = "xjacka@gmail.com" }
 ]
-requires-python = ">=3.11,<4.0"
+requires-python = ">=3.11,<3.14"
 
 [project.urls]
 homepage = "https://framework.beeai.dev/"

--- a/python/tests/utils/test_strings.py
+++ b/python/tests/utils/test_strings.py
@@ -2,10 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+
 from beeai_framework.utils.strings import validate_class_name
 
 
-def test_validate_class_name_valid():
+def test_validate_class_name_valid() -> None:
     # Valid identifiers
     validate_class_name("MyClass")
     validate_class_name("my_function")
@@ -13,7 +14,7 @@ def test_validate_class_name_valid():
     validate_class_name("Class123")
 
 
-def test_validate_class_name_invalid():
+def test_validate_class_name_invalid() -> None:
     # Invalid identifiers
     invalid_names = [
         "",
@@ -22,8 +23,8 @@ def test_validate_class_name_invalid():
         "My Class",
         "My.Class",
         "class",  # reserved word is allowed as identifier in isidentifier() but we might want to be stricter?
-                  # actually isidentifier() returns True for keywords.
-                  # but you can't import a class named 'class'.
+        # actually isidentifier() returns True for keywords.
+        # but you can't import a class named 'class'.
         "import",
         "def",
         "!",
@@ -39,7 +40,8 @@ def test_validate_class_name_invalid():
             with pytest.raises(ValueError, match="Invalid class name"):
                 validate_class_name(name)
 
-def test_validate_class_name_keywords():
+
+def test_validate_class_name_keywords() -> None:
     # Python keywords are identifiers but we shouldn't allow them as class names for safety?
     # Actually, the main goal is to prevent module probing or injection like 'module.submodule'.
     # A single keyword like 'class' is not an injection in the same way.

--- a/python/tests/utils/test_strings.py
+++ b/python/tests/utils/test_strings.py
@@ -7,44 +7,38 @@ from beeai_framework.utils.strings import validate_class_name
 
 
 def test_validate_class_name_valid() -> None:
-    # Valid identifiers
     validate_class_name("MyClass")
     validate_class_name("my_function")
     validate_class_name("_InternalClass")
     validate_class_name("Class123")
 
 
-def test_validate_class_name_invalid() -> None:
-    # Invalid identifiers
-    invalid_names = [
+@pytest.mark.parametrize(
+    "name",
+    [
         "",
         "123Class",
         "My-Class",
         "My Class",
         "My.Class",
-        "class",  # reserved word is allowed as identifier in isidentifier() but we might want to be stricter?
-        # actually isidentifier() returns True for keywords.
-        # but you can't import a class named 'class'.
-        "import",
-        "def",
         "!",
         "@",
         "#",
         "import os; os.system('ls')",
         "__import__('os').system('ls')",
-    ]
-    for name in invalid_names:
-        # Some of these are actually valid identifiers (like 'class', 'import')
-        # but most are not.
-        if not name.isidentifier() or not name:
-            with pytest.raises(ValueError, match="Invalid class name"):
-                validate_class_name(name)
+    ],
+)
+def test_validate_class_name_invalid(name: str) -> None:
+    with pytest.raises(ValueError, match="Invalid class name"):
+        validate_class_name(name)
 
 
-def test_validate_class_name_keywords() -> None:
-    # Python keywords are identifiers but we shouldn't allow them as class names for safety?
-    # Actually, the main goal is to prevent module probing or injection like 'module.submodule'.
-    # A single keyword like 'class' is not an injection in the same way.
-    # But let's see if we want to block them.
-    # For now, validate_class_name only uses isidentifier().
-    pass
+@pytest.mark.parametrize("name", ["class", "import", "def", "for", "return", "None", "True", "False"])
+def test_validate_class_name_rejects_keywords(name: str) -> None:
+    with pytest.raises(ValueError, match="Invalid class name"):
+        validate_class_name(name)
+
+
+def test_validate_class_name_rejects_none() -> None:
+    with pytest.raises(ValueError, match="Invalid class name"):
+        validate_class_name(None)


### PR DESCRIPTION
## Summary

- Aligns `requires-python` in `pyproject.toml` with the existing Poetry constraint (`<3.14`). Without this, uv and other PEP 621-compliant installers allowed installation on Python 3.14, where Pydantic's `TypeAdapter(ChatModelKwargs)` fails to resolve forward references due to PEP 649 annotation evaluation changes.
- Widens `validate_class_name` parameter to `str | None` to match the actual `parse_module().entity_id` type (pyrefly fix).
- Bundled pre-existing ruff auto-fixes (import order, missing return-type annotations on test functions, two formatting tweaks in `tools/tool.py`) so the pre-commit hook passes.

Real Python 3.14 support is a follow-up effort — the underlying `TypeAdapter` + `from __future__ import annotations` + `TypedDict` issue needs either a lazy-built adapter or dropping deferred annotations in `backend/chat.py`.

Closes #1431

## Test plan

- [ ] `poetry install` with Python 3.14 fails with a clear "unsupported Python version" message (not a Pydantic runtime error).
- [ ] `poetry run pytest tests/utils/test_strings.py` passes.
- [ ] Pre-commit hooks (`pyrefly`, `ruff check`, `ruff format`) pass on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)