### PR TITLE
fix(adapters): resolve hardcoded modelId in LangChainEmbeddingModel

### DIFF
--- a/typescript/src/adapters/langchain/backend/embedding.test.ts
+++ b/typescript/src/adapters/langchain/backend/embedding.test.ts
@@ -22,6 +22,20 @@ class LegacyFakeEmbedding extends FakeEmbedding {
   modelName = "legacy-model";
 }
 
+class NonStringModelEmbedding extends Embeddings {
+  model = { name: "not-a-string" };
+  modelName = "legacy-model";
+  constructor() {
+    super({});
+  }
+  async embedDocuments(texts: string[]) {
+    return texts.map(() => [0]);
+  }
+  async embedQuery() {
+    return [0];
+  }
+}
+
 describe("LangChainEmbeddingModel", () => {
   it("returns model from 'model' property", () => {
     const instance = new LangChainEmbeddingModel(new FakeEmbedding("text-embedding-ada-002"));
@@ -30,6 +44,11 @@ describe("LangChainEmbeddingModel", () => {
 
   it("falls back to modelName when model is absent", () => {
     const instance = new LangChainEmbeddingModel(new LegacyFakeEmbedding());
+    expect(instance.modelId).toBe("legacy-model");
+  });
+
+  it("falls back to modelName when model is not a string", () => {
+    const instance = new LangChainEmbeddingModel(new NonStringModelEmbedding());
     expect(instance.modelId).toBe("legacy-model");
   });
 

--- a/typescript/src/adapters/langchain/backend/embedding.test.ts
+++ b/typescript/src/adapters/langchain/backend/embedding.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2025 © BeeAI a Series of LF Projects, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { LangChainEmbeddingModel } from "@/adapters/langchain/backend/embedding.js";
+import { Embeddings } from "@langchain/core/embeddings";
+
+class FakeEmbedding extends Embeddings {
+  constructor(public readonly model?: string) {
+    super({});
+  }
+  async embedDocuments(texts: string[]) {
+    return texts.map(() => [0]);
+  }
+  async embedQuery() {
+    return [0];
+  }
+}
+
+class LegacyFakeEmbedding extends FakeEmbedding {
+  modelName = "legacy-model";
+}
+
+describe("LangChainEmbeddingModel", () => {
+  it("returns model from 'model' property", () => {
+    const instance = new LangChainEmbeddingModel(new FakeEmbedding("text-embedding-ada-002"));
+    expect(instance.modelId).toBe("text-embedding-ada-002");
+  });
+
+  it("falls back to modelName when model is absent", () => {
+    const instance = new LangChainEmbeddingModel(new LegacyFakeEmbedding());
+    expect(instance.modelId).toBe("legacy-model");
+  });
+
+  it("falls back to 'langchain' when neither property exists", () => {
+    const instance = new LangChainEmbeddingModel(new FakeEmbedding());
+    expect(instance.modelId).toBe("langchain");
+  });
+
+  it("returns 'langchain' as providerId", () => {
+    const instance = new LangChainEmbeddingModel(new FakeEmbedding("any"));
+    expect(instance.providerId).toBe("langchain");
+  });
+});

--- a/typescript/src/adapters/langchain/backend/embedding.ts
+++ b/typescript/src/adapters/langchain/backend/embedding.ts
@@ -26,7 +26,9 @@ export class LangChainEmbeddingModel extends EmbeddingModel {
   }
 
   get modelId(): string {
-    return "langchain"; // TODO
+    const lc = this.lcEmbedding as Record<string, unknown>;
+    const id = lc["model"] ?? lc["modelName"];
+    return typeof id === "string" ? id : "langchain";
   }
 
   get providerId(): string {

--- a/typescript/src/adapters/langchain/backend/embedding.ts
+++ b/typescript/src/adapters/langchain/backend/embedding.ts
@@ -26,8 +26,8 @@ export class LangChainEmbeddingModel extends EmbeddingModel {
   }
 
   get modelId(): string {
-    const lc = this.lcEmbedding as Record<string, unknown>;
-    const id = lc["model"] ?? lc["modelName"];
+    const lc = this.lcEmbedding as unknown as Record<string, unknown>;
+    const id = typeof lc["model"] === "string" ? lc["model"] : lc["modelName"];
     return typeof id === "string" ? id : "langchain";
   }
 


### PR DESCRIPTION
## Summary

`LangChainEmbeddingModel.modelId` was returning the static string `"langchain"` for every instance, regardless of the actual underlying model. This breaks any code that relies on `modelId` to distinguish between embedding backends (logging, serialization, routing, caching by model).

**Root cause:** The getter had a `// TODO` placeholder — the LangChain `Embeddings` base class does not expose a standard `modelId`, so the concrete implementation's `model` / `modelName` property was never read.

**Fix:** The getter now resolves the model identifier dynamically:
- Reads `model` first (modern LangChain convention: `OpenAIEmbeddings`, `OllamaEmbeddings`, etc.)
- Falls back to `modelName` (legacy convention, still present in some community models)
- Returns `"langchain"` only when neither property is available

Note: `LangChainChatModel.modelId` already uses `this.lcLLM._modelType()` — the embedding side was just missed.

## Test plan

- [x] Unit tests added covering all three resolution paths (`model`, `modelName`, neither)
- [x] All 4 new tests pass
- [x] No changes to public API or serialization format

