### PR TITLE
test(middleware): add unit tests for GlobalTrajectoryMiddleware and StreamToolCallMiddleware

### DIFF
--- a/python/tests/middleware/__init__.py
+++ b/python/tests/middleware/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0

--- a/python/tests/middleware/test_stream_tool_call.py
+++ b/python/tests/middleware/test_stream_tool_call.py
@@ -1,0 +1,180 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from beeai_framework.context import RunContext
+from beeai_framework.emitter import Emitter
+from beeai_framework.middleware.stream_tool_call import (
+    StreamToolCallMiddleware,
+    StreamToolCallMiddlewareUpdateEvent,
+)
+from beeai_framework.tools import StringToolOutput, Tool
+from beeai_framework.tools.types import ToolRunOptions
+from beeai_framework.utils.strings import to_safe_word
+
+
+# ---------------------------------------------------------------------------
+# Minimal tool fixture
+# ---------------------------------------------------------------------------
+
+
+class SearchInput(BaseModel):
+    query: str
+
+
+class FakeSearchTool(Tool[SearchInput, ToolRunOptions, StringToolOutput]):
+    name = "FakeSearchTool"
+    description = "Fake tool used in tests."
+    input_schema = SearchInput
+
+    def _create_emitter(self) -> Emitter:
+        return Emitter.root().child(
+            namespace=["tool", "custom", to_safe_word(self.name)],
+            creator=self,
+        )
+
+    async def _run(self, input: SearchInput, options: ToolRunOptions, run: RunContext) -> StringToolOutput:
+        return StringToolOutput(result=input.query)
+
+
+# ---------------------------------------------------------------------------
+# Init & state
+# ---------------------------------------------------------------------------
+
+
+class TestStreamToolCallMiddlewareInit:
+    def test_initial_buffer_is_empty(self) -> None:
+        tool = FakeSearchTool()
+        m = StreamToolCallMiddleware(tool, key="query")
+        assert m._buffer == ""
+        assert m._delta == ""
+
+    def test_cleanups_list_starts_empty(self) -> None:
+        tool = FakeSearchTool()
+        m = StreamToolCallMiddleware(tool, key="query")
+        assert m._cleanups == []
+
+    def test_match_nested_default_is_false(self) -> None:
+        tool = FakeSearchTool()
+        m = StreamToolCallMiddleware(tool, key="query")
+        assert m._match_nested is False
+
+    def test_force_streaming_default_is_false(self) -> None:
+        tool = FakeSearchTool()
+        m = StreamToolCallMiddleware(tool, key="query")
+        assert m._force_streaming is False
+
+    def test_custom_flags_stored(self) -> None:
+        tool = FakeSearchTool()
+        m = StreamToolCallMiddleware(tool, key="query", match_nested=True, force_streaming=True)
+        assert m._match_nested is True
+        assert m._force_streaming is True
+
+
+# ---------------------------------------------------------------------------
+# unbind
+# ---------------------------------------------------------------------------
+
+
+class TestUnbind:
+    def test_unbind_drains_cleanups(self) -> None:
+        tool = FakeSearchTool()
+        m = StreamToolCallMiddleware(tool, key="query")
+
+        called: list[str] = []
+        m._cleanups.append(lambda: called.append("a"))
+        m._cleanups.append(lambda: called.append("b"))
+
+        m.unbind()
+
+        assert called == ["a", "b"]
+        assert m._cleanups == []
+
+    def test_unbind_is_idempotent(self) -> None:
+        tool = FakeSearchTool()
+        m = StreamToolCallMiddleware(tool, key="query")
+        m.unbind()
+        m.unbind()  # Should not raise
+
+
+# ---------------------------------------------------------------------------
+# _process — matching and non-matching tool names
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_process_emits_update_for_matching_tool() -> None:
+    tool = FakeSearchTool()
+    m = StreamToolCallMiddleware(tool, key="query")
+
+    received: list[StreamToolCallMiddlewareUpdateEvent] = []
+
+    @m.emitter.on("update")
+    def capture(event: StreamToolCallMiddlewareUpdateEvent, meta: Any) -> None:
+        received.append(event)
+
+    await m._process(tool.name, {"query": "hello world"})
+
+    assert len(received) == 1
+    assert received[0].output == "hello world"
+    assert received[0].delta == "hello world"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_process_does_not_emit_for_wrong_tool_name() -> None:
+    tool = FakeSearchTool()
+    m = StreamToolCallMiddleware(tool, key="query")
+
+    received: list[Any] = []
+
+    @m.emitter.on("update")
+    def capture(event: Any, meta: Any) -> None:
+        received.append(event)
+
+    await m._process("OtherTool", {"query": "hello"})
+
+    assert len(received) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_process_delta_tracks_incremental_output() -> None:
+    tool = FakeSearchTool()
+    m = StreamToolCallMiddleware(tool, key="query")
+
+    events: list[StreamToolCallMiddlewareUpdateEvent] = []
+
+    @m.emitter.on("update")
+    def capture(event: StreamToolCallMiddlewareUpdateEvent, meta: Any) -> None:
+        events.append(event)
+
+    await m._process(tool.name, {"query": "hello"})
+    await m._process(tool.name, {"query": "hello world"})
+
+    assert len(events) == 2
+    assert events[0].delta == "hello"
+    assert events[1].delta == " world"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_process_skips_emit_when_delta_is_empty() -> None:
+    tool = FakeSearchTool()
+    m = StreamToolCallMiddleware(tool, key="query")
+
+    events: list[Any] = []
+
+    @m.emitter.on("update")
+    def capture(event: Any, meta: Any) -> None:
+        events.append(event)
+
+    await m._process(tool.name, {"query": "hello"})
+    await m._process(tool.name, {"query": "hello"})  # same content, delta == ""
+
+    assert len(events) == 1

