### PR TITLE
docs: add OpenAI-compatible gateway example

### DIFF
--- a/docs/modules/backend.mdx
+++ b/docs/modules/backend.mdx
@@ -46,6 +46,49 @@ Meanwhile, you can use the Ollama for local models in [Python](https://github.co
 or [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/examples/backend/providers/ollama.ts) or the [Langchain adapter](#adding-a-provider-using-the-langchain-adapter) for hosted providers.
 </Tip>
 
+### OpenAI-compatible gateways
+
+You can also point the OpenAI backend at a governed OpenAI-compatible gateway.
+For example, Tuning Engines can sit between BeeAI Framework and the underlying
+model providers so that BeeAI owns the agent/runtime behavior while Tuning
+Engines centralizes model access, policy checks, audit logs, traces, and usage
+reporting.
+
+<CodeGroup>
+
+```py Python
+import os
+
+from beeai_framework.adapters.openai import OpenAIChatModel
+from beeai_framework.backend import UserMessage
+
+llm = OpenAIChatModel(
+    "gpt-4o",
+    api_key=os.environ["TUNING_ENGINES_API_KEY"],
+    base_url="https://api.tuningengines.com/v1",
+)
+
+response = await llm.run([UserMessage("What should I check before deploying this agent?")])
+print(response.get_text_content())
+```
+
+```ts TypeScript
+import { OpenAIChatModel } from "beeai-framework/adapters/openai/backend/chat";
+import { UserMessage } from "beeai-framework/backend/message";
+
+const llm = new OpenAIChatModel("gpt-4o", {}, {
+  apiKey: process.env.TUNING_ENGINES_API_KEY,
+  baseURL: "https://api.tuningengines.com/v1",
+});
+
+const response = await llm.create({
+  messages: [new UserMessage("What should I check before deploying this agent?")],
+});
+console.info(response.getTextContent());
+```
+
+</CodeGroup>
+
 <Note>
 	Google Gemini, MistralAI, and Transformers are supported in Python only. The Transformers chat model does not support tool calling.
 </Note>


### PR DESCRIPTION
## Summary
- add a Tuning Engines example to the backend provider docs
- show Python and TypeScript OpenAI backend setup with a custom base URL
- clarify that BeeAI Framework owns the agent/runtime behavior while Tuning Engines handles governed model access, policy checks, traces, and usage reporting

## Why
We are an AI infrastructure team using BeeAI Framework with Tuning Engines. The backend docs already cover provider choices and OpenAI configuration; this adds a small copy-paste example for teams that need a governed OpenAI-compatible endpoint without changing their BeeAI agent code. It would mean a lot to us if this is useful, and I am happy to adjust the section name or wording to match your docs.

## Validation
- git diff --check
- checked Python and TypeScript constructor options against the local OpenAI adapter code