### PR TITLE
fix(python): ignore empty tool messages

### DIFF
--- a/python/beeai_framework/memory/utils.py
+++ b/python/beeai_framework/memory/utils.py
@@ -18,11 +18,13 @@ def extract_last_tool_call_pair(memory: BaseMemory) -> tuple[AssistantMessage, T
         return None
 
     tool_call: AssistantMessage = memory.messages[tool_call_index]  # type: ignore
+    tool_call_id = tool_call.get_tool_calls()[0].id
 
     tool_response_index = find_index(
         memory.messages,
         lambda msg: bool(
-            isinstance(msg, ToolMessage) and msg.get_tool_results()[0].tool_call_id == tool_call.get_tool_calls()[0].id
+            isinstance(msg, ToolMessage)
+            and any(result.tool_call_id == tool_call_id for result in msg.get_tool_results())
         ),
         reverse_traversal=True,
         fallback=-1,

--- a/python/beeai_framework/memory/utils.py
+++ b/python/beeai_framework/memory/utils.py
@@ -18,13 +18,12 @@ def extract_last_tool_call_pair(memory: BaseMemory) -> tuple[AssistantMessage, T
         return None
 
     tool_call: AssistantMessage = memory.messages[tool_call_index]  # type: ignore
-    tool_call_id = tool_call.get_tool_calls()[0].id
+    tool_call_id = tool_call.get_tool_calls()[-1].id
 
     tool_response_index = find_index(
         memory.messages,
         lambda msg: bool(
-            isinstance(msg, ToolMessage)
-            and any(result.tool_call_id == tool_call_id for result in msg.get_tool_results())
+            isinstance(msg, ToolMessage) and any(result.tool_call_id == tool_call_id for result in msg.content)
         ),
         reverse_traversal=True,
         fallback=-1,

--- a/python/tests/memory/test_utils.py
+++ b/python/tests/memory/test_utils.py
@@ -1,0 +1,38 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+
+from beeai_framework.backend.message import (
+    AssistantMessage,
+    MessageToolCallContent,
+    MessageToolResultContent,
+    ToolMessage,
+)
+from beeai_framework.memory.unconstrained_memory import UnconstrainedMemory
+from beeai_framework.memory.utils import extract_last_tool_call_pair
+
+
+def test_extract_last_tool_call_pair_returns_matching_tool_response() -> None:
+    memory = UnconstrainedMemory()
+    assistant_message = AssistantMessage(
+        MessageToolCallContent(id="call_1", tool_name="weather", args='{"city":"Paris"}')
+    )
+    tool_message = ToolMessage(MessageToolResultContent(tool_name="weather", tool_call_id="call_1", result="sunny"))
+
+    asyncio.run(memory.add_many([assistant_message, tool_message]))
+
+    assert extract_last_tool_call_pair(memory) == (assistant_message, tool_message)
+
+
+def test_extract_last_tool_call_pair_ignores_empty_tool_messages() -> None:
+    memory = UnconstrainedMemory()
+    assistant_message = AssistantMessage(
+        MessageToolCallContent(id="call_1", tool_name="weather", args='{"city":"Paris"}')
+    )
+    empty_tool_message = ToolMessage([])
+    tool_message = ToolMessage(MessageToolResultContent(tool_name="weather", tool_call_id="call_1", result="sunny"))
+
+    asyncio.run(memory.add_many([assistant_message, empty_tool_message, tool_message]))
+
+    assert extract_last_tool_call_pair(memory) == (assistant_message, tool_message)

--- a/python/tests/memory/test_utils.py
+++ b/python/tests/memory/test_utils.py
@@ -36,3 +36,23 @@ def test_extract_last_tool_call_pair_ignores_empty_tool_messages() -> None:
     asyncio.run(memory.add_many([assistant_message, empty_tool_message, tool_message]))
 
     assert extract_last_tool_call_pair(memory) == (assistant_message, tool_message)
+
+
+def test_extract_last_tool_call_pair_uses_last_tool_call_from_message() -> None:
+    memory = UnconstrainedMemory()
+    assistant_message = AssistantMessage(
+        [
+            MessageToolCallContent(id="call_1", tool_name="weather", args='{"city":"Paris"}'),
+            MessageToolCallContent(id="call_2", tool_name="weather", args='{"city":"Berlin"}'),
+        ]
+    )
+    first_tool_message = ToolMessage(
+        MessageToolResultContent(tool_name="weather", tool_call_id="call_1", result="sunny")
+    )
+    last_tool_message = ToolMessage(
+        MessageToolResultContent(tool_name="weather", tool_call_id="call_2", result="rainy")
+    )
+
+    asyncio.run(memory.add_many([assistant_message, first_tool_message, last_tool_message]))
+
+    assert extract_last_tool_call_pair(memory) == (assistant_message, last_tool_message)


### PR DESCRIPTION
## Summary
- avoid indexing the first tool result while scanning memory for the last tool call/response pair
- use the last tool call from a multi-tool assistant message when selecting the matching tool response
- ignore empty or unrelated tool messages instead of raising `IndexError`
- add regression coverage for matching tool responses, empty tool messages, and multi-tool assistant messages

## Validation
- `uv run --with pytest --with syrupy pytest tests/memory/test_utils.py -q` -> 3 passed; emitted local warnings for an unknown asyncio config option and PyCharm diff patching
- `uv run --with ruff ruff check beeai_framework/memory/utils.py tests/memory/test_utils.py`
- `uv run --with ruff ruff format --check beeai_framework/memory/utils.py tests/memory/test_utils.py`
- `git diff --check`

## Notes
The commits include DCO signoffs as required by the Python contributing guide.