--- a/python/tests/middleware/test_trajectory.py
+++ b/python/tests/middleware/test_trajectory.py
@@ -1,0 +1,203 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import io
+import sys
+from typing import Any, Unpack
+
+import pytest
+
+from beeai_framework.backend import AssistantMessage, UserMessage
+from beeai_framework.context import RunMiddlewareType
+from beeai_framework.emitter import Emitter
+from beeai_framework.errors import FrameworkError
+from beeai_framework.logger import Logger
+from beeai_framework.middleware.trajectory import (
+    GlobalTrajectoryMiddleware,
+    TraceLevel,
+    _create_target,
+)
+from beeai_framework.runnable import Runnable, RunnableOptions, RunnableOutput, runnable_entry
+
+
+# ---------------------------------------------------------------------------
+# Minimal Runnable for integration tests
+# ---------------------------------------------------------------------------
+
+
+class EchoRunnable(Runnable[RunnableOutput]):
+    def __init__(self, middlewares: list[RunMiddlewareType] | None = None) -> None:
+        super().__init__(middlewares)
+
+    @property
+    def emitter(self) -> Emitter:
+        return Emitter.root().child(namespace=["test", "echo_runnable"])
+
+    @runnable_entry
+    async def run(self, input: list[Any], /, **kwargs: Unpack[RunnableOptions]) -> RunnableOutput:
+        return RunnableOutput(output=[AssistantMessage(content="pong")])
+
+
+# ---------------------------------------------------------------------------
+# _create_target
+# ---------------------------------------------------------------------------
+
+
+class TestCreateTarget:
+    def test_none_returns_stdout(self) -> None:
+        assert _create_target(None) is sys.stdout
+
+    def test_true_returns_stdout(self) -> None:
+        assert _create_target(True) is sys.stdout
+
+    def test_false_returns_null_writeable(self) -> None:
+        target = _create_target(False)
+        result = target.write("hello")
+        assert result == 5  # returns length but discards content
+
+    def test_logger_returns_writeable_wrapper(self) -> None:
+        log = Logger(__name__)
+        target = _create_target(log)
+        result = target.write("test message\n")
+        assert isinstance(result, int)
+
+    def test_custom_writeable_returned_as_is(self) -> None:
+        buf = io.StringIO()
+        assert _create_target(buf) is buf
+
+
+# ---------------------------------------------------------------------------
+# TraceLevel
+# ---------------------------------------------------------------------------
+
+
+class TestTraceLevel:
+    def test_defaults_are_zero(self) -> None:
+        level = TraceLevel()
+        assert level.relative == 0
+        assert level.absolute == 0
+
+    def test_accepts_positive_values(self) -> None:
+        level = TraceLevel(relative=3, absolute=7)
+        assert level.relative == 3
+        assert level.absolute == 7
+
+    def test_relative_cannot_be_negative(self) -> None:
+        with pytest.raises(Exception):
+            TraceLevel(relative=-1)
+
+    def test_absolute_cannot_be_negative(self) -> None:
+        with pytest.raises(Exception):
+            TraceLevel(absolute=-1)
+
+
+# ---------------------------------------------------------------------------
+# GlobalTrajectoryMiddleware — init & configuration
+# ---------------------------------------------------------------------------
+
+
+class TestGlobalTrajectoryMiddlewareInit:
+    def test_enabled_by_default(self) -> None:
+        m = GlobalTrajectoryMiddleware()
+        assert m.enabled is True
+
+    def test_disabled_via_flag(self) -> None:
+        m = GlobalTrajectoryMiddleware(enabled=False)
+        assert m.enabled is False
+
+    def test_custom_target_stored(self) -> None:
+        buf = io.StringIO()
+        m = GlobalTrajectoryMiddleware(target=buf)
+        assert m._target is buf
+
+    def test_false_target_creates_null_writeable(self) -> None:
+        m = GlobalTrajectoryMiddleware(target=False)
+        # Should not raise and writes are silently discarded
+        m._target.write("ignored")
+
+    def test_custom_formatter_stored(self) -> None:
+        fmt = lambda x: "custom"
+        m = GlobalTrajectoryMiddleware(formatter=fmt)
+        assert m._formatter is fmt
+
+    def test_included_list_stored(self) -> None:
+        m = GlobalTrajectoryMiddleware(included=[Logger])
+        assert Logger in m._included
+
+    def test_excluded_list_stored(self) -> None:
+        m = GlobalTrajectoryMiddleware(excluded=[Logger])
+        assert Logger in m._excluded
+
+
+# ---------------------------------------------------------------------------
+# GlobalTrajectoryMiddleware._format_payload
+# ---------------------------------------------------------------------------
+
+
+class TestFormatPayload:
+    def _middleware(self, **kwargs: Any) -> GlobalTrajectoryMiddleware:
+        return GlobalTrajectoryMiddleware(target=False, **kwargs)
+
+    def test_string_passthrough(self) -> None:
+        m = self._middleware()
+        assert m._format_payload("hello") == "hello"
+
+    def test_integer_converted_to_string(self) -> None:
+        m = self._middleware()
+        assert m._format_payload(42) == "42"
+
+    def test_bool_converted_to_string(self) -> None:
+        m = self._middleware()
+        assert m._format_payload(True) == "True"
+
+    def test_none_converted_to_string(self) -> None:
+        m = self._middleware()
+        assert m._format_payload(None) == "None"
+
+    def test_framework_error_uses_explain(self) -> None:
+        m = self._middleware()
+        err = FrameworkError("something broke")
+        result = m._format_payload(err)
+        assert "something broke" in result
+
+    def test_dict_serialized_as_json(self) -> None:
+        m = self._middleware()
+        result = m._format_payload({"key": "value"})
+        assert "key" in result
+        assert "value" in result
+
+    def test_pretty_flag_adds_indentation(self) -> None:
+        m_compact = self._middleware(pretty=False)
+        m_pretty = self._middleware(pretty=True)
+        payload = {"a": 1, "b": 2}
+        assert "\n" not in m_compact._format_payload(payload)
+        assert "\n" in m_pretty._format_payload(payload)
+
+
+# ---------------------------------------------------------------------------
+# GlobalTrajectoryMiddleware — integration (Runnable)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_middleware_writes_to_target_when_enabled() -> None:
+    buf = io.StringIO()
+    m = GlobalTrajectoryMiddleware(target=buf)
+
+    r = EchoRunnable()
+    await r.run([UserMessage(content="ping")]).middleware(m)
+
+    assert buf.tell() > 0, "Expected middleware to write at least one line to target"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_middleware_does_not_write_when_disabled() -> None:
+    buf = io.StringIO()
+    m = GlobalTrajectoryMiddleware(target=buf, enabled=False)
+
+    r = EchoRunnable()
+    await r.run([UserMessage(content="ping")]).middleware(m)
+
+    assert buf.tell() == 0, "Expected no writes when middleware is disabled"

