### PR TITLE
Python 3.14 support

### DIFF
--- a/python/beeai_framework/backend/chat.py
+++ b/python/beeai_framework/backend/chat.py
@@ -1,9 +1,8 @@
 # Copyright 2025 © BeeAI a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 import contextlib
+import functools
 import logging
 from abc import abstractmethod
 from collections.abc import AsyncGenerator, Callable
@@ -235,7 +234,14 @@ class ChatModelOptions(RunnableOptions, total=False):
     """
 
 
-_ChatModelKwargsAdapter = TypeAdapter(ChatModelKwargs)
+@functools.cache
+def _get_chat_model_kwargs_adapter() -> TypeAdapter[ChatModelKwargs]:
+    return TypeAdapter(ChatModelKwargs)
+
+
+class ChatModelResponseConfig(BaseModel):
+    force_tool_call_via_response_format: bool = False
+    response_format_schema: type[BaseModel] | None = None
 
 
 class ChatModel(Runnable[ChatModelOutput]):
@@ -352,7 +358,7 @@ class ChatModel(Runnable[ChatModelOutput]):
         self._settings = kwargs.get("settings", {})
         self._settings.update(**exclude_non_annotated(kwargs, ChatModelKwargs))
 
-        kwargs = _ChatModelKwargsAdapter.validate_python(kwargs)
+        kwargs = _get_chat_model_kwargs_adapter().validate_python(kwargs)
 
         parameters = type(self).get_default_parameters()
         update_model(parameters, sources=[kwargs.get("parameters")])
@@ -738,7 +744,7 @@ class ChatModel(Runnable[ChatModelOutput]):
         options: ModelLike[ChatModelParameters] | None = None,
         /,
         **kwargs: Any,
-    ) -> ChatModel:
+    ) -> "ChatModel":
         """Create a ChatModel instance from a provider and model name.
 
         This factory method allows you to instantiate a chat model by specifying
@@ -943,8 +949,3 @@ def _raise_tool_choice_error(
         generated_error=message,
         response=output,
     )
-
-
-class ChatModelResponseConfig(BaseModel):
-    force_tool_call_via_response_format: bool = False
-    response_format_schema: type[BaseModel] | None = None

--- a/python/beeai_framework/backend/embedding.py
+++ b/python/beeai_framework/backend/embedding.py
@@ -1,6 +1,7 @@
 # Copyright 2025 © BeeAI a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
+import functools
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
@@ -47,7 +48,9 @@ class EmbeddingModelKwargs(TypedDict, total=False):
     __pydantic_config__ = ConfigDict(extra="forbid", arbitrary_types_allowed=True)  # type: ignore
 
 
-_EmbeddingModelKwargsAdapter = TypeAdapter(EmbeddingModelKwargs)
+@functools.cache
+def _get_embedding_model_kwargs_adapter() -> TypeAdapter[EmbeddingModelKwargs]:
+    return TypeAdapter(EmbeddingModelKwargs)
 
 
 class EmbeddingModel(ABC):
@@ -134,7 +137,7 @@ class EmbeddingModel(ABC):
         self._settings: dict[str, Any] = kwargs.get("settings", {})
         self._settings.update(**exclude_non_annotated(kwargs, EmbeddingModelKwargs))
 
-        kwargs = _EmbeddingModelKwargsAdapter.validate_python(kwargs)
+        kwargs = _get_embedding_model_kwargs_adapter().validate_python(kwargs)
         self.middlewares: list[RunMiddlewareType] = [*kwargs.get("middlewares", [])]
 
     def create(

--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -10214,4 +10214,4 @@ wikipedia = ["wikipedia-api"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">= 3.11,<3.14"
-content-hash = "93fac6d6a0936520fc0a6c5b445502c964809b483f434be6f938ce95c5453521"
+content-hash = "ebd042076b9dc8eb94d6bff1b80acd375594c5c70924852715a2e815b9f0323a"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -42,7 +42,7 @@ litellm = "^1.83.14"
 llama-index-core = {version = "^0.14.0", optional = true}
 markdown = {version = "^3.8.2", optional = true}
 mcp = {version = "^1.23.0", optional = true}
-pydantic = "^2.11.10"
+pydantic = "^2.12.4"
 pydantic-settings = "^2.11.0"
 requests = ">=2.33.0,<3.0.0"
 unstructured = {version = "^0.18.31", optional = true}


### PR DESCRIPTION
### Which issue(s) does this pull-request address?

This PR adds support for Python 3.14.

### Description

- Fix type checking in chat.py
- Prevent issues with type checking in embedding.py in the future 
- Raise minimal pydantic version to 2.12.4 to include fixes for Python 3.14

### Checklist

#### General
- [X] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [X] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [X] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [X] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [X] Code quality checks pass: `mise check` (`mise fix` to auto-fix)

#### Testing
- [X] Unit tests pass: `mise test:unit`
- [ ] E2E tests pass: `mise test:e2e`
- [ ] Tests are included (for bug fixes or new features)

#### Documentation
- [ ] Documentation is updated
- [ ] Embedme embeds code examples in docs. To update after edits, run: Python `mise docs:fix`

#### Considerations
This PR fixes the problem https://github.com/i-am-bee/beeai-framework/issues/1431 with 3.14 and i have tested it by patching beeai 0.1.79 as that was the last version installable with 3.14 but since litellm now too requires python < 3.14 i did not raise the supported Python in metadata to 3.14. Will have to find out what do do about litellm first. However this change works correctly on both 3.13 and 3.14 so it can be merged right away.
