### PR TITLE
Fix two issues

### DIFF
--- a/python/beeai_framework/adapters/mcp/serve/server.py
+++ b/python/beeai_framework/adapters/mcp/serve/server.py
@@ -173,7 +173,7 @@ def _tool_factory(
 
         return MCPCallToolResult(
             content=[MCPTextContent(type="text", text=output.get_text_content())],
-            structuredContent=to_json_serializable(output)
+            structuredContent=(res if isinstance(res := to_json_serializable(output), dict) else {"result": res})
             if isinstance(output, CustomJsonDump)  # (eg: JSONToolOutput/SearchToolOutput)
             else None,
             _meta={"is_empty": output.is_empty()},

--- a/python/beeai_framework/agents/requirement/requirements/_utils.py
+++ b/python/beeai_framework/agents/requirement/requirements/_utils.py
@@ -16,7 +16,13 @@ MultiTargetType = Sequence[TargetType] | TargetType
 def _extract_targets(
     target: MultiTargetType | None,
 ) -> set[str | type | AnyTool]:
-    targets = list(target) if isinstance(target, Sequence) else [target] if target is not None else []
+    targets = (
+        list(target)
+        if isinstance(target, Sequence) and not isinstance(target, str)
+        else [target]
+        if target is not None
+        else []
+    )
     return set(targets)
 
 


### PR DESCRIPTION
### Description

This PR:

- Makes statements like `ConditionalRequirement(DuckDuckGoSearchTool, only_after="some_tool")` work again
  (broken since https://github.com/i-am-bee/beeai-framework/commit/3b90dae7194eff80c103eb1e242ad6365e2828fe)
- Makes tools returning e.g. `JSONToolOutput[list[str]]` registered with `MCPServer` send valid MCP responses - `structuredContent` must be a JSON object, so the tool result has to be wrapped in a dict

### Checklist

#### General
- [x] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [x] Code quality checks pass: `mise check` (`mise fix` to auto-fix)

#### Testing
- [x] Unit tests pass: `mise test:unit`
- [ ] E2E tests pass: `mise test:e2e`
- [ ] Tests are included (for bug fixes or new features)

#### Documentation
- [ ] Documentation is updated
- [ ] Embedme embeds code examples in docs. To update after edits, run: Python `mise docs:fix`