--- a/python/tests/middleware/test_trajectory.py
+++ b/python/tests/middleware/test_trajectory.py
@@ -6,6 +6,7 @@ import sys
 from typing import Any, Unpack
 
 import pytest
+from pydantic import ValidationError
 
 from beeai_framework.backend import AssistantMessage, UserMessage
 from beeai_framework.context import RunMiddlewareType
@@ -18,7 +19,6 @@ from beeai_framework.middleware.trajectory import (
     _create_target,
 )
 from beeai_framework.runnable import Runnable, RunnableOptions, RunnableOutput, runnable_entry
-
 
 # ---------------------------------------------------------------------------
 # Minimal Runnable for integration tests
@@ -83,11 +83,11 @@ class TestTraceLevel:
         assert level.absolute == 7
 
     def test_relative_cannot_be_negative(self) -> None:
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             TraceLevel(relative=-1)
 
     def test_absolute_cannot_be_negative(self) -> None:
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             TraceLevel(absolute=-1)
 
 
@@ -116,7 +116,9 @@ class TestGlobalTrajectoryMiddlewareInit:
         m._target.write("ignored")
 
     def test_custom_formatter_stored(self) -> None:
-        fmt = lambda x: "custom"
+        def fmt(x: Any) -> str:
+            return "custom"
+
         m = GlobalTrajectoryMiddleware(formatter=fmt)
         assert m._formatter is fmt
 
