### PR TITLE
fix(infra): package commitizen plugin entry point

### DIFF
--- a/python/cz_commitizen/__init__.py
+++ b/python/cz_commitizen/__init__.py
@@ -1,6 +1,2 @@
 # Copyright 2025 © BeeAI a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
-
-from cz_commitizen.monorepo_commits import MonorepoCommitsCz
-
-__all__ = ["MonorepoCommitsCz"]

--- a/python/cz_commitizen/monorepo_commits.py
+++ b/python/cz_commitizen/monorepo_commits.py
@@ -1,15 +1,18 @@
 # Copyright 2025 © BeeAI a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-from collections.abc import Iterable
-from typing import Any
+from __future__ import annotations
 
-from commitizen import git
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any
+
 from commitizen.cz.conventional_commits import ConventionalCommitsCz  # type: ignore
 
 __all__ = ["MonorepoCommitsCz"]
 
-from commitizen.question import CzQuestion
+if TYPE_CHECKING:
+    from commitizen import git
+    from commitizen.question import CzQuestion
 
 
 class MonorepoCommitsCz(ConventionalCommitsCz):
@@ -24,6 +27,8 @@ class MonorepoCommitsCz(ConventionalCommitsCz):
     def changelog_message_builder_hook(
         self, parsed_message: dict[str, Any], commit: git.GitCommit
     ) -> dict[str, Any] | Iterable[dict[str, Any]] | None:
+        from commitizen import git
+
         changed_files = git.get_filenames_in_commit(commit.rev) or []
 
         has_python_changes = any(file.startswith("python/") for file in changed_files)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -16,6 +16,12 @@ homepage = "https://framework.beeai.dev/"
 repository = "https://github.com/i-am-bee/beeai-framework"
 documentation = "https://i-am-bee.github.io/beeai-framework/#/python/"
 
+[tool.poetry]
+packages = [
+    { include = "beeai_framework" },
+    { include = "cz_commitizen" },
+]
+
 [tool.poetry.dependencies]
 python = ">= 3.11,<3.14"
 a2a-sdk = {version = "^0.3.9", optional = true, extras = ["grpc", "http-server", "telemetry"]}
@@ -192,7 +198,7 @@ requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.plugins."commitizen.plugin"]
-cz_monorepo_commits = "cz_commitizen:MonorepoCommitsCz"
+cz_monorepo_commits = "cz_commitizen.monorepo_commits:MonorepoCommitsCz"
 
 [tool.ruff]
 lint.select = [

--- a/python/tasks.toml
+++ b/python/tasks.toml
@@ -82,7 +82,7 @@ outputs = { auto = true }
 depends = ["python:setup"]
 dir = "{{config_root}}/python"
 run = "rm -rf build dist 2>/dev/null; poetry build"
-sources = ["beeai_framework/**/*.py"]
+sources = ["beeai_framework/**/*.py", "cz_commitizen/**/*.py"]
 outputs = { auto = true }
 
 # test


### PR DESCRIPTION
## Summary
- include the existing `cz_commitizen` helper package in the Python wheel so the published Commitizen entry point resolves
- point the Commitizen plugin entry point at the real implementation class while keeping package import side effects minimal
- track `cz_commitizen/**/*.py` as a Python build source

Closes #1454.

## Validation
- `uv build --wheel`
- isolated wheel install with `commitizen`, then `cz commit --help`
- isolated wheel install with `commitizen`, then `cz check --message 'fix: packaging test'`\n- isolated wheel install with `commitizen`, then verified `commitizen.cz.registry['cz_monorepo_commits']` resolves to `cz_commitizen.monorepo_commits.MonorepoCommitsCz` and exposes `change_type_map`\n- inspected the rebuilt wheel to confirm `cz_commitizen/__init__.py`, `cz_commitizen/monorepo_commits.py`, and the updated `commitizen.plugin` entry point are present\n- `uv run --no-project --with ruff ruff check cz_commitizen`\n- `uv run --no-project --with ruff ruff format --check cz_commitizen`\n- `uv run --no-project --with pyrefly --with commitizen pyrefly check cz_commitizen`\n- `git diff --check`\n\nNote: I could not run the documented `mise` tasks in this workspace because `mise` is not installed, so I used the focused build/lint/type/plugin-discovery checks above.