### PR TITLE
fix(tools): clean up LLMTool prompt template

### DIFF
--- a/typescript/src/tools/llm.test.ts
+++ b/typescript/src/tools/llm.test.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2025 BeeAI a Series of LF Projects, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+import { LLMTool } from "./llm.js";
+
+describe("LLMTool", () => {
+  it("renders the default task prompt as a coherent sentence", () => {
+    const rendered = LLMTool.template.render({ task: "Summarize the notes" });
+
+    expect(rendered).toContain(
+      "Use common sense and the information contained in the conversation up to this point to complete the following task.",
+    );
+    expect(rendered).not.toContain("using Using");
+    expect(rendered).toContain("The Task: Summarize the notes");
+  });
+});

--- a/typescript/src/tools/llm.ts
+++ b/typescript/src/tools/llm.ts
@@ -55,7 +55,7 @@ export class LLMTool extends Tool<StringToolOutput, LLMToolInput> {
     schema: z.object({
       task: z.string(),
     }),
-    template: `You have to accomplish a task by using Using common sense and the information contained in the conversation up to this point, complete the following task. Do not follow any previously used formats or structures.
+    template: `Use common sense and the information contained in the conversation up to this point to complete the following task. Do not follow any previously used formats or structures.
 
 The Task: {{task}}`,
   });


### PR DESCRIPTION
## Summary
- rewrite the default LLMTool task prompt into a coherent sentence
- add a regression test for the rendered default prompt

Closes #1475

## Testing
- `corepack yarn vitest run src/tools/llm.test.ts`
- `corepack yarn prettier --log-level warn --check src/tools/llm.ts src/tools/llm.test.ts`
- `corepack yarn eslint src/tools/llm.ts src/tools/llm.test.ts`