### PR TITLE
fix: preserve LiteLLM text with tool calls

### DIFF
--- a/python/beeai_framework/adapters/litellm/chat.py
+++ b/python/beeai_framework/adapters/litellm/chat.py
@@ -310,23 +310,28 @@ class LiteLLMChatModel(ChatModel, ABC):
 
         output: list[AnyMessage] = []
         if update and update.model_dump(exclude_none=True):
-            content: list[MessageTextContent | MessageToolCallContent] = []
             text = update.content if update.content is not None else getattr(update, "reasoning_content", None)
-            if text is not None:
-                content.append(MessageTextContent(text=text))
-
             tool_calls = getattr(update, "tool_calls", None)
-            if tool_calls:
-                content.extend(
-                    MessageToolCallContent(
-                        id=call.id or "",
-                        tool_name=call.function.name or "",
-                        args=call.function.arguments,
-                    )
-                    for call in tool_calls
-                )
+            if text is not None:
+                text_id = f"{chunk.id}:text" if tool_calls else chunk.id
+                output.append(AssistantMessage(MessageTextContent(text=text), id=text_id))
 
-            output.append(AssistantMessage(content, id=chunk.id))
+            if tool_calls:
+                output.append(
+                    AssistantMessage(
+                        [
+                            MessageToolCallContent(
+                                id=call.id or "",
+                                tool_name=call.function.name or "",
+                                args=call.function.arguments,
+                            )
+                            for call in tool_calls
+                        ],
+                        id=chunk.id,
+                    )
+                )
+            elif text is None:
+                output.append(AssistantMessage("", id=chunk.id))
 
         return ChatModelOutput(
             output=output,

--- a/python/beeai_framework/adapters/litellm/chat.py
+++ b/python/beeai_framework/adapters/litellm/chat.py
@@ -310,21 +310,19 @@ class LiteLLMChatModel(ChatModel, ABC):
         output = []
         if update and update.model_dump(exclude_none=True):
             content: list[MessageTextContent | MessageToolCallContent] = []
-            text = update.content or getattr(update, "reasoning_content", None)
-            if text:
+            text = update.content if update.content is not None else getattr(update, "reasoning_content", None)
+            if text is not None:
                 content.append(MessageTextContent(text=text))
 
             tool_calls = getattr(update, "tool_calls", None)
             if tool_calls:
                 content.extend(
-                    [
-                        MessageToolCallContent(
-                            id=call.id or "",
-                            tool_name=call.function.name or "",
-                            args=call.function.arguments,
-                        )
-                        for call in tool_calls
-                    ]
+                    MessageToolCallContent(
+                        id=call.id or "",
+                        tool_name=call.function.name or "",
+                        args=call.function.arguments,
+                    )
+                    for call in tool_calls
                 )
 
             output.append(AssistantMessage(content, id=chunk.id))

--- a/python/beeai_framework/adapters/litellm/chat.py
+++ b/python/beeai_framework/adapters/litellm/chat.py
@@ -37,6 +37,7 @@ from beeai_framework.backend.chat import (
 )
 from beeai_framework.backend.errors import ChatModelError
 from beeai_framework.backend.message import (
+    AnyMessage,
     AssistantMessage,
     MessageTextContent,
     MessageToolCallContent,
@@ -307,7 +308,7 @@ class LiteLLMChatModel(ChatModel, ABC):
                     total_cost_usd=prompt_tokens_cost_usd + completion_tokens_cost_usd,
                 )
 
-        output = []
+        output: list[AnyMessage] = []
         if update and update.model_dump(exclude_none=True):
             content: list[MessageTextContent | MessageToolCallContent] = []
             text = update.content if update.content is not None else getattr(update, "reasoning_content", None)

--- a/python/beeai_framework/adapters/litellm/chat.py
+++ b/python/beeai_framework/adapters/litellm/chat.py
@@ -307,27 +307,30 @@ class LiteLLMChatModel(ChatModel, ABC):
                     total_cost_usd=prompt_tokens_cost_usd + completion_tokens_cost_usd,
                 )
 
