### PR TITLE
Fix/duckduckgo backend parameter

### DIFF
--- a/python/beeai_framework/tools/search/duckduckgo/duckduckgo.py
+++ b/python/beeai_framework/tools/search/duckduckgo/duckduckgo.py
@@ -43,9 +43,7 @@ class DuckDuckGoSearchToolOutput(SearchToolOutput):
     pass
 
 
-class DuckDuckGoSearchTool(
-    Tool[DuckDuckGoSearchToolInput, ToolRunOptions, DuckDuckGoSearchToolOutput]
-):
+class DuckDuckGoSearchTool(Tool[DuckDuckGoSearchToolInput, ToolRunOptions, DuckDuckGoSearchToolOutput]):
     name = "DuckDuckGo"
     description = "Search for online trends, news, current events, real-time information, or research topics."
     input_schema = DuckDuckGoSearchToolInput
@@ -76,11 +74,8 @@ class DuckDuckGoSearchTool(
         try:
             results = DDGS(
                 proxy=os.environ.get("BEEAI_DDG_TOOL_PROXY"),
-                verify=os.environ.get("BEEAI_DDG_TOOL_PROXY_VERIFY", "").lower()
-                != "false",
-            ).text(
-                input.query, max_results=self.max_results, safesearch=self.safe_search
-            )
+                verify=os.environ.get("BEEAI_DDG_TOOL_PROXY_VERIFY", "").lower() != "false",
+            ).text(input.query, max_results=self.max_results, safesearch=self.safe_search)
             search_results: list[SearchToolResult] = [
                 DuckDuckGoSearchToolResult(
                     title=result.get("title") or "",

--- a/python/beeai_framework/tools/search/duckduckgo/duckduckgo.py
+++ b/python/beeai_framework/tools/search/duckduckgo/duckduckgo.py
@@ -43,7 +43,9 @@ class DuckDuckGoSearchToolOutput(SearchToolOutput):
     pass
 
 
-class DuckDuckGoSearchTool(Tool[DuckDuckGoSearchToolInput, ToolRunOptions, DuckDuckGoSearchToolOutput]):
+class DuckDuckGoSearchTool(
+    Tool[DuckDuckGoSearchToolInput, ToolRunOptions, DuckDuckGoSearchToolOutput]
+):
     name = "DuckDuckGo"
     description = "Search for online trends, news, current events, real-time information, or research topics."
     input_schema = DuckDuckGoSearchToolInput
@@ -66,16 +68,24 @@ class DuckDuckGoSearchTool(Tool[DuckDuckGoSearchToolInput, ToolRunOptions, DuckD
         )
 
     async def _run(
-        self, input: DuckDuckGoSearchToolInput, options: ToolRunOptions | None, context: RunContext
+        self,
+        input: DuckDuckGoSearchToolInput,
+        options: ToolRunOptions | None,
+        context: RunContext,
     ) -> DuckDuckGoSearchToolOutput:
         try:
             results = DDGS(
                 proxy=os.environ.get("BEEAI_DDG_TOOL_PROXY"),
-                verify=os.environ.get("BEEAI_DDG_TOOL_PROXY_VERIFY", "").lower() != "false",
-            ).text(input.query, max_results=self.max_results, safesearch=self.safe_search, backend="duckduckgo")
+                verify=os.environ.get("BEEAI_DDG_TOOL_PROXY_VERIFY", "").lower()
+                != "false",
+            ).text(
+                input.query, max_results=self.max_results, safesearch=self.safe_search
+            )
             search_results: list[SearchToolResult] = [
                 DuckDuckGoSearchToolResult(
-                    title=result.get("title") or "", description=result.get("body") or "", url=result.get("href") or ""
+                    title=result.get("title") or "",
+                    description=result.get("body") or "",
+                    url=result.get("href") or "",
                 )
                 for result in results
             ]


### PR DESCRIPTION
# Pull Request: Fix DuckDuckGoSearchTool "No results found" Error

## Which issue(s) does this pull-request address?

Closes: #1459

## Description

The `DuckDuckGoSearchTool` from beeai-framework was consistently failing with `DDGSException(ddgs.exceptions): No results found` error for all search queries, regardless of the query content or format. This issue affected all users of the tool and prevented the agent from performing web searches.

### Root Cause

After investigation, the root cause was identified in `python/beeai_framework/tools/search/duckduckgo/duckduckgo.py` at line 75. The code was passing an incompatible `backend="duckduckgo"` parameter to the `DDGS().text()` method:

```python
.text(input.query, max_results=self.max_results, safesearch=self.safe_search, backend="duckduckgo")
```

The `backend="duckduckgo"` parameter is **not compatible** with current versions of the `duckduckgo-search` library (9.14.4+). This parameter causes the library to always return "No results found", even for valid search queries.

### Solution

Removed the problematic `backend="duckduckgo"` parameter, allowing the library to use its **default working backend**:

```python
.text(input.query, max_results=self.max_results, safesearch=self.safe_search)
```

The default backend is actively maintained by the duckduckgo-search library and returns results correctly.

### Changes

- **File Modified:** `python/beeai_framework/tools/search/duckduckgo/duckduckgo.py`
- **Lines Changed:** Line 75
- **What Changed:** Removed `backend="duckduckgo"` parameter from DDGS().text() call
- **Result:** All search queries now work properly and return relevant results

### Testing

The fix has been tested with multiple search queries:
- ✅ "trending on X Mexico" - returns results
- ✅ "trending on X today" - returns results
- ✅ "Mexico news" - returns results

All queries that previously failed with "No results found" now return valid search results.

### Impact

This fix enables:
- Search again with duckduckgo

### Version Information

- **beeai-framework:** 0.1.80
- **duckduckgo-search:** 9.14.4+
- **Python:** 3.11+

---

## Checklist

### General
- [x] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md)
- [x] I have signed off on my commit (using `git commit -s`)
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Appropriate label(s) added to PR: `Python`

### Code Quality Checks
- [x] Code quality checks pass: `mise check`
  - Black formatting: ✅ Passed
  - Ruff linting: ✅ All checks passed
  - License headers: ✅ Verified
  - Commit message validation: ✅ Passed

### Testing
- [x] Tested with multiple search queries
- [x] Verified that "No results found" error no longer occurs
- [x] Confirmed that the default backend returns valid results
- [x] No breaking changes introduced

### Documentation
- [x] No documentation changes needed (this is a bug fix for existing functionality)
- [x] No API changes (parameter removal is internal implementation detail)

---

## Commit Information

**Commit Message:**
```
fix(duckduckgo): remove broken backend parameter

The backend='duckduckgo' parameter in DDGS().text() is incompatible with
current versions of duckduckgo-search (9.14.4+), causing all searches to fail
with 'No results found' error.
```

**Commit Hash:** 92922441

**Sign-off:** Included (via `-s` flag)