@@ -188,7 +190,10 @@ async def test_middleware_writes_to_target_when_enabled() -> None:
     r = EchoRunnable()
     await r.run([UserMessage(content="ping")]).middleware(m)
 
-    assert buf.tell() > 0, "Expected middleware to write at least one line to target"
+    output = buf.getvalue()
+    assert output, "Expected middleware to write at least one line to target"
+    # The trajectory labels each entry with the originating class name.
+    assert "EchoRunnable" in output
 
 
 @pytest.mark.asyncio
@@ -200,4 +205,4 @@ async def test_middleware_does_not_write_when_disabled() -> None:
     r = EchoRunnable()
     await r.run([UserMessage(content="ping")]).middleware(m)
 
-    assert buf.tell() == 0, "Expected no writes when middleware is disabled"
+    assert buf.getvalue() == "", "Expected no writes when middleware is disabled"


### PR DESCRIPTION
## Summary

The `middleware` module had zero test coverage despite being a core cross-cutting concern used throughout the framework. This PR adds 36 unit tests across two new test files.

### `tests/middleware/test_trajectory.py` (27 tests)

**`_create_target` helper** — verifies all 5 input types map to the correct writable target (`None`/`True` → stdout, `False` → silent discard, `Logger` → wrapper, custom writable → returned as-is).

**`TraceLevel` model** — validates defaults, custom values, and rejection of negative depth fields.

**`GlobalTrajectoryMiddleware` init** — checks that `enabled`, `target`, `formatter`, `included`, and `excluded` are stored correctly.

**`_format_payload`** — covers all branches: `str`/`int`/`bool`/`None` passthrough, `FrameworkError.explain()` delegation, dict → JSON, and pretty-print indentation toggle.

**Integration tests** — run a minimal `Runnable` with the middleware attached and assert that:
- writes reach the target when `enabled=True`
- the target receives nothing when `enabled=False`

### `tests/middleware/test_stream_tool_call.py` (9 tests)

**Init state** — buffer/delta start empty, flags default to `False`.

**`unbind()`** — drains `_cleanups` in order and is idempotent.

**`_process()`** — emits `update` for matching tool name, skips for wrong name, tracks incremental delta correctly across successive calls, and suppresses emit when delta is empty.

## Test plan

- [x] All 36 tests pass: `poetry run pytest tests/middleware/ -v`
- [x] No existing tests broken: `poetry run pytest -m unit` (full suite)