+        output = []
+        if update and update.model_dump(exclude_none=True):
+            content: list[MessageTextContent | MessageToolCallContent] = []
+            text = update.content or getattr(update, "reasoning_content", None)
+            if text:
+                content.append(MessageTextContent(text=text))
+
+            tool_calls = getattr(update, "tool_calls", None)
+            if tool_calls:
+                content.extend(
+                    [
+                        MessageToolCallContent(
+                            id=call.id or "",
+                            tool_name=call.function.name or "",
+                            args=call.function.arguments,
+                        )
+                        for call in tool_calls
+                    ]
+                )
+
+            output.append(AssistantMessage(content, id=chunk.id))
+
         return ChatModelOutput(
-            output=(
-                [
-                    AssistantMessage(
-                        [
-                            MessageToolCallContent(
-                                id=call.id or "",
-                                tool_name=call.function.name or "",
-                                args=call.function.arguments,
-                            )
-                            for call in update.tool_calls
-                        ],
-                        id=chunk.id,
-                    )
-                    if update.tool_calls
-                    # pyrefly: ignore [bad-argument-type]
-                    else AssistantMessage(update.content or update.reasoning_content or "", id=chunk.id)
-                ]
-                if (update and update.model_dump(exclude_none=True))
-                else []
-            ),
+            output=output,
             # Will be set later
             output_structured=None,
             finish_reason=finish_reason,

--- a/python/tests/backend/providers/test_litellm_chat.py
+++ b/python/tests/backend/providers/test_litellm_chat.py
@@ -50,9 +50,11 @@ def test_transform_output_preserves_text_with_tool_calls() -> None:
 
     output = DummyLiteLLMChatModel()._transform_output(cast(LiteLLMModelResponse, ModelResponse(message)))
 
-    message_output = cast(AssistantMessage, output.output[0])
-    assert message_output.text == "I will call the tool."
-    tool_call = message_output.get_tool_calls()[0]
+    assert len(output.output) == 2
+    text_output = cast(AssistantMessage, output.output[0])
+    tool_output = cast(AssistantMessage, output.output[1])
+    assert text_output.text == "I will call the tool."
+    tool_call = tool_output.get_tool_calls()[0]
     assert tool_call.id == "call-id"
     assert tool_call.tool_name == "search"
     assert tool_call.args == '{"query":"bee"}'

--- a/python/tests/backend/providers/test_litellm_chat.py
+++ b/python/tests/backend/providers/test_litellm_chat.py
@@ -2,18 +2,23 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import pytest
+from litellm import ModelResponse as LiteLLMModelResponse
 
 from beeai_framework.adapters.litellm.chat import LiteLLMChatModel
+from beeai_framework.backend.constants import ProviderName
+from beeai_framework.backend.message import AssistantMessage
 
 
 class DummyLiteLLMChatModel(LiteLLMChatModel):
-    provider_id = "openai"
-
     def __init__(self) -> None:
         super().__init__("test-model", provider_id="openai")
+
+    @property
+    def provider_id(self) -> ProviderName:
+        return "openai"
 
 
 class ModelDumpNamespace(SimpleNamespace):
@@ -43,10 +48,11 @@ def test_transform_output_preserves_text_with_tool_calls() -> None:
         ],
     )
 
-    output = DummyLiteLLMChatModel()._transform_output(ModelResponse(message))
+    output = DummyLiteLLMChatModel()._transform_output(cast(LiteLLMModelResponse, ModelResponse(message)))
 
-    assert output.output[0].text == "I will call the tool."
-    tool_call = output.output[0].get_tool_calls()[0]
+    message_output = cast(AssistantMessage, output.output[0])
+    assert message_output.text == "I will call the tool."
+    tool_call = message_output.get_tool_calls()[0]
     assert tool_call.id == "call-id"
     assert tool_call.tool_name == "search"
     assert tool_call.args == '{"query":"bee"}'
@@ -56,7 +62,7 @@ def test_transform_output_preserves_text_with_tool_calls() -> None:
 def test_transform_output_handles_missing_reasoning_content() -> None:
     message = ModelDumpNamespace(content=None, tool_calls=None, role="assistant")
 
-    output = DummyLiteLLMChatModel()._transform_output(ModelResponse(message))
+    output = DummyLiteLLMChatModel()._transform_output(cast(LiteLLMModelResponse, ModelResponse(message)))
 
     assert len(output.output) == 1
     assert output.output[0].text == ""

--- a/python/tests/backend/providers/test_litellm_chat.py
+++ b/python/tests/backend/providers/test_litellm_chat.py
@@ -1,0 +1,62 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from beeai_framework.adapters.litellm.chat import LiteLLMChatModel
+
+
+class DummyLiteLLMChatModel(LiteLLMChatModel):
+    provider_id = "openai"
+
+    def __init__(self) -> None:
+        super().__init__("test-model", provider_id="openai")
+
+
+class ModelDumpNamespace(SimpleNamespace):
+    def model_dump(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {key: value for key, value in vars(self).items() if value is not None}
+
+
+class ModelResponse(dict[str, Any]):
+    choices: list[Any]
+    id: str
+
+    def __init__(self, message: Any) -> None:
+        super().__init__(model="test-model", usage=None)
+        self.id = "response-id"
+        self.choices = [SimpleNamespace(message=message, finish_reason="tool_calls")]
+
+
+@pytest.mark.unit
+def test_transform_output_preserves_text_with_tool_calls() -> None:
+    message = ModelDumpNamespace(
+        content="I will call the tool.",
+        tool_calls=[
+            SimpleNamespace(
+                id="call-id",
+                function=SimpleNamespace(name="search", arguments='{"query":"bee"}'),
+            )
+        ],
+    )
+
+    output = DummyLiteLLMChatModel()._transform_output(ModelResponse(message))
+
+    assert output.output[0].text == "I will call the tool."
+    tool_call = output.output[0].get_tool_calls()[0]
+    assert tool_call.id == "call-id"
+    assert tool_call.tool_name == "search"
+    assert tool_call.args == '{"query":"bee"}'
+
+
+@pytest.mark.unit
+def test_transform_output_handles_missing_reasoning_content() -> None:
+    message = ModelDumpNamespace(content=None, tool_calls=None, role="assistant")
+
+    output = DummyLiteLLMChatModel()._transform_output(ModelResponse(message))
+
+    assert len(output.output) == 1
+    assert output.output[0].text == ""


### PR DESCRIPTION
## Summary
- preserve LiteLLM assistant text content when tool calls are present
- avoid AttributeError when LiteLLM omits `reasoning_content` on a delta/message
- add focused regression coverage for text+tool-call and missing-reasoning cases

Fixes #1448.

## Verification
- `uv run --no-sync ruff check beeai_framework/adapters/litellm/chat.py tests/backend/providers/test_litellm_chat.py`
- `uv run --no-sync ruff format beeai_framework/adapters/litellm/chat.py tests/backend/providers/test_litellm_chat.py --check`
- `uv run --no-sync pytest tests/backend/providers/test_litellm_chat.py -q`
- `git diff --check`