### PR TITLE
docs(workflows): add TypeScript memory workflow example

### DIFF
--- a/docs/src/content/docs/modules/workflows.mdx
+++ b/docs/src/content/docs/modules/workflows.mdx
@@ -476,9 +476,44 @@ if __name__ == "__main__":
 
 ```
 
-{/* <!-- todo typescript/examples/workflows/memory.ts --> */}
+{/* <!-- embedme typescript/examples/workflows/memory.ts --> */}
 ```ts Typescript [expandable]
-Example coming soon
+import "dotenv/config.js";
+import { createConsoleReader } from "examples/helpers/io.js";
+import { AssistantMessage, UserMessage } from "beeai-framework/backend/message";
+import { UnconstrainedMemory } from "beeai-framework/memory/unconstrainedMemory";
+import { Workflow } from "beeai-framework/workflows/workflow";
+import { z } from "zod";
+
+// State with memory and output
+const schema = z.object({
+  memory: z.instanceof(UnconstrainedMemory),
+  output: z.string().default(""),
+});
+
+type State = z.infer<typeof schema>;
+
+// Echo step: reverse the last message and store as output
+async function echo(state: State): Promise<typeof Workflow.END> {
+  const lastMessage = state.memory.messages.at(-1);
+  state.output = lastMessage ? [...lastMessage.text].reverse().join("") : "";
+  return Workflow.END;
+}
+
+const workflow = new Workflow({ schema }).addStep("echo", echo);
+const memory = new UnconstrainedMemory();
+
+const reader = createConsoleReader();
+for await (const { prompt } of reader) {
+  // Add user message to memory
+  await memory.add(new UserMessage(prompt));
+  // Run workflow with shared memory instance
+  const response = await workflow.run({ memory, output: "" });
+  // Add assistant response to memory
+  await memory.add(new AssistantMessage(response.result.output));
+
+  reader.write("Assistant 🤖 : ", response.result.output);
+}
 ```
 
 </CodeGroup>

--- a/typescript/examples/workflows/memory.ts
+++ b/typescript/examples/workflows/memory.ts
@@ -1,0 +1,36 @@
+import "dotenv/config.js";
+import { createConsoleReader } from "examples/helpers/io.js";
+import { AssistantMessage, UserMessage } from "beeai-framework/backend/message";
+import { UnconstrainedMemory } from "beeai-framework/memory/unconstrainedMemory";
+import { Workflow } from "beeai-framework/workflows/workflow";
+import { z } from "zod";
+
+// State with memory and output
+const schema = z.object({
+  memory: z.instanceof(UnconstrainedMemory),
+  output: z.string().default(""),
+});
+
+type State = z.infer<typeof schema>;
+
+// Echo step: reverse the last message and store as output
+async function echo(state: State): Promise<typeof Workflow.END> {
+  const lastMessage = state.memory.messages.at(-1);
+  state.output = lastMessage ? [...lastMessage.text].reverse().join("") : "";
+  return Workflow.END;
+}
+
+const workflow = new Workflow({ schema }).addStep("echo", echo);
+const memory = new UnconstrainedMemory();
+
+const reader = createConsoleReader();
+for await (const { prompt } of reader) {
+  // Add user message to memory
+  await memory.add(new UserMessage(prompt));
+  // Run workflow with shared memory instance
+  const response = await workflow.run({ memory, output: "" });
+  // Add assistant response to memory
+  await memory.add(new AssistantMessage(response.result.output));
+
+  reader.write("Assistant 🤖 : ", response.result.output);
+}


### PR DESCRIPTION
## Summary

- Ports `python/examples/workflows/memory.py` to `typescript/examples/workflows/memory.ts`
- Replaces the `Example coming soon` placeholder in `docs/src/content/docs/modules/workflows.mdx` with the embedded TypeScript code block

Fixes #1468

## Changes

- `typescript/examples/workflows/memory.ts`: new file — a simple echo workflow that reverses user input and maintains conversation history via `UnconstrainedMemory` in workflow state
- `docs/src/content/docs/modules/workflows.mdx`: replaces `<!-- todo ... -->` + "Example coming soon" with `<!-- embedme ... -->` pointing at the new file and the inlined code block