### PR TITLE
docs(tools): add Xquik examples

### DIFF
--- a/python/examples/README.md
+++ b/python/examples/README.md
@@ -60,6 +60,7 @@ This repository contains examples demonstrating the usage of the BeeAI Framework
 - [`decorator.py`](/python/examples/tools/decorator.py): Tool creation using decorator
 - [`duckduckgo.py`](/python/examples/tools/duckduckgo.py): DDG Search Tool for searching the web
 - [`openmeteo.py`](/python/examples/tools/openmeteo.py): Open-Meteo Tool for retrieving weather data
+- [`custom/xquik.py`](/python/examples/tools/custom/xquik.py): Xquik API tool for searching X posts
 
 ## Observability
 

--- a/python/examples/tools/custom/xquik.py
+++ b/python/examples/tools/custom/xquik.py
@@ -1,0 +1,107 @@
+import asyncio
+import json
+import os
+import sys
+from typing import Any, Literal
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from beeai_framework.context import RunContext
+from beeai_framework.emitter import Emitter
+from beeai_framework.errors import FrameworkError
+from beeai_framework.tools import JSONToolOutput, Tool, ToolError, ToolRunOptions
+from pydantic import BaseModel, Field
+
+
+class XquikSearchTweetsToolInput(BaseModel):
+    query: str = Field(description="X search query with standard search operators.")
+    query_type: Literal["Latest", "Top"] = Field(default="Latest", description="Sort order.")
+    limit: int = Field(default=5, ge=1, le=20, description="Maximum tweets to return.")
+
+
+class XquikSearchTweetsToolOutput(JSONToolOutput[dict[str, Any]]):
+    pass
+
+
+def fetch_xquik_json(url: str, api_key: str) -> dict[str, Any]:
+    request = Request(
+        url,
+        headers={"Accept": "application/json", "x-api-key": api_key},
+    )
+    try:
+        with urlopen(request, timeout=30) as response:
+            body = response.read().decode("utf-8")
+    except HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise ToolError(
+            "Request to Xquik API failed.",
+            cause=RuntimeError(detail),
+            context={"status_code": exc.code},
+        ) from exc
+    except URLError as exc:
+        raise ToolError("Could not connect to Xquik API.", cause=exc) from exc
+
+    result = json.loads(body)
+    if not isinstance(result, dict):
+        raise ToolError("Xquik API returned an unexpected response shape.")
+
+    return result
+
+
+class XquikSearchTweetsTool(
+    Tool[XquikSearchTweetsToolInput, ToolRunOptions, XquikSearchTweetsToolOutput]
+):
+    name = "XquikSearchTweets"
+    description = "Searches X posts through the Xquik REST API."
+    input_schema = XquikSearchTweetsToolInput
+
+    def _create_emitter(self) -> Emitter:
+        return Emitter.root().child(
+            namespace=["tool", "example", "xquik"],
+            creator=self,
+        )
+
+    async def _run(
+        self,
+        tool_input: XquikSearchTweetsToolInput,
+        options: ToolRunOptions | None,
+        context: RunContext,
+    ) -> XquikSearchTweetsToolOutput:
+        api_key = os.getenv("XQUIK_API_KEY")
+        if not api_key:
+            raise ToolError("Set XQUIK_API_KEY before running the Xquik search example.")
+
+        base_url = os.getenv("XQUIK_BASE_URL", "https://xquik.com/api/v1").rstrip("/")
+        params = urlencode(
+            {
+                "q": tool_input.query,
+                "queryType": tool_input.query_type,
+                "limit": tool_input.limit,
+            }
+        )
+        result = await asyncio.to_thread(fetch_xquik_json, f"{base_url}/x/tweets/search?{params}", api_key)
+
+        return XquikSearchTweetsToolOutput(result)
+
+
+async def main() -> None:
+    if not os.getenv("XQUIK_API_KEY"):
+        print("Set XQUIK_API_KEY to run this example.")
+        return
+
+    tool = XquikSearchTweetsTool()
+    result = await tool.run(
+        XquikSearchTweetsToolInput(
+            query="from:xquikcom",
+            limit=5,
+        )
+    )
+    print(result.get_text_content())
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except FrameworkError as e:
+        sys.exit(e.explain())

--- a/python/examples/tools/custom/xquik.py
+++ b/python/examples/tools/custom/xquik.py
@@ -31,7 +31,7 @@ def fetch_xquik_json(url: str, api_key: str) -> dict[str, Any]:
     )
     try:
         with urlopen(request, timeout=30) as response:
-            body = response.read().decode("utf-8")
+            body = response.read().decode("utf-8", errors="replace")
     except HTTPError as exc:
         detail = exc.read().decode("utf-8", errors="replace")
         raise ToolError(

--- a/python/examples/tools/custom/xquik.py
+++ b/python/examples/tools/custom/xquik.py
@@ -7,11 +7,12 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
+from pydantic import BaseModel, Field
+
 from beeai_framework.context import RunContext
 from beeai_framework.emitter import Emitter
 from beeai_framework.errors import FrameworkError
 from beeai_framework.tools import JSONToolOutput, Tool, ToolError, ToolRunOptions
-from pydantic import BaseModel, Field
 
 
 class XquikSearchTweetsToolInput(BaseModel):
@@ -49,9 +50,7 @@ def fetch_xquik_json(url: str, api_key: str) -> dict[str, Any]:
     return result
 
 
-class XquikSearchTweetsTool(
-    Tool[XquikSearchTweetsToolInput, ToolRunOptions, XquikSearchTweetsToolOutput]
-):
+class XquikSearchTweetsTool(Tool[XquikSearchTweetsToolInput, ToolRunOptions, XquikSearchTweetsToolOutput]):
     name = "XquikSearchTweets"
     description = "Searches X posts through the Xquik REST API."
     input_schema = XquikSearchTweetsToolInput

--- a/python/examples/tools/custom/xquik.py
+++ b/python/examples/tools/custom/xquik.py
@@ -64,7 +64,7 @@ class XquikSearchTweetsTool(
 
     async def _run(
         self,
-        tool_input: XquikSearchTweetsToolInput,
+        input: XquikSearchTweetsToolInput,
         options: ToolRunOptions | None,
         context: RunContext,
     ) -> XquikSearchTweetsToolOutput:
@@ -75,9 +75,9 @@ class XquikSearchTweetsTool(
         base_url = os.getenv("XQUIK_BASE_URL", "https://xquik.com/api/v1").rstrip("/")
         params = urlencode(
             {
-                "q": tool_input.query,
-                "queryType": tool_input.query_type,
-                "limit": tool_input.limit,
+                "q": input.query,
+                "queryType": input.query_type,
+                "limit": input.limit,
             }
         )
         result = await asyncio.to_thread(fetch_xquik_json, f"{base_url}/x/tweets/search?{params}", api_key)

--- a/typescript/examples/README.md
+++ b/typescript/examples/README.md
@@ -118,6 +118,7 @@ This repository contains examples demonstrating the usage of the BeeAI Framework
 - [`base.ts`](/typescript/examples/tools/custom/base.ts): Custom tool base implementation
 - [`dynamic.ts`](/typescript/examples/tools/custom/dynamic.ts): Dynamic tool creation
 - [`openLibrary.ts`](/typescript/examples/tools/custom/openLibrary.ts): OpenLibrary API tool
+- [`xquik.ts`](/typescript/examples/tools/custom/xquik.ts): Xquik API tool for searching X posts
 - [`python.ts`](/typescript/examples/tools/custom/python.ts): Python-based custom tool
 
 - [`langchain.ts`](/typescript/examples/tools/langchain.ts): LangChain tool integration

--- a/typescript/examples/tools/custom/xquik.ts
+++ b/typescript/examples/tools/custom/xquik.ts
@@ -1,0 +1,55 @@
+import { DynamicTool, JSONToolOutput, ToolError } from "beeai-framework/tools/base";
+import { z } from "zod";
+
+type XquikSearchTweetsResponse = Record<string, unknown>;
+
+const getBaseUrl = () =>
+  (process.env.XQUIK_BASE_URL ?? "https://xquik.com/api/v1").replace(/\/$/, "");
+
+export const xquikSearchTweetsTool = new DynamicTool({
+  name: "XquikSearchTweets",
+  description: "Searches X posts through the Xquik REST API.",
+  inputSchema: z.object({
+    query: z.string().min(1).describe("X search query with standard search operators."),
+    queryType: z.enum(["Latest", "Top"]).default("Latest").describe("Sort order."),
+    limit: z.number().int().min(1).max(20).default(5).describe("Maximum tweets to return."),
+  }),
+  async handler(input, _options, run) {
+    const apiKey = process.env.XQUIK_API_KEY;
+    if (!apiKey) {
+      throw new ToolError("Set XQUIK_API_KEY before running the Xquik search example.");
+    }
+
+    const url = new URL(`${getBaseUrl()}/x/tweets/search`);
+    url.searchParams.set("q", input.query);
+    url.searchParams.set("queryType", input.queryType);
+    url.searchParams.set("limit", input.limit.toString());
+
+    const response = await fetch(url, {
+      headers: {
+        "Accept": "application/json",
+        "x-api-key": apiKey,
+      },
+      signal: run.signal,
+    });
+
+    if (!response.ok) {
+      throw new ToolError("Request to Xquik API failed.", [new Error(await response.text())], {
+        context: { statusCode: response.status },
+      });
+    }
+
+    const result = (await response.json()) as XquikSearchTweetsResponse;
+    return new JSONToolOutput(result);
+  },
+});
+
+if (!process.env.XQUIK_API_KEY) {
+  console.log("Set XQUIK_API_KEY to run this example.");
+} else {
+  const result = await xquikSearchTweetsTool.run({
+    query: "from:xquikcom",
+    limit: 5,
+  });
+  console.log(result.getTextContent());
+}

--- a/typescript/examples/tools/custom/xquik.ts
+++ b/typescript/examples/tools/custom/xquik.ts
@@ -1,4 +1,5 @@
 import { DynamicTool, JSONToolOutput, ToolError } from "beeai-framework/tools/base";
+import { pathToFileURL } from "node:url";
 import { z } from "zod";
 
 type XquikSearchTweetsResponse = Record<string, unknown>;
@@ -44,9 +45,11 @@ export const xquikSearchTweetsTool = new DynamicTool({
   },
 });
 
-if (!process.env.XQUIK_API_KEY) {
+const isDirectRun = import.meta.url === pathToFileURL(process.argv[1] ?? "").href;
+
+if (isDirectRun && !process.env.XQUIK_API_KEY) {
   console.log("Set XQUIK_API_KEY to run this example.");
-} else {
+} else if (isDirectRun) {
   const result = await xquikSearchTweetsTool.run({
     query: "from:xquikcom",
     limit: 5,

--- a/typescript/tests/examples/examples.test.ts
+++ b/typescript/tests/examples/examples.test.ts
@@ -59,6 +59,7 @@ const exclude: string[] = [
   !getEnv("ANTHROPIC_API_KEY") && ["examples/backend/providers/anthropic.ts"],
   !getEnv("XAI_API_KEY") && ["examples/backend/providers/xai.ts"],
   !getEnv("MINIMAX_API_KEY") && ["examples/backend/providers/minimax.ts"],
+  !getEnv("XQUIK_API_KEY") && ["examples/tools/custom/xquik.ts"],
   "examples/tools/custom/extending.ts", // DDG problems
 ]
   .filter(isTruthy)


### PR DESCRIPTION
### Which issue(s) does this pull-request address?

Closes: N/A

This is an examples-only addition for using a custom BeeAI tool with an authenticated external REST API.

### Description

Adds Xquik search examples for both BeeAI Framework runtimes:

- Python custom tool example at `python/examples/tools/custom/xquik.py`
- TypeScript dynamic tool example at `typescript/examples/tools/custom/xquik.ts`
- README links under each examples Tools section

The examples call `GET /x/tweets/search` with `XQUIK_API_KEY`, optional `XQUIK_BASE_URL`, and no new package dependencies.

### Validation

- `python3.11 -m py_compile python/examples/tools/custom/xquik.py`
- `ruff check --config python/pyproject.toml python/examples/tools/custom/xquik.py python/examples/README.md`
- `prettier@3.6.2 --check typescript/examples/tools/custom/xquik.ts python/examples/README.md typescript/examples/README.md`
- `esbuild@0.27.2 typescript/examples/tools/custom/xquik.ts --bundle --platform=node --format=esm '--external:beeai-framework/*' --external:zod`
- `git diff --check`

I could not run `mise check`, `mise test:unit`, or `mise test:e2e` locally because this checkout does not have the project's mise or yarn toolchain installed. The added examples were kept dependency-free and validated with focused syntax, formatting, and parse checks.

### Checklist

#### General
- [x] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md) / [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [ ] Code quality checks pass: `mise check` (`mise fix` to auto-fix)

#### Testing
- [ ] Unit tests pass: `mise test:unit`
- [ ] E2E tests pass: `mise test:e2e`
- [ ] Tests are included (for bug fixes or new features)

#### Documentation
- [x] Documentation is updated
- [ ] Embedme embeds code examples in docs. To update after edits, run: Python `mise docs:fix`
