### PR TITLE
fix: raise ValueError instead of returning it in to_any_model

### DIFF
--- a/python/beeai_framework/utils/models.py
+++ b/python/beeai_framework/utils/models.py
@@ -34,10 +34,6 @@ def to_any_model(classes: Sequence[type[BaseModel]], obj: ModelLike[T]) -> Any:
 
     class_names = "\n".join(cls.__name__ for cls in classes)
     raise ValueError(f"Failed to create a model instance from the passed object!\n{class_names}")
-<<<<<<< Updated upstream
-=======
-
->>>>>>> Stashed changes
 
 def to_model_optional(cls: type[T], obj: ModelLike[T] | None) -> T | None:
     return None if obj is None else to_model(cls, obj)

--- a/python/beeai_framework/utils/models.py
+++ b/python/beeai_framework/utils/models.py
@@ -35,6 +35,7 @@ def to_any_model(classes: Sequence[type[BaseModel]], obj: ModelLike[T]) -> Any:
     class_names = "\n".join(cls.__name__ for cls in classes)
     raise ValueError(f"Failed to create a model instance from the passed object!\n{class_names}")
 
+
 def to_model_optional(cls: type[T], obj: ModelLike[T] | None) -> T | None:
     return None if obj is None else to_model(cls, obj)
 

--- a/python/beeai_framework/utils/models.py
+++ b/python/beeai_framework/utils/models.py
@@ -32,8 +32,8 @@ def to_any_model(classes: Sequence[type[BaseModel]], obj: ModelLike[T]) -> Any:
         with suppress(Exception):
             return to_model(cls, obj)
 
-    return ValueError(
-        "Failed to create a model instance from the passed object!" + "\n".join(cls.__name__ for cls in classes),
+    raise ValueError(
+        "Failed to create a model instance from the passed object!\n" + "\n".join(cls.__name__ for cls in classes),
     )
 
 

--- a/python/beeai_framework/utils/models.py
+++ b/python/beeai_framework/utils/models.py
@@ -32,10 +32,8 @@ def to_any_model(classes: Sequence[type[BaseModel]], obj: ModelLike[T]) -> Any:
         with suppress(Exception):
             return to_model(cls, obj)
 
-    raise ValueError(
-        "Failed to create a model instance from the passed object!\n" + "\n".join(cls.__name__ for cls in classes),
-    )
-
+    class_names = "\n".join(cls.__name__ for cls in classes)
+    raise ValueError(f"Failed to create a model instance from the passed object!\n{class_names}")
 
 def to_model_optional(cls: type[T], obj: ModelLike[T] | None) -> T | None:
     return None if obj is None else to_model(cls, obj)

--- a/python/beeai_framework/utils/models.py
+++ b/python/beeai_framework/utils/models.py
@@ -34,6 +34,10 @@ def to_any_model(classes: Sequence[type[BaseModel]], obj: ModelLike[T]) -> Any:
 
     class_names = "\n".join(cls.__name__ for cls in classes)
     raise ValueError(f"Failed to create a model instance from the passed object!\n{class_names}")
+<<<<<<< Updated upstream
+=======
+
+>>>>>>> Stashed changes
 
 def to_model_optional(cls: type[T], obj: ModelLike[T] | None) -> T | None:
     return None if obj is None else to_model(cls, obj)

--- a/python/tests/utils/test_models.py
+++ b/python/tests/utils/test_models.py
@@ -2,6 +2,7 @@ import pytest
 from pydantic import BaseModel
 from beeai_framework.utils.models import to_any_model
 
+<<<<<<< Updated upstream
 class Dog(BaseModel):
     name: str
 
@@ -11,3 +12,18 @@ class Cat(BaseModel):
 def test_to_any_model_raises_on_invalid():
     with pytest.raises(ValueError):
         to_any_model([Dog, Cat], {"age": 5})
+=======
+
+class Dog(BaseModel):
+    name: str
+
+
+class Cat(BaseModel):
+    name: str
+
+
+def test_to_any_model_raises_on_invalid():
+    with pytest.raises(ValueError, match="Failed to create a model instance from the passed object!\nDog\nCat"):
+        to_any_model([Dog, Cat], {"age": 5})
+        
+>>>>>>> Stashed changes

--- a/python/tests/utils/test_models.py
+++ b/python/tests/utils/test_models.py
@@ -1,18 +1,11 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 from pydantic import BaseModel
+
 from beeai_framework.utils.models import to_any_model
 
-<<<<<<< Updated upstream
-class Dog(BaseModel):
-    name: str
-
-class Cat(BaseModel):
-    name: str
-
-def test_to_any_model_raises_on_invalid():
-    with pytest.raises(ValueError):
-        to_any_model([Dog, Cat], {"age": 5})
-=======
 
 class Dog(BaseModel):
     name: str
@@ -22,8 +15,6 @@ class Cat(BaseModel):
     name: str
 
 
-def test_to_any_model_raises_on_invalid():
+def test_to_any_model_raises_on_invalid() -> None:
     with pytest.raises(ValueError, match="Failed to create a model instance from the passed object!\nDog\nCat"):
         to_any_model([Dog, Cat], {"age": 5})
-        
->>>>>>> Stashed changes

--- a/python/tests/utils/test_models.py
+++ b/python/tests/utils/test_models.py
@@ -1,0 +1,13 @@
+import pytest
+from pydantic import BaseModel
+from beeai_framework.utils.models import to_any_model
+
+class Dog(BaseModel):
+    name: str
+
+class Cat(BaseModel):
+    name: str
+
+def test_to_any_model_raises_on_invalid():
+    with pytest.raises(ValueError):
+        to_any_model([Dog, Cat], {"age": 5})


### PR DESCRIPTION
Fixes #1473

## Changes
- Changed `return ValueError(...)` to `raise ValueError(...)` in `to_any_model`
- Added `\n` separator between error message and class names
- Added regression test in `tests/utils/test_models.py`