### PR TITLE
Feat/1479 OpenAI server

### DIFF
--- a/docs/src/content/docs/integrations/openai-api.mdx
+++ b/docs/src/content/docs/integrations/openai-api.mdx
@@ -51,8 +51,28 @@ Key benefits
 	
 	```
 
+	{/* <!-- embedme typescript/examples/serve/openai_responses.ts --> */}
 	```ts TypeScript [expandable]
-	 // coming soon
+	import "dotenv/config.js";
+
+	import { OpenMeteoTool } from "beeai-framework/tools/weather/openMeteo";
+	import { OllamaChatModel } from "beeai-framework/adapters/ollama/backend/chat";
+	import { ToolCallingAgent } from "beeai-framework/agents/toolCalling/agent";
+	import { UnconstrainedMemory } from "beeai-framework/memory/unconstrainedMemory";
+	import { OpenAIServer } from "beeai-framework/adapters/openai/serve/server";
+
+	// ensure the model is pulled before running
+	const llm = new OllamaChatModel("granite4:micro");
+
+	const agent = new ToolCallingAgent({
+	  llm,
+	  memory: new UnconstrainedMemory(),
+	  tools: [
+	    new OpenMeteoTool(), // weather tool
+	  ],
+	});
+
+	await new OpenAIServer({ api: "responses", port: 9999 }).register(agent).serve();
 	```
 
 </CodeGroup>

--- a/docs/src/content/docs/integrations/openai-api.mdx
+++ b/docs/src/content/docs/integrations/openai-api.mdx
@@ -82,7 +82,7 @@ You can easily call the exposed entities via cURL.
 <CodeGroup>
 
 	```sh Responses API
-	curl --location 'http://0.0.0.0:9998/responses' \
+	curl --location 'http://127.0.0.1:9998/responses' \
 	--header 'Content-Type: application/json' \
 	--data '{
 		"model": "agent",
@@ -93,7 +93,7 @@ You can easily call the exposed entities via cURL.
 	```
 
 	```sh Chat Completion API
-	curl --location 'http://0.0.0.0:9998/chat/completions' \
+	curl --location 'http://127.0.0.1:9998/chat/completions' \
 	--header 'Content-Type: application/json' \
 	--data '{
 	    "model": "agent",

--- a/docs/src/content/docs/integrations/openai-api.mdx
+++ b/docs/src/content/docs/integrations/openai-api.mdx
@@ -54,16 +54,16 @@ Key benefits
 	{/* <!-- embedme typescript/examples/serve/openai_responses.ts --> */}
 	```ts TypeScript [expandable]
 	import "dotenv/config.js";
-
+	
 	import { OpenMeteoTool } from "beeai-framework/tools/weather/openMeteo";
 	import { OllamaChatModel } from "beeai-framework/adapters/ollama/backend/chat";
 	import { ToolCallingAgent } from "beeai-framework/agents/toolCalling/agent";
 	import { UnconstrainedMemory } from "beeai-framework/memory/unconstrainedMemory";
 	import { OpenAIServer } from "beeai-framework/adapters/openai/serve/server";
-
+	
 	// ensure the model is pulled before running
 	const llm = new OllamaChatModel("granite4:micro");
-
+	
 	const agent = new ToolCallingAgent({
 	  llm,
 	  memory: new UnconstrainedMemory(),
@@ -71,8 +71,9 @@ Key benefits
 	    new OpenMeteoTool(), // weather tool
 	  ],
 	});
-
+	
 	await new OpenAIServer({ api: "responses", port: 9999 }).register(agent).serve();
+	
 	```
 
 </CodeGroup>

--- a/typescript/examples/serve/openai.ts
+++ b/typescript/examples/serve/openai.ts
@@ -1,0 +1,20 @@
+import "dotenv/config.js";
+
+import { OpenMeteoTool } from "beeai-framework/tools/weather/openMeteo";
+import { OllamaChatModel } from "beeai-framework/adapters/ollama/backend/chat";
+import { ToolCallingAgent } from "beeai-framework/agents/toolCalling/agent";
+import { UnconstrainedMemory } from "beeai-framework/memory/unconstrainedMemory";
+import { OpenAIServer } from "beeai-framework/adapters/openai/serve/server";
+
+// ensure the model is pulled before running
+const llm = new OllamaChatModel("granite4:micro");
+
+const agent = new ToolCallingAgent({
+  llm,
+  memory: new UnconstrainedMemory(),
+  tools: [
+    new OpenMeteoTool(), // weather tool
+  ],
+});
+
+await new OpenAIServer().register(agent).serve();

--- a/typescript/examples/serve/openai_responses.ts
+++ b/typescript/examples/serve/openai_responses.ts
@@ -17,4 +17,4 @@ const agent = new ToolCallingAgent({
   ],
 });
 
-await new OpenAIServer({ api: "responses", host: "0.0.0.0", port: 9999 }).register(agent).serve();
+await new OpenAIServer({ api: "responses", port: 9999 }).register(agent).serve();

--- a/typescript/examples/serve/openai_responses.ts
+++ b/typescript/examples/serve/openai_responses.ts
@@ -1,0 +1,20 @@
+import "dotenv/config.js";
+
+import { OpenMeteoTool } from "beeai-framework/tools/weather/openMeteo";
+import { OllamaChatModel } from "beeai-framework/adapters/ollama/backend/chat";
+import { ToolCallingAgent } from "beeai-framework/agents/toolCalling/agent";
+import { UnconstrainedMemory } from "beeai-framework/memory/unconstrainedMemory";
+import { OpenAIServer } from "beeai-framework/adapters/openai/serve/server";
+
+// ensure the model is pulled before running
+const llm = new OllamaChatModel("granite4:micro");
+
+const agent = new ToolCallingAgent({
+  llm,
+  memory: new UnconstrainedMemory(),
+  tools: [
+    new OpenMeteoTool(), // weather tool
+  ],
+});
+
+await new OpenAIServer({ api: "responses", host: "0.0.0.0", port: 9999 }).register(agent).serve();

--- a/typescript/src/adapters/openai/serve/api.ts
+++ b/typescript/src/adapters/openai/serve/api.ts
@@ -56,16 +56,26 @@ export class ChatCompletionAPI {
         res.setHeader("Cache-Control", "no-cache");
         res.setHeader("Connection", "keep-alive");
 
+        // Abort the agent run if the client disconnects early
+        const controller = new AbortController();
+        req.on("close", () => {
+          controller.abort();
+        });
+
         try {
           await clonedAgent
-            .run({ prompt: null })
+            .run({ prompt: null }, { signal: controller.signal })
             .observe((emitter) => {
               // Match all events and filter for "update" — required because the
               // emitter is typed as Emitter<unknown> at the AnyAgent abstraction.
               emitter.match("*.*", async (eventData: any, event) => {
-                if (event.name !== "update") return;
+                if (event.name !== "update") {
+                  return;
+                }
                 const { update } = eventData as { update: { value: string } };
-                if (res.writableEnded) return;
+                if (res.writableEnded || res.destroyed) {
+                  return;
+                }
                 const data = {
                   id,
                   object: "chat.completion.chunk",
@@ -86,24 +96,26 @@ export class ChatCompletionAPI {
               });
             });
 
-          const finalData = {
-            id,
-            object: "chat.completion.chunk",
-            model: requestBody.model,
-            created: Math.floor(Date.now() / 1000),
-            choices: [
-              {
-                index: 0,
-                delta: {},
-                finish_reason: "stop",
-              },
-            ],
-          };
-          res.write(`data: ${JSON.stringify(finalData)}\n\n`);
-          res.write(`data: [DONE]\n\n`);
+          if (!res.writableEnded && !res.destroyed) {
+            const finalData = {
+              id,
+              object: "chat.completion.chunk",
+              model: requestBody.model,
+              created: Math.floor(Date.now() / 1000),
+              choices: [
+                {
+                  index: 0,
+                  delta: {},
+                  finish_reason: "stop",
+                },
+              ],
+            };
+            res.write(`data: ${JSON.stringify(finalData)}\n\n`);
+            res.write(`data: [DONE]\n\n`);
+          }
         } catch (error) {
           logger.error(error, "Error during streaming agent run");
-          if (!res.writableEnded) {
+          if (!res.writableEnded && !res.destroyed) {
             // Send an error chunk so the client can detect failure
             const errData = {
               id,
@@ -113,11 +125,17 @@ export class ChatCompletionAPI {
               choices: [{ index: 0, delta: {}, finish_reason: "error" }],
               error: { message: String(error) },
             };
-            res.write(`data: ${JSON.stringify(errData)}\n\n`);
-            res.write(`data: [DONE]\n\n`);
+            try {
+              res.write(`data: ${JSON.stringify(errData)}\n\n`);
+              res.write(`data: [DONE]\n\n`);
+            } catch (writeError) {
+              logger.error(writeError, "Failed to write error response chunk");
+            }
           }
         } finally {
-          res.end();
+          if (!res.writableEnded && !res.destroyed) {
+            res.end();
+          }
         }
       } else {
         const result = await clonedAgent.run({ prompt: null });
@@ -148,7 +166,9 @@ export class ChatCompletionAPI {
       }
     } catch (error) {
       logger.error(error, "Error handling /chat/completions request");
-      res.status(500).json({ error: String(error) });
+      if (!res.headersSent) {
+        res.status(500).json({ error: String(error) });
+      }
     }
   }
 }

--- a/typescript/src/adapters/openai/serve/api.ts
+++ b/typescript/src/adapters/openai/serve/api.ts
@@ -32,9 +32,10 @@ export class ChatCompletionAPI {
     const requestBody = req.body as ChatCompletionRequestBody;
     logger.debug(`Received request: ${JSON.stringify(requestBody)}`);
 
-    const authHeader = req.headers.authorization;
     if (this.apiKey) {
-      if (!authHeader || authHeader.replace("Bearer ", "") !== this.apiKey) {
+      const authHeader = req.headers.authorization;
+      const token = Array.isArray(authHeader) ? authHeader[0] : authHeader;
+      if (!token || token.replace("Bearer ", "") !== this.apiKey) {
         res.status(401).json({ detail: "Missing or invalid API key" });
         return;
       }
@@ -57,7 +58,7 @@ export class ChatCompletionAPI {
         res.setHeader("Connection", "keep-alive");
 
         // Simple streaming implementation mapping to SSE
-        (clonedAgent.emitter as any).on("update", async ({ update }: any) => {
+        const updateListener = async ({ update }: any) => {
           const data = {
             id,
             object: "chat.completion.chunk",
@@ -75,6 +76,13 @@ export class ChatCompletionAPI {
             ],
           };
           res.write(`data: ${JSON.stringify(data)}\n\n`);
+        };
+        
+        (clonedAgent.emitter as any).on("update", updateListener);
+
+        // Cleanup if client disconnects early
+        req.on("close", () => {
+          (clonedAgent.emitter as any).off("update", updateListener);
         });
 
         await clonedAgent.run({ prompt: null });

--- a/typescript/src/adapters/openai/serve/api.ts
+++ b/typescript/src/adapters/openai/serve/api.ts
@@ -66,14 +66,19 @@ export class ChatCompletionAPI {
           await clonedAgent
             .run({ prompt: null }, { signal: controller.signal })
             .observe((emitter) => {
-              // Match all events and filter for "update" — required because the
-              // emitter is typed as Emitter<unknown> at the AnyAgent abstraction.
+              // Match all events — required because the emitter is typed as
+              // Emitter<unknown> at the AnyAgent abstraction. We emit text deltas
+              // from "update" (ReActAgent incremental tokens) and from "success"
+              // (ToolCallingAgent emits only start/success, with the final answer
+              // in state.result). This keeps streaming working for both agents.
               emitter.match("*.*", async (eventData: any, event) => {
-                if (event.name !== "update") {
-                  return;
+                let delta: string | undefined;
+                if (event.name === "update") {
+                  delta = eventData?.update?.value;
+                } else if (event.name === "success") {
+                  delta = eventData?.state?.result?.text;
                 }
-                const { update } = eventData as { update: { value: string } };
-                if (res.writableEnded || res.destroyed) {
+                if (!delta || res.writableEnded || res.destroyed) {
                   return;
                 }
                 const data = {
@@ -86,7 +91,7 @@ export class ChatCompletionAPI {
                       index: 0,
                       delta: {
                         role: "assistant",
-                        content: update.value,
+                        content: delta,
                       },
                       finish_reason: null,
                     },

--- a/typescript/src/adapters/openai/serve/api.ts
+++ b/typescript/src/adapters/openai/serve/api.ts
@@ -9,7 +9,6 @@ import { AnyAgent } from "@/agents/types.js";
 import { transformRequestMessages } from "./utils.js";
 import { ChatCompletionRequestBody, ChatCompletionResponse } from "./types.js";
 import { Logger } from "@/logger/logger.js";
-import { ReActAgentRunOutput } from "@/agents/react/types.js";
 
 const logger = Logger.root.child({
   name: "OpenAI API",
@@ -57,10 +56,37 @@ export class ChatCompletionAPI {
         res.setHeader("Cache-Control", "no-cache");
         res.setHeader("Connection", "keep-alive");
 
-        // Simple streaming implementation mapping to SSE
-        const updateListener = ({ update }: any) => {
-          if (res.writableEnded) return;
-          const data = {
+        try {
+          await clonedAgent
+            .run({ prompt: null })
+            .observe((emitter) => {
+              // Match all events and filter for "update" — required because the
+              // emitter is typed as Emitter<unknown> at the AnyAgent abstraction.
+              emitter.match("*.*", async (eventData: any, event) => {
+                if (event.name !== "update") return;
+                const { update } = eventData as { update: { value: string } };
+                if (res.writableEnded) return;
+                const data = {
+                  id,
+                  object: "chat.completion.chunk",
+                  model: requestBody.model,
+                  created: Math.floor(Date.now() / 1000),
+                  choices: [
+                    {
+                      index: 0,
+                      delta: {
+                        role: "assistant",
+                        content: update.value,
+                      },
+                      finish_reason: null,
+                    },
+                  ],
+                };
+                res.write(`data: ${JSON.stringify(data)}\n\n`);
+              });
+            });
+
+          const finalData = {
             id,
             object: "chat.completion.chunk",
             model: requestBody.model,
@@ -68,45 +94,34 @@ export class ChatCompletionAPI {
             choices: [
               {
                 index: 0,
-                delta: {
-                  role: "assistant",
-                  content: update.value,
-                },
-                finish_reason: null,
+                delta: {},
+                finish_reason: "stop",
               },
             ],
           };
-          res.write(`data: ${JSON.stringify(data)}\n\n`);
-        };
-        
-        (clonedAgent.emitter as any).on("update", updateListener);
-
-        // Cleanup if client disconnects early
-        req.on("close", () => {
-          (clonedAgent.emitter as any).off("update", updateListener);
-        });
-
-        await clonedAgent.run({ prompt: null });
-
-        const finalData = {
-          id,
-          object: "chat.completion.chunk",
-          model: requestBody.model,
-          created: Math.floor(Date.now() / 1000),
-          choices: [
-            {
-              index: 0,
-              delta: {},
-              finish_reason: "stop",
-            },
-          ],
-        };
-        res.write(`data: ${JSON.stringify(finalData)}\n\n`);
-        res.write(`data: [DONE]\n\n`);
-        res.end();
+          res.write(`data: ${JSON.stringify(finalData)}\n\n`);
+          res.write(`data: [DONE]\n\n`);
+        } catch (error) {
+          logger.error(error, "Error during streaming agent run");
+          if (!res.writableEnded) {
+            // Send an error chunk so the client can detect failure
+            const errData = {
+              id,
+              object: "chat.completion.chunk",
+              model: requestBody.model,
+              created: Math.floor(Date.now() / 1000),
+              choices: [{ index: 0, delta: {}, finish_reason: "error" }],
+              error: { message: String(error) },
+            };
+            res.write(`data: ${JSON.stringify(errData)}\n\n`);
+            res.write(`data: [DONE]\n\n`);
+          }
+        } finally {
+          res.end();
+        }
       } else {
-        const result = (await clonedAgent.run({ prompt: null })) as ReActAgentRunOutput;
-        
+        const result = await clonedAgent.run({ prompt: null });
+
         const response: ChatCompletionResponse = {
           id: `chatcmpl-${uuidv4()}`,
           object: "chat.completion",

--- a/typescript/src/adapters/openai/serve/api.ts
+++ b/typescript/src/adapters/openai/serve/api.ts
@@ -35,7 +35,7 @@ export class ChatCompletionAPI {
     if (this.apiKey) {
       const authHeader = req.headers.authorization;
       const token = Array.isArray(authHeader) ? authHeader[0] : authHeader;
-      if (!token || token.replace("Bearer ", "") !== this.apiKey) {
+      if (!token || token.replace(/^Bearer\s+/i, "") !== this.apiKey) {
         res.status(401).json({ detail: "Missing or invalid API key" });
         return;
       }
@@ -58,7 +58,7 @@ export class ChatCompletionAPI {
         res.setHeader("Connection", "keep-alive");
 
         // Simple streaming implementation mapping to SSE
-        const updateListener = async ({ update }: any) => {
+        const updateListener = ({ update }: any) => {
           const data = {
             id,
             object: "chat.completion.chunk",

--- a/typescript/src/adapters/openai/serve/api.ts
+++ b/typescript/src/adapters/openai/serve/api.ts
@@ -59,6 +59,7 @@ export class ChatCompletionAPI {
 
         // Simple streaming implementation mapping to SSE
         const updateListener = ({ update }: any) => {
+          if (res.writableEnded) return;
           const data = {
             id,
             object: "chat.completion.chunk",

--- a/typescript/src/adapters/openai/serve/api.ts
+++ b/typescript/src/adapters/openai/serve/api.ts
@@ -1,0 +1,130 @@
+/**
+ * Copyright 2025 © BeeAI a Series of LF Projects, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import express, { Request, Response, Router } from "express";
+import { v4 as uuidv4 } from "uuid";
+import { AnyAgent } from "@/agents/types.js";
+import { transformRequestMessages } from "./utils.js";
+import { ChatCompletionRequestBody, ChatCompletionResponse } from "./types.js";
+import { Logger } from "@/logger/logger.js";
+import { ReActAgentRunOutput } from "@/agents/react/types.js";
+
+const logger = Logger.root.child({
+  name: "OpenAI API",
+});
+
+export class ChatCompletionAPI {
+  public readonly router: Router;
+
+  constructor(
+    private readonly modelFactory: (modelId: string) => Promise<AnyAgent>,
+    private readonly apiKey?: string,
+  ) {
+    this.router = express.Router();
+    this.router.use(express.json());
+
+    this.router.post("/chat/completions", this.handler.bind(this));
+  }
+
+  private async handler(req: Request, res: Response) {
+    const requestBody = req.body as ChatCompletionRequestBody;
+    logger.debug(`Received request: ${JSON.stringify(requestBody)}`);
+
+    const authHeader = req.headers.authorization;
+    if (this.apiKey) {
+      if (!authHeader || authHeader.replace("Bearer ", "") !== this.apiKey) {
+        res.status(401).json({ detail: "Missing or invalid API key" });
+        return;
+      }
+    }
+
+    try {
+      const messages = transformRequestMessages(requestBody.messages || []);
+      const agent = await this.modelFactory(requestBody.model);
+
+      // We clone the agent to avoid mutating the registered instance
+      const clonedAgent = await agent.clone();
+      clonedAgent.memory = await clonedAgent.memory.clone();
+      clonedAgent.memory.reset();
+      await clonedAgent.memory.addMany(messages);
+
+      if (requestBody.stream) {
+        const id = `chatcmpl-${uuidv4()}`;
+        res.setHeader("Content-Type", "text/event-stream");
+        res.setHeader("Cache-Control", "no-cache");
+        res.setHeader("Connection", "keep-alive");
+
+        // Simple streaming implementation mapping to SSE
+        (clonedAgent.emitter as any).on("update", async ({ update }: any) => {
+          const data = {
+            id,
+            object: "chat.completion.chunk",
+            model: requestBody.model,
+            created: Math.floor(Date.now() / 1000),
+            choices: [
+              {
+                index: 0,
+                delta: {
+                  role: "assistant",
+                  content: update.value,
+                },
+                finish_reason: null,
+              },
+            ],
+          };
+          res.write(`data: ${JSON.stringify(data)}\n\n`);
+        });
+
+        await clonedAgent.run({ prompt: null });
+
+        const finalData = {
+          id,
+          object: "chat.completion.chunk",
+          model: requestBody.model,
+          created: Math.floor(Date.now() / 1000),
+          choices: [
+            {
+              index: 0,
+              delta: {},
+              finish_reason: "stop",
+            },
+          ],
+        };
+        res.write(`data: ${JSON.stringify(finalData)}\n\n`);
+        res.write(`data: [DONE]\n\n`);
+        res.end();
+      } else {
+        const result = (await clonedAgent.run({ prompt: null })) as ReActAgentRunOutput;
+        
+        const response: ChatCompletionResponse = {
+          id: `chatcmpl-${uuidv4()}`,
+          object: "chat.completion",
+          created: Math.floor(Date.now() / 1000),
+          model: requestBody.model,
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: "assistant",
+                content: result.result?.text ?? "",
+              },
+              finish_reason: "stop",
+            },
+          ],
+          usage: {
+            prompt_tokens: 0, // Mock usage since agents might not bubble it up uniformly yet
+            completion_tokens: 0,
+            total_tokens: 0,
+          },
+        };
+
+        res.json(response);
+      }
+    } catch (error) {
+      logger.error(error, "Error handling /chat/completions request");
+      res.status(500).json({ error: String(error) });
+    }
+  }
+}

--- a/typescript/src/adapters/openai/serve/index.ts
+++ b/typescript/src/adapters/openai/serve/index.ts
@@ -5,3 +5,4 @@
 
 export * from "./server.js";
 export * from "./types.js";
+export * from "./responses_types.js";

--- a/typescript/src/adapters/openai/serve/index.ts
+++ b/typescript/src/adapters/openai/serve/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Copyright 2025 © BeeAI a Series of LF Projects, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from "./server.js";
+export * from "./types.js";

--- a/typescript/src/adapters/openai/serve/responses_api.ts
+++ b/typescript/src/adapters/openai/serve/responses_api.ts
@@ -1,0 +1,284 @@
+/**
+ * Copyright 2025 © BeeAI a Series of LF Projects, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import express, { Request, Response, Router } from "express";
+import { v4 as uuidv4 } from "uuid";
+import { AnyAgent } from "@/agents/types.js";
+import { Logger } from "@/logger/logger.js";
+import { ReActAgentRunOutput } from "@/agents/react/types.js";
+import { SystemMessage, UserMessage, Message } from "@/backend/message.js";
+import { openaiInputToBeeAIMessage } from "./responses_utils.js";
+import {
+  ResponsesRequestBody,
+  ResponsesRequestInputMessage,
+  ResponsesResponse,
+  ResponsesMessageOutput,
+  ResponsesMessageContent,
+  ResponsesStreamResponseCreated,
+  ResponsesStreamResponseInProgress,
+  ResponsesStreamResponseCompleted,
+  ResponsesStreamOutputItemAdded,
+  ResponsesStreamOutputItemDone,
+  ResponsesStreamContentPartAdded,
+  ResponsesStreamContentPartDone,
+  ResponsesStreamOutputTextDelta,
+  ResponsesStreamOutputTextDone,
+  ResponsesStreamPartOutputText,
+  ResponsesStreamError,
+} from "./responses_types.js";
+
+const logger = Logger.root.child({
+  name: "OpenAI Responses API",
+});
+
+export class ResponsesAPI {
+  public readonly router: Router;
+
+  constructor(
+    private readonly modelFactory: (modelId: string) => Promise<AnyAgent>,
+    private readonly apiKey?: string,
+  ) {
+    this.router = express.Router();
+    this.router.use(express.json());
+
+    this.router.post("/responses", this.handler.bind(this));
+  }
+
+  private async handler(req: Request, res: Response) {
+    const requestBody = req.body as ResponsesRequestBody;
+    logger.debug(`Received request: ${JSON.stringify(requestBody)}`);
+
+    const authHeader = req.headers.authorization;
+    if (this.apiKey) {
+      if (!authHeader || authHeader.replace("Bearer ", "") !== this.apiKey) {
+        res.status(401).json({ detail: "Missing or invalid API key" });
+        return;
+      }
+    }
+
+    try {
+      const messages: Message[] = [];
+
+      // Convert instructions to SystemMessage if present
+      if (requestBody.instructions) {
+        messages.push(new SystemMessage(requestBody.instructions));
+      }
+
+      // Convert input to BeeAI messages
+      if (typeof requestBody.input === "string") {
+        messages.push(new UserMessage(requestBody.input));
+      } else {
+        for (const msg of requestBody.input as ResponsesRequestInputMessage[]) {
+          messages.push(openaiInputToBeeAIMessage(msg));
+        }
+      }
+
+      const agent = await this.modelFactory(requestBody.model);
+
+      // We clone the agent to avoid mutating the registered instance
+      const clonedAgent = await agent.clone();
+      clonedAgent.memory = await clonedAgent.memory.clone();
+      clonedAgent.memory.reset();
+      await clonedAgent.memory.addMany(messages);
+
+      const responseId = `resp_${uuidv4()}`;
+
+      if (requestBody.stream) {
+        res.setHeader("Content-Type", "text/event-stream");
+        res.setHeader("Cache-Control", "no-cache");
+        res.setHeader("Connection", "keep-alive");
+
+        let sequenceNumber = 0;
+        const outputItemId = `msg_${uuidv4()}`;
+        let accumulatedText = "";
+
+        const sendEvent = (eventType: string, data: unknown) => {
+          sequenceNumber++;
+          res.write(`event: ${eventType}\ndata: ${JSON.stringify(data)}\n\n`);
+        };
+
+        // response.created
+        const createdResponse: ResponsesResponse = {
+          id: responseId,
+          object: "response",
+          created: Math.floor(Date.now() / 1000),
+          status: "in_progress",
+          model: requestBody.model,
+        };
+
+        const createdEvent: ResponsesStreamResponseCreated = {
+          type: "response.created",
+          response: createdResponse,
+          sequence_number: sequenceNumber,
+        };
+        sendEvent("response.created", createdEvent);
+
+        // response.in_progress
+        const inProgressEvent: ResponsesStreamResponseInProgress = {
+          type: "response.in_progress",
+          response: { ...createdResponse },
+          sequence_number: sequenceNumber,
+        };
+        sendEvent("response.in_progress", inProgressEvent);
+
+        // response.output_item.added
+        const outputItem: ResponsesMessageOutput = {
+          type: "message",
+          id: outputItemId,
+          status: "in_progress",
+          role: "assistant",
+          content: [],
+        };
+        const outputItemAddedEvent: ResponsesStreamOutputItemAdded = {
+          type: "response.output_item.added",
+          item: outputItem,
+          output_index: 0,
+          sequence_number: sequenceNumber,
+        };
+        sendEvent("response.output_item.added", outputItemAddedEvent);
+
+        // response.content_part.added
+        const emptyPart: ResponsesStreamPartOutputText = {
+          text: "",
+          type: "response.output_text.done",
+          annotations: [],
+        };
+        const contentPartAddedEvent: ResponsesStreamContentPartAdded = {
+          type: "response.content_part.added",
+          content_index: 0,
+          item_id: outputItemId,
+          output_index: 0,
+          part: emptyPart,
+          sequence_number: sequenceNumber,
+        };
+        sendEvent("response.content_part.added", contentPartAddedEvent);
+
+        // Listen to agent emitter 'update' events for streaming deltas
+        (clonedAgent.emitter as any).on("update", async ({ update }: any) => {
+          const delta = update.value;
+          accumulatedText += delta;
+
+          const deltaEvent: ResponsesStreamOutputTextDelta = {
+            type: "response.output_text.delta",
+            content_index: 0,
+            delta,
+            item_id: outputItemId,
+            output_index: 0,
+            sequence_number: sequenceNumber,
+          };
+          sendEvent("response.output_text.delta", deltaEvent);
+        });
+
+        try {
+          await clonedAgent.run({ prompt: null });
+
+          // response.output_text.done
+          const textDoneEvent: ResponsesStreamOutputTextDone = {
+            type: "response.output_text.done",
+            content_index: 0,
+            text: accumulatedText,
+            item_id: outputItemId,
+            output_index: 0,
+            sequence_number: sequenceNumber,
+          };
+          sendEvent("response.output_text.done", textDoneEvent);
+
+          // response.content_part.done
+          const finalPart: ResponsesStreamPartOutputText = {
+            text: accumulatedText,
+            type: "response.output_text.done",
+            annotations: [],
+          };
+          const contentPartDoneEvent: ResponsesStreamContentPartDone = {
+            type: "response.content_part.done",
+            content_index: 0,
+            item_id: outputItemId,
+            output_index: 0,
+            part: finalPart,
+            sequence_number: sequenceNumber,
+          };
+          sendEvent("response.content_part.done", contentPartDoneEvent);
+
+          // response.output_item.done
+          const completedOutputItem: ResponsesMessageOutput = {
+            type: "message",
+            id: outputItemId,
+            status: "completed",
+            role: "assistant",
+            content: [{ type: "output_text", text: accumulatedText }],
+          };
+          const outputItemDoneEvent: ResponsesStreamOutputItemDone = {
+            type: "response.output_item.done",
+            item: completedOutputItem,
+            output_index: 0,
+            sequence_number: sequenceNumber,
+          };
+          sendEvent("response.output_item.done", outputItemDoneEvent);
+
+          // response.completed
+          const completedResponse: ResponsesResponse = {
+            id: responseId,
+            object: "response",
+            created: Math.floor(Date.now() / 1000),
+            status: "completed",
+            model: requestBody.model,
+            output: [completedOutputItem],
+          };
+          const completedEvent: ResponsesStreamResponseCompleted = {
+            type: "response.completed",
+            response: completedResponse,
+            sequence_number: sequenceNumber,
+          };
+          sendEvent("response.completed", completedEvent);
+        } catch (error) {
+          const errorEvent: ResponsesStreamError = {
+            type: "error",
+            code: "500",
+            message: String(error),
+            param: "",
+            sequence_number: sequenceNumber,
+          };
+          sendEvent("error", errorEvent);
+        }
+
+        res.end();
+      } else {
+        const result = (await clonedAgent.run({ prompt: null })) as ReActAgentRunOutput;
+
+        const messageContent: ResponsesMessageContent = {
+          type: "output_text",
+          text: result.result?.text ?? "",
+        };
+
+        const messageOutput: ResponsesMessageOutput = {
+          type: "message",
+          id: `msg_${uuidv4()}`,
+          status: "completed",
+          role: "assistant",
+          content: [messageContent],
+        };
+
+        const response: ResponsesResponse = {
+          id: responseId,
+          object: "response",
+          created: Math.floor(Date.now() / 1000),
+          status: "completed",
+          model: requestBody.model,
+          output: [messageOutput],
+          usage: {
+            input_tokens: 0,
+            output_tokens: 0,
+            total_tokens: 0,
+          },
+        };
+
+        res.json(response);
+      }
+    } catch (error) {
+      logger.error(error, "Error handling /responses request");
+      res.status(500).json({ error: String(error) });
+    }
+  }
+}

--- a/typescript/src/adapters/openai/serve/responses_api.ts
+++ b/typescript/src/adapters/openai/serve/responses_api.ts
@@ -50,9 +50,10 @@ export class ResponsesAPI {
     const requestBody = req.body as ResponsesRequestBody;
     logger.debug(`Received request: ${JSON.stringify(requestBody)}`);
 
-    const authHeader = req.headers.authorization;
     if (this.apiKey) {
-      if (!authHeader || authHeader.replace("Bearer ", "") !== this.apiKey) {
+      const authHeader = req.headers.authorization;
+      const token = Array.isArray(authHeader) ? authHeader[0] : authHeader;
+      if (!token || token.replace("Bearer ", "") !== this.apiKey) {
         res.status(401).json({ detail: "Missing or invalid API key" });
         return;
       }
@@ -156,7 +157,7 @@ export class ResponsesAPI {
         sendEvent("response.content_part.added", contentPartAddedEvent);
 
         // Listen to agent emitter 'update' events for streaming deltas
-        (clonedAgent.emitter as any).on("update", async ({ update }: any) => {
+        const updateListener = async ({ update }: any) => {
           const delta = update.value;
           accumulatedText += delta;
 
@@ -169,6 +170,13 @@ export class ResponsesAPI {
             sequence_number: sequenceNumber,
           };
           sendEvent("response.output_text.delta", deltaEvent);
+        };
+        
+        (clonedAgent.emitter as any).on("update", updateListener);
+
+        // Cleanup if client disconnects early
+        req.on("close", () => {
+          (clonedAgent.emitter as any).off("update", updateListener);
         });
 
         try {

--- a/typescript/src/adapters/openai/serve/responses_api.ts
+++ b/typescript/src/adapters/openai/serve/responses_api.ts
@@ -94,8 +94,9 @@ export class ResponsesAPI {
         const outputItemId = `msg_${uuidv4()}`;
         let accumulatedText = "";
 
-        const sendEvent = (eventType: string, data: unknown) => {
+        const sendEvent = (eventType: string, data: { sequence_number?: number }) => {
           sequenceNumber++;
+          data.sequence_number = sequenceNumber;
           if (res.writableEnded || res.destroyed) {
             return;
           }
@@ -118,7 +119,6 @@ export class ResponsesAPI {
         const createdEvent: ResponsesStreamResponseCreated = {
           type: "response.created",
           response: createdResponse,
-          sequence_number: sequenceNumber,
         };
         sendEvent("response.created", createdEvent);
 
@@ -126,7 +126,6 @@ export class ResponsesAPI {
         const inProgressEvent: ResponsesStreamResponseInProgress = {
           type: "response.in_progress",
           response: { ...createdResponse },
-          sequence_number: sequenceNumber,
         };
         sendEvent("response.in_progress", inProgressEvent);
 
@@ -142,7 +141,6 @@ export class ResponsesAPI {
           type: "response.output_item.added",
           item: outputItem,
           output_index: 0,
-          sequence_number: sequenceNumber,
         };
         sendEvent("response.output_item.added", outputItemAddedEvent);
 
@@ -158,7 +156,6 @@ export class ResponsesAPI {
           item_id: outputItemId,
           output_index: 0,
           part: emptyPart,
-          sequence_number: sequenceNumber,
         };
         sendEvent("response.content_part.added", contentPartAddedEvent);
 
@@ -174,17 +171,21 @@ export class ResponsesAPI {
           await clonedAgent
             .run({ prompt: null }, { signal: controller.signal })
             .observe((emitter) => {
-              // Match all events and filter for "update" — required because the
-              // emitter is typed as Emitter<unknown> at the AnyAgent abstraction.
+              // Match all events — required because the emitter is typed as
+              // Emitter<unknown> at the AnyAgent abstraction. We emit text deltas
+              // from "update" (ReActAgent incremental tokens) and from "success"
+              // (ToolCallingAgent emits only start/success, with the final answer
+              // in state.result). This keeps streaming working for both agents.
               emitter.match("*.*", async (data: any, event) => {
-                if (event.name !== "update") {
+                let delta: string | undefined;
+                if (event.name === "update") {
+                  delta = data?.update?.value;
+                } else if (event.name === "success") {
+                  delta = data?.state?.result?.text;
+                }
+                if (!delta || res.writableEnded || res.destroyed) {
                   return;
                 }
-                const { update } = data as { update: { value: string } };
-                if (res.writableEnded || res.destroyed) {
-                  return;
-                }
-                const delta = update.value;
                 accumulatedText += delta;
 
                 const deltaEvent: ResponsesStreamOutputTextDelta = {
@@ -193,7 +194,6 @@ export class ResponsesAPI {
                   delta,
                   item_id: outputItemId,
                   output_index: 0,
-                  sequence_number: sequenceNumber,
                 };
                 sendEvent("response.output_text.delta", deltaEvent);
               });
@@ -206,7 +206,6 @@ export class ResponsesAPI {
             text: accumulatedText,
             item_id: outputItemId,
             output_index: 0,
-            sequence_number: sequenceNumber,
           };
           sendEvent("response.output_text.done", textDoneEvent);
 
@@ -222,7 +221,6 @@ export class ResponsesAPI {
             item_id: outputItemId,
             output_index: 0,
             part: finalPart,
-            sequence_number: sequenceNumber,
           };
           sendEvent("response.content_part.done", contentPartDoneEvent);
 
@@ -238,7 +236,6 @@ export class ResponsesAPI {
             type: "response.output_item.done",
             item: completedOutputItem,
             output_index: 0,
-            sequence_number: sequenceNumber,
           };
           sendEvent("response.output_item.done", outputItemDoneEvent);
 
@@ -254,7 +251,6 @@ export class ResponsesAPI {
           const completedEvent: ResponsesStreamResponseCompleted = {
             type: "response.completed",
             response: completedResponse,
-            sequence_number: sequenceNumber,
           };
           sendEvent("response.completed", completedEvent);
         } catch (error) {
@@ -263,7 +259,6 @@ export class ResponsesAPI {
             code: "500",
             message: String(error),
             param: "",
-            sequence_number: sequenceNumber,
           };
           sendEvent("error", errorEvent);
         }

--- a/typescript/src/adapters/openai/serve/responses_api.ts
+++ b/typescript/src/adapters/openai/serve/responses_api.ts
@@ -96,7 +96,14 @@ export class ResponsesAPI {
 
         const sendEvent = (eventType: string, data: unknown) => {
           sequenceNumber++;
-          res.write(`event: ${eventType}\ndata: ${JSON.stringify(data)}\n\n`);
+          if (res.writableEnded || res.destroyed) {
+            return;
+          }
+          try {
+            res.write(`event: ${eventType}\ndata: ${JSON.stringify(data)}\n\n`);
+          } catch (writeErr) {
+            logger.error(writeErr, `Failed to write event ${eventType} to response`);
+          }
         };
 
         // response.created
@@ -155,18 +162,28 @@ export class ResponsesAPI {
         };
         sendEvent("response.content_part.added", contentPartAddedEvent);
 
+        // Abort the agent run if the client disconnects early
+        const controller = new AbortController();
+        req.on("close", () => {
+          controller.abort();
+        });
+
         try {
           // Use .observe() to subscribe to the run-scoped emitter — the correct
           // BeeAI pattern for intercepting agent events during a run.
           await clonedAgent
-            .run({ prompt: null })
+            .run({ prompt: null }, { signal: controller.signal })
             .observe((emitter) => {
               // Match all events and filter for "update" — required because the
               // emitter is typed as Emitter<unknown> at the AnyAgent abstraction.
               emitter.match("*.*", async (data: any, event) => {
-                if (event.name !== "update") return;
+                if (event.name !== "update") {
+                  return;
+                }
                 const { update } = data as { update: { value: string } };
-                if (res.writableEnded) return;
+                if (res.writableEnded || res.destroyed) {
+                  return;
+                }
                 const delta = update.value;
                 accumulatedText += delta;
 
@@ -251,7 +268,9 @@ export class ResponsesAPI {
           sendEvent("error", errorEvent);
         }
 
-        res.end();
+        if (!res.writableEnded && !res.destroyed) {
+          res.end();
+        }
       } else {
         const result = await clonedAgent.run({ prompt: null });
 
@@ -286,7 +305,9 @@ export class ResponsesAPI {
       }
     } catch (error) {
       logger.error(error, "Error handling /responses request");
-      res.status(500).json({ error: String(error) });
+      if (!res.headersSent) {
+        res.status(500).json({ error: String(error) });
+      }
     }
   }
 }

--- a/typescript/src/adapters/openai/serve/responses_api.ts
+++ b/typescript/src/adapters/openai/serve/responses_api.ts
@@ -53,7 +53,7 @@ export class ResponsesAPI {
     if (this.apiKey) {
       const authHeader = req.headers.authorization;
       const token = Array.isArray(authHeader) ? authHeader[0] : authHeader;
-      if (!token || token.replace("Bearer ", "") !== this.apiKey) {
+      if (!token || token.replace(/^Bearer\s+/i, "") !== this.apiKey) {
         res.status(401).json({ detail: "Missing or invalid API key" });
         return;
       }
@@ -157,7 +157,7 @@ export class ResponsesAPI {
         sendEvent("response.content_part.added", contentPartAddedEvent);
 
         // Listen to agent emitter 'update' events for streaming deltas
-        const updateListener = async ({ update }: any) => {
+        const updateListener = ({ update }: any) => {
           const delta = update.value;
           accumulatedText += delta;
 

--- a/typescript/src/adapters/openai/serve/responses_api.ts
+++ b/typescript/src/adapters/openai/serve/responses_api.ts
@@ -7,7 +7,6 @@ import express, { Request, Response, Router } from "express";
 import { v4 as uuidv4 } from "uuid";
 import { AnyAgent } from "@/agents/types.js";
 import { Logger } from "@/logger/logger.js";
-import { ReActAgentRunOutput } from "@/agents/react/types.js";
 import { SystemMessage, UserMessage, Message } from "@/backend/message.js";
 import { openaiInputToBeeAIMessage } from "./responses_utils.js";
 import {
@@ -143,7 +142,7 @@ export class ResponsesAPI {
         // response.content_part.added
         const emptyPart: ResponsesStreamPartOutputText = {
           text: "",
-          type: "response.output_text.done",
+          type: "output_text",
           annotations: [],
         };
         const contentPartAddedEvent: ResponsesStreamContentPartAdded = {
@@ -156,32 +155,32 @@ export class ResponsesAPI {
         };
         sendEvent("response.content_part.added", contentPartAddedEvent);
 
-        // Listen to agent emitter 'update' events for streaming deltas
-        const updateListener = ({ update }: any) => {
-          if (res.writableEnded) return;
-          const delta = update.value;
-          accumulatedText += delta;
-
-          const deltaEvent: ResponsesStreamOutputTextDelta = {
-            type: "response.output_text.delta",
-            content_index: 0,
-            delta,
-            item_id: outputItemId,
-            output_index: 0,
-            sequence_number: sequenceNumber,
-          };
-          sendEvent("response.output_text.delta", deltaEvent);
-        };
-        
-        (clonedAgent.emitter as any).on("update", updateListener);
-
-        // Cleanup if client disconnects early
-        req.on("close", () => {
-          (clonedAgent.emitter as any).off("update", updateListener);
-        });
-
         try {
-          await clonedAgent.run({ prompt: null });
+          // Use .observe() to subscribe to the run-scoped emitter — the correct
+          // BeeAI pattern for intercepting agent events during a run.
+          await clonedAgent
+            .run({ prompt: null })
+            .observe((emitter) => {
+              // Match all events and filter for "update" — required because the
+              // emitter is typed as Emitter<unknown> at the AnyAgent abstraction.
+              emitter.match("*.*", async (data: any, event) => {
+                if (event.name !== "update") return;
+                const { update } = data as { update: { value: string } };
+                if (res.writableEnded) return;
+                const delta = update.value;
+                accumulatedText += delta;
+
+                const deltaEvent: ResponsesStreamOutputTextDelta = {
+                  type: "response.output_text.delta",
+                  content_index: 0,
+                  delta,
+                  item_id: outputItemId,
+                  output_index: 0,
+                  sequence_number: sequenceNumber,
+                };
+                sendEvent("response.output_text.delta", deltaEvent);
+              });
+            });
 
           // response.output_text.done
           const textDoneEvent: ResponsesStreamOutputTextDone = {
@@ -197,7 +196,7 @@ export class ResponsesAPI {
           // response.content_part.done
           const finalPart: ResponsesStreamPartOutputText = {
             text: accumulatedText,
-            type: "response.output_text.done",
+            type: "output_text",
             annotations: [],
           };
           const contentPartDoneEvent: ResponsesStreamContentPartDone = {
@@ -254,7 +253,7 @@ export class ResponsesAPI {
 
         res.end();
       } else {
-        const result = (await clonedAgent.run({ prompt: null })) as ReActAgentRunOutput;
+        const result = await clonedAgent.run({ prompt: null });
 
         const messageContent: ResponsesMessageContent = {
           type: "output_text",

--- a/typescript/src/adapters/openai/serve/responses_api.ts
+++ b/typescript/src/adapters/openai/serve/responses_api.ts
@@ -158,6 +158,7 @@ export class ResponsesAPI {
 
         // Listen to agent emitter 'update' events for streaming deltas
         const updateListener = ({ update }: any) => {
+          if (res.writableEnded) return;
           const delta = update.value;
           accumulatedText += delta;
 

--- a/typescript/src/adapters/openai/serve/responses_types.ts
+++ b/typescript/src/adapters/openai/serve/responses_types.ts
@@ -1,0 +1,172 @@
+/**
+ * Copyright 2025 © BeeAI a Series of LF Projects, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// request
+
+export interface ResponsesRequestInputMessage {
+  role: "user" | "assistant" | "system" | "developer";
+  content: string | null;
+  type: string;
+}
+
+export interface ResponsesRequestConversation {
+  id: string;
+}
+
+export interface ResponsesRequestBody {
+  model: string;
+  input: string | ResponsesRequestInputMessage[];
+  instructions?: string | null;
+  conversation?: string | ResponsesRequestConversation | null;
+  stream?: boolean | null;
+}
+
+// response
+
+export interface ResponsesMessageContent {
+  type: "output_text";
+  text: string;
+}
+
+export interface ResponsesMessageOutput {
+  type: "message";
+  id: string;
+  status: string;
+  role: "assistant";
+  content: ResponsesMessageContent[];
+}
+
+export interface ResponsesReasoningContent {
+  type: "reasoning_text";
+  text: string;
+}
+
+export interface ResponsesReasoningSummary {
+  type: "summary_text";
+  text: string;
+}
+
+export interface ResponsesReasoningOutput {
+  type: "reasoning";
+  id: string;
+  status: string;
+  summary?: ResponsesReasoningSummary | null;
+  content?: ResponsesReasoningContent | null;
+}
+
+export interface ResponsesCustomToolCallOutput {
+  type: "custom_tool_call";
+  id: string;
+  name: string;
+  input: string;
+  call_id: string;
+}
+
+export interface ResponsesUsage {
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+}
+
+export type ResponsesResponseOutput =
+  | ResponsesMessageOutput
+  | ResponsesReasoningOutput
+  | ResponsesCustomToolCallOutput;
+
+export interface ResponsesResponse {
+  id: string;
+  object: "response";
+  created: number;
+  status: string;
+  error?: string | null;
+  instructions?: string | null;
+  model: string;
+  output?: ResponsesResponseOutput[] | null;
+  usage?: ResponsesUsage | null;
+}
+
+// stream
+
+export interface ResponsesStreamResponseCreated {
+  type: "response.created";
+  response: ResponsesResponse;
+  sequence_number: number;
+}
+
+export interface ResponsesStreamResponseInProgress {
+  type: "response.in_progress";
+  response: ResponsesResponse;
+  sequence_number: number;
+}
+
+export interface ResponsesStreamResponseCompleted {
+  type: "response.completed";
+  response: ResponsesResponse;
+  sequence_number: number;
+}
+
+export interface ResponsesStreamOutputItemAdded {
+  type: "response.output_item.added";
+  item: ResponsesResponseOutput;
+  output_index: number;
+  sequence_number: number;
+}
+
+export interface ResponsesStreamOutputItemDone {
+  type: "response.output_item.done";
+  item: ResponsesResponseOutput;
+  output_index: number;
+  sequence_number: number;
+}
+
+export interface ResponsesStreamPartOutputText {
+  text: string;
+  type: "response.output_text.done";
+  annotations: unknown[];
+}
+
+export interface ResponsesStreamContentPartAdded {
+  type: "response.content_part.added";
+  content_index: number;
+  item_id: string;
+  output_index: number;
+  part: ResponsesStreamPartOutputText;
+  sequence_number: number;
+}
+
+export interface ResponsesStreamContentPartDone {
+  type: "response.content_part.done";
+  content_index: number;
+  item_id: string;
+  output_index: number;
+  part: ResponsesStreamPartOutputText;
+  sequence_number: number;
+}
+
+export interface ResponsesStreamOutputTextDelta {
+  type: "response.output_text.delta";
+  content_index: number;
+  delta: string;
+  item_id: string;
+  output_index: number;
+  sequence_number: number;
+}
+
+export interface ResponsesStreamOutputTextDone {
+  type: "response.output_text.done";
+  content_index: number;
+  text: string;
+  item_id: string;
+  output_index: number;
+  sequence_number: number;
+}
+
+export interface ResponsesStreamError {
+  type: "error";
+  code: string;
+  message: string;
+  param: string;
+  sequence_number: number;
+}

--- a/typescript/src/adapters/openai/serve/responses_types.ts
+++ b/typescript/src/adapters/openai/serve/responses_types.ts
@@ -92,33 +92,33 @@ export interface ResponsesResponse {
 export interface ResponsesStreamResponseCreated {
   type: "response.created";
   response: ResponsesResponse;
-  sequence_number: number;
+  sequence_number?: number;
 }
 
 export interface ResponsesStreamResponseInProgress {
   type: "response.in_progress";
   response: ResponsesResponse;
-  sequence_number: number;
+  sequence_number?: number;
 }
 
 export interface ResponsesStreamResponseCompleted {
   type: "response.completed";
   response: ResponsesResponse;
-  sequence_number: number;
+  sequence_number?: number;
 }
 
 export interface ResponsesStreamOutputItemAdded {
   type: "response.output_item.added";
   item: ResponsesResponseOutput;
   output_index: number;
-  sequence_number: number;
+  sequence_number?: number;
 }
 
 export interface ResponsesStreamOutputItemDone {
   type: "response.output_item.done";
   item: ResponsesResponseOutput;
   output_index: number;
-  sequence_number: number;
+  sequence_number?: number;
 }
 
 export interface ResponsesStreamPartOutputText {
@@ -133,7 +133,7 @@ export interface ResponsesStreamContentPartAdded {
   item_id: string;
   output_index: number;
   part: ResponsesStreamPartOutputText;
-  sequence_number: number;
+  sequence_number?: number;
 }
 
 export interface ResponsesStreamContentPartDone {
@@ -142,7 +142,7 @@ export interface ResponsesStreamContentPartDone {
   item_id: string;
   output_index: number;
   part: ResponsesStreamPartOutputText;
-  sequence_number: number;
+  sequence_number?: number;
 }
 
 export interface ResponsesStreamOutputTextDelta {
@@ -151,7 +151,7 @@ export interface ResponsesStreamOutputTextDelta {
   delta: string;
   item_id: string;
   output_index: number;
-  sequence_number: number;
+  sequence_number?: number;
 }
 
 export interface ResponsesStreamOutputTextDone {
@@ -160,7 +160,7 @@ export interface ResponsesStreamOutputTextDone {
   text: string;
   item_id: string;
   output_index: number;
-  sequence_number: number;
+  sequence_number?: number;
 }
 
 export interface ResponsesStreamError {
@@ -168,5 +168,5 @@ export interface ResponsesStreamError {
   code: string;
   message: string;
   param: string;
-  sequence_number: number;
+  sequence_number?: number;
 }

--- a/typescript/src/adapters/openai/serve/responses_types.ts
+++ b/typescript/src/adapters/openai/serve/responses_types.ts
@@ -123,7 +123,7 @@ export interface ResponsesStreamOutputItemDone {
 
 export interface ResponsesStreamPartOutputText {
   text: string;
-  type: "response.output_text.done";
+  type: "output_text";
   annotations: unknown[];
 }
 

--- a/typescript/src/adapters/openai/serve/responses_utils.ts
+++ b/typescript/src/adapters/openai/serve/responses_utils.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2025 © BeeAI a Series of LF Projects, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ResponsesRequestInputMessage } from "./responses_types.js";
+import { Message, UserMessage, AssistantMessage, SystemMessage } from "@/backend/message.js";
+
+export function openaiInputToBeeAIMessage(message: ResponsesRequestInputMessage): Message {
+  switch (message.role) {
+    case "user":
+      return new UserMessage(message.content ?? "");
+    case "system":
+    case "developer":
+      return new SystemMessage(message.content ?? "");
+    case "assistant":
+      return new AssistantMessage(message.content ?? "");
+    default:
+      throw new Error(`Invalid role: ${message.role}`);
+  }
+}

--- a/typescript/src/adapters/openai/serve/server.ts
+++ b/typescript/src/adapters/openai/serve/server.ts
@@ -73,12 +73,20 @@ export class OpenAIServer extends Server<AnyAgent, AnyAgent, OpenAIServerConfig,
     // Also mount at root for direct access
     app.use("/", api.router);
 
-    app.listen(this.config.port, this.config.host, () => {
-      this.ready = true;
-      logger.info(
-        `OpenAI-compatible server started on http://${this.config.host}:${this.config.port}`,
-      );
-      logger.info(`Press Ctrl+C to stop the server`);
+    return new Promise((resolve, reject) => {
+      const server = app.listen(this.config.port, this.config.host, () => {
+        this.ready = true;
+        logger.info(
+          `OpenAI-compatible server started on http://${this.config.host}:${this.config.port}`,
+        );
+        logger.info(`Press Ctrl+C to stop the server`);
+        resolve();
+      });
+
+      server.on("error", (error) => {
+        logger.error(error, "Failed to start server");
+        reject(error);
+      });
     });
   }
 }

--- a/typescript/src/adapters/openai/serve/server.ts
+++ b/typescript/src/adapters/openai/serve/server.ts
@@ -9,7 +9,10 @@ import { Server } from "@/serve/server.js";
 import express from "express";
 import { Logger } from "@/logger/logger.js";
 import { ChatCompletionAPI } from "./api.js";
+import { ResponsesAPI } from "./responses_api.js";
 import { ValueError } from "@/errors.js";
+
+export type OpenAIAPIType = "chat-completion" | "responses";
 
 const logger = Logger.root.child({
   name: "OpenAI server",
@@ -18,6 +21,7 @@ const logger = Logger.root.child({
 export class OpenAIServerConfig {
   host = "0.0.0.0";
   port = 9999;
+  api: OpenAIAPIType = "chat-completion";
   apiKey?: string;
 }
 
@@ -59,11 +63,14 @@ export class OpenAIServer extends Server<AnyAgent, AnyAgent, OpenAIServerConfig,
       return member;
     };
 
-    const api = new ChatCompletionAPI(modelFactory, this.config.apiKey);
-    
+    const api =
+      this.config.api === "responses"
+        ? new ResponsesAPI(modelFactory, this.config.apiKey)
+        : new ChatCompletionAPI(modelFactory, this.config.apiKey);
+
     // Mount the API under /v1 to simulate standard OpenAI structure
     app.use("/v1", api.router);
-    // Also mount at root for /chat/completions if users ping root
+    // Also mount at root for direct access
     app.use("/", api.router);
 
     app.listen(this.config.port, this.config.host, () => {

--- a/typescript/src/adapters/openai/serve/server.ts
+++ b/typescript/src/adapters/openai/serve/server.ts
@@ -30,7 +30,12 @@ export interface OpenAIServerMetadata {
   description?: string;
 }
 
-export class OpenAIServer extends Server<AnyAgent, AnyAgent, OpenAIServerConfig, OpenAIServerMetadata> {
+export class OpenAIServer extends Server<
+  AnyAgent,
+  AnyAgent,
+  OpenAIServerConfig,
+  OpenAIServerMetadata
+> {
   private ready = false;
 
   constructor(config: OpenAIServerConfig = new OpenAIServerConfig()) {
@@ -53,9 +58,9 @@ export class OpenAIServer extends Server<AnyAgent, AnyAgent, OpenAIServerConfig,
       // Find the first agent that matches the requested model ID by name.
       // If the client doesn't pass a specific name or it doesn't match, we fallback to the first member.
       const matchedMember = this.members.find(
-        (m) => this.metadataByInput.get(m)?.name === modelId || m.meta.name === modelId
+        (m) => this.metadataByInput.get(m)?.name === modelId || m.meta.name === modelId,
       );
-      
+
       const member = matchedMember ?? this.members[0];
       if (!member) {
         throw new ValueError(`Model '${modelId}' not registered`);

--- a/typescript/src/adapters/openai/serve/server.ts
+++ b/typescript/src/adapters/openai/serve/server.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2025 © BeeAI a Series of LF Projects, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AnyAgent } from "@/agents/types.js";
+import { BaseAgent } from "@/agents/base.js";
+import { Server } from "@/serve/server.js";
+import express from "express";
+import { Logger } from "@/logger/logger.js";
+import { ChatCompletionAPI } from "./api.js";
+import { ValueError } from "@/errors.js";
+
+const logger = Logger.root.child({
+  name: "OpenAI server",
+});
+
+export class OpenAIServerConfig {
+  host = "0.0.0.0";
+  port = 9999;
+  apiKey?: string;
+}
+
+export interface OpenAIServerMetadata {
+  name?: string;
+  description?: string;
+}
+
+export class OpenAIServer extends Server<AnyAgent, AnyAgent, OpenAIServerConfig, OpenAIServerMetadata> {
+  private ready = false;
+
+  constructor(config: OpenAIServerConfig = new OpenAIServerConfig()) {
+    super(config);
+  }
+
+  public register(input: AnyAgent, metadata?: OpenAIServerMetadata) {
+    super.register(input, metadata);
+    return this;
+  }
+
+  public async serve(): Promise<void> {
+    if (this.members.length === 0) {
+      throw new ValueError("No agents registered to the server.");
+    }
+
+    const app = express();
+
+    const modelFactory = async (modelId: string): Promise<AnyAgent> => {
+      // Find the first agent that matches the requested model ID by name.
+      // If the client doesn't pass a specific name or it doesn't match, we fallback to the first member.
+      const matchedMember = this.members.find(
+        (m) => this.metadataByInput.get(m)?.name === modelId || m.meta.name === modelId
+      );
+      
+      const member = matchedMember ?? this.members[0];
+      if (!member) {
+        throw new ValueError(`Model '${modelId}' not registered`);
+      }
+      return member;
+    };
+
+    const api = new ChatCompletionAPI(modelFactory, this.config.apiKey);
+    
+    // Mount the API under /v1 to simulate standard OpenAI structure
+    app.use("/v1", api.router);
+    // Also mount at root for /chat/completions if users ping root
+    app.use("/", api.router);
+
+    app.listen(this.config.port, this.config.host, () => {
+      this.ready = true;
+      logger.info(
+        `OpenAI-compatible server started on http://${this.config.host}:${this.config.port}`,
+      );
+      logger.info(`Press Ctrl+C to stop the server`);
+    });
+  }
+}
+
+const defaultAgentFactory = async (
+  agent: AnyAgent,
+  _?: OpenAIServerMetadata,
+): Promise<AnyAgent> => {
+  return agent;
+};
+
+// Assuming all agents can be wrapped this way as an interim abstraction
+// Since BaseAgent is the base abstraction.
+OpenAIServer.registerFactory(BaseAgent, defaultAgentFactory);

--- a/typescript/src/adapters/openai/serve/server.ts
+++ b/typescript/src/adapters/openai/serve/server.ts
@@ -68,10 +68,8 @@ export class OpenAIServer extends Server<AnyAgent, AnyAgent, OpenAIServerConfig,
         ? new ResponsesAPI(modelFactory, this.config.apiKey)
         : new ChatCompletionAPI(modelFactory, this.config.apiKey);
 
-    // Mount the API under /v1 to simulate standard OpenAI structure
+    // Mount the API under /v1 to follow the standard OpenAI URL structure
     app.use("/v1", api.router);
-    // Also mount at root for direct access
-    app.use("/", api.router);
 
     return new Promise((resolve, reject) => {
       const server = app.listen(this.config.port, this.config.host, () => {

--- a/typescript/src/adapters/openai/serve/server.ts
+++ b/typescript/src/adapters/openai/serve/server.ts
@@ -14,15 +14,26 @@ import { ValueError } from "@/errors.js";
 
 export type OpenAIAPIType = "chat-completion" | "responses";
 
-const logger = Logger.root.child({
+export const logger = Logger.root.child({
   name: "OpenAI server",
 });
 
+const LOOPBACK_HOSTS = ["127.0.0.1", "localhost", "::1"];
+
 export class OpenAIServerConfig {
-  host = "0.0.0.0";
+  // Bind to loopback by default. The endpoints are unauthenticated unless `apiKey`
+  // is set, so binding to all interfaces ("0.0.0.0") is opt-in to avoid exposing an
+  // unauthenticated server to the network by default.
+  host = "127.0.0.1";
   port = 9999;
   api: OpenAIAPIType = "chat-completion";
   apiKey?: string;
+
+  constructor(partial?: Partial<OpenAIServerConfig>) {
+    if (partial) {
+      Object.assign(this, partial);
+    }
+  }
 }
 
 export interface OpenAIServerMetadata {
@@ -38,8 +49,8 @@ export class OpenAIServer extends Server<
 > {
   private ready = false;
 
-  constructor(config: OpenAIServerConfig = new OpenAIServerConfig()) {
-    super(config);
+  constructor(config?: Partial<OpenAIServerConfig>) {
+    super(config ? new OpenAIServerConfig(config) : new OpenAIServerConfig());
   }
 
   public register(input: AnyAgent, metadata?: OpenAIServerMetadata) {
@@ -53,6 +64,14 @@ export class OpenAIServer extends Server<
     }
 
     const app = express();
+
+    if (this.config.apiKey === undefined && !LOOPBACK_HOSTS.includes(this.config.host)) {
+      logger.warn(
+        `OpenAIServer is binding to a non-loopback host (${this.config.host}) with no \`apiKey\` set: ` +
+          `the API will be reachable from the network without authentication. ` +
+          `Set \`apiKey\` in the config, or bind to 127.0.0.1, to avoid exposing it.`,
+      );
+    }
 
     const modelFactory = async (modelId: string): Promise<AnyAgent> => {
       // Find the first agent that matches the requested model ID by name.

--- a/typescript/src/adapters/openai/serve/types.ts
+++ b/typescript/src/adapters/openai/serve/types.ts
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2025 © BeeAI a Series of LF Projects, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export interface ChatMessage {
+  role: "system" | "user" | "assistant" | "tool";
+  content: string | null;
+  name?: string;
+  tool_calls?: {
+    id: string;
+    type: "function";
+    function: { name: string; arguments: string };
+  }[];
+  tool_call_id?: string;
+}
+
+export interface ChatCompletionRequestBody {
+  model: string;
+  messages: ChatMessage[];
+  stream?: boolean;
+}
+
+export interface ChatCompletionChoice {
+  index: number;
+  message: {
+    role: "assistant";
+    content: string | null;
+    tool_calls?: {
+      id: string;
+      type: "function";
+      function: { name: string; arguments: string };
+    }[];
+  };
+  finish_reason: string | null;
+}
+
+export interface ChatCompletionUsage {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+}
+
+export interface ChatCompletionResponse {
+  id: string;
+  object: "chat.completion";
+  created: number;
+  model: string;
+  choices: ChatCompletionChoice[];
+  usage?: ChatCompletionUsage;
+}
+
+export interface ChatCompletionChunkChoice {
+  index: number;
+  delta: {
+    role?: "assistant";
+    content?: string | null;
+    tool_calls?: {
+      id?: string;
+      type?: "function";
+      function?: { name?: string; arguments?: string };
+    }[];
+  };
+  finish_reason: string | null;
+}
+
+export interface ChatCompletionChunk {
+  id: string;
+  object: "chat.completion.chunk";
+  created: number;
+  model: string;
+  choices: ChatCompletionChunkChoice[];
+}

--- a/typescript/src/adapters/openai/serve/utils.ts
+++ b/typescript/src/adapters/openai/serve/utils.ts
@@ -24,13 +24,21 @@ export function openaiMessageToBeeAIMessage(msg: ChatMessage): Message {
     const assistantMsg = new AssistantMessage(msg.content ?? "");
     if (msg.tool_calls) {
       for (const call of msg.tool_calls) {
-        assistantMsg.content.push({
-          type: "tool-call",
-          toolCallId: call.id, // Vercel AI SDK style
-          toolName: call.function.name,
-          args: JSON.parse(call.function.arguments || "{}"),
-          input: JSON.parse(call.function.arguments || "{}"), // BeeAI style
-        } as any);
+          let args = {};
+          try {
+            args = JSON.parse(call.function.arguments || "{}");
+          } catch (e) {
+            // Model generated invalid JSON for arguments, fallback to empty object
+            // to allow execution to proceed gracefully
+          }
+          
+          assistantMsg.content.push({
+            type: "tool-call",
+            toolCallId: call.id, // Vercel AI SDK style
+            toolName: call.function.name,
+            args: args,
+            input: args, // BeeAI style
+          } as any);
       }
     }
     return assistantMsg;

--- a/typescript/src/adapters/openai/serve/utils.ts
+++ b/typescript/src/adapters/openai/serve/utils.ts
@@ -24,21 +24,21 @@ export function openaiMessageToBeeAIMessage(msg: ChatMessage): Message {
     const assistantMsg = new AssistantMessage(msg.content ?? "");
     if (msg.tool_calls) {
       for (const call of msg.tool_calls) {
-          let args = {};
-          try {
-            args = JSON.parse(call.function.arguments || "{}");
-          } catch (e) {
-            // Model generated invalid JSON for arguments, fallback to empty object
-            // to allow execution to proceed gracefully
-          }
-          
-          assistantMsg.content.push({
-            type: "tool-call",
-            toolCallId: call.id, // Vercel AI SDK style
-            toolName: call.function.name,
-            args: args,
-            input: args, // BeeAI style
-          } as any);
+        let args = {};
+        try {
+          args = JSON.parse(call.function.arguments || "{}");
+        } catch (e) {
+          // Model generated invalid JSON for arguments, fallback to empty object
+          // to allow execution to proceed gracefully
+        }
+
+        assistantMsg.content.push({
+          type: "tool-call",
+          toolCallId: call.id, // Vercel AI SDK style
+          toolName: call.function.name,
+          args: args,
+          input: args, // BeeAI style
+        } as any);
       }
     }
     return assistantMsg;
@@ -55,9 +55,7 @@ export function transformRequestMessages(inputs: ChatMessage[]): Message[] {
     const nextMsg = converted[i + 1];
     const nextNextMsg = converted[i + 2];
 
-    if (msg instanceof SystemMessage) {
-      continue;
-    }
+    // Pass system messages through so the agent memory respects them.
 
     // Ported from Python: Remove a handoff tool call if it's the last pair
     if (

--- a/typescript/src/adapters/openai/serve/utils.ts
+++ b/typescript/src/adapters/openai/serve/utils.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2025 © BeeAI a Series of LF Projects, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ChatMessage } from "./types.js";
+import { Message, UserMessage, AssistantMessage, SystemMessage, ToolMessage } from "@/backend/message.js";
+
+export function openaiMessageToBeeAIMessage(msg: ChatMessage): Message {
+  if (msg.role === "system") {
+    return new SystemMessage(msg.content ?? "");
+  } else if (msg.role === "user") {
+    return new UserMessage(msg.content ?? "");
+  } else if (msg.role === "tool") {
+    // any cast to workaround ToolResultPart typings from different ai packages or BeeAI wrapper
+    return new ToolMessage({
+      type: "tool-result",
+      toolCallId: msg.tool_call_id!,
+      toolName: msg.name || "",
+      result: msg.content,
+      output: { type: "text", value: msg.content },
+    } as any);
+  } else if (msg.role === "assistant") {
+    const assistantMsg = new AssistantMessage(msg.content ?? "");
+    if (msg.tool_calls) {
+      for (const call of msg.tool_calls) {
+        assistantMsg.content.push({
+          type: "tool-call",
+          toolCallId: call.id, // Vercel AI SDK style
+          toolName: call.function.name,
+          args: JSON.parse(call.function.arguments || "{}"),
+          input: JSON.parse(call.function.arguments || "{}"), // BeeAI style
+        } as any);
+      }
+    }
+    return assistantMsg;
+  }
+  throw new Error(`Unsupported role: ${msg.role}`);
+}
+
+export function transformRequestMessages(inputs: ChatMessage[]): Message[] {
+  const messages: Message[] = [];
+  const converted = inputs.map(openaiMessageToBeeAIMessage);
+
+  for (let i = 0; i < converted.length; i++) {
+    const msg = converted[i];
+    const nextMsg = converted[i + 1];
+    const nextNextMsg = converted[i + 2];
+
+    if (msg instanceof SystemMessage) {
+      continue;
+    }
+
+    // Ported from Python: Remove a handoff tool call if it's the last pair
+    if (
+      nextNextMsg === undefined &&
+      msg instanceof AssistantMessage &&
+      msg.getToolCalls().length > 0 &&
+      nextMsg instanceof ToolMessage &&
+      nextMsg.getToolResults().length > 0 &&
+      // Vercel AI SDK uses toolCallId for both tool-call and tool-result
+      (msg.getToolCalls()[0] as any).toolCallId === nextMsg.getToolResults()[0].toolCallId &&
+      msg.getToolCalls()[0].toolName.toLowerCase().startsWith("transfer_to_")
+    ) {
+      break;
+    }
+
+    messages.push(msg);
+  }
+
+  return messages;
+}

--- a/typescript/src/adapters/openai/serve/utils.ts
+++ b/typescript/src/adapters/openai/serve/utils.ts
@@ -4,7 +4,13 @@
  */
 
 import { ChatMessage } from "./types.js";
-import { Message, UserMessage, AssistantMessage, SystemMessage, ToolMessage } from "@/backend/message.js";
+import {
+  Message,
+  UserMessage,
+  AssistantMessage,
+  SystemMessage,
+  ToolMessage,
+} from "@/backend/message.js";
 
 export function openaiMessageToBeeAIMessage(msg: ChatMessage): Message {
   if (msg.role === "system") {
@@ -27,7 +33,7 @@ export function openaiMessageToBeeAIMessage(msg: ChatMessage): Message {
         let args = {};
         try {
           args = JSON.parse(call.function.arguments || "{}");
-        } catch (e) {
+        } catch {
           // Model generated invalid JSON for arguments, fallback to empty object
           // to allow execution to proceed gracefully
         }

--- a/typescript/tests/adapters/openai/serve/server.test.ts
+++ b/typescript/tests/adapters/openai/serve/server.test.ts
@@ -3,17 +3,41 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { openaiMessageToBeeAIMessage } from "@/adapters/openai/serve/utils.js";
 import { openaiInputToBeeAIMessage } from "@/adapters/openai/serve/responses_utils.js";
 import { UserMessage, SystemMessage, AssistantMessage, ToolMessage } from "@/backend/message.js";
+import { OpenAIServer, OpenAIServerConfig, logger } from "@/adapters/openai/serve/server.js";
+import { BaseAgent } from "@/agents/base.js";
+import { Emitter } from "@/emitter/emitter.js";
+import { UnconstrainedMemory } from "@/memory/unconstrainedMemory.js";
+import type { AnyAgent } from "@/agents/types.js";
+
+const INSECURE_WARNING_FRAGMENT = "without authentication";
+
+function hasInsecureWarning(warnings: string[]): boolean {
+  return warnings.some((w) => w.includes(INSECURE_WARNING_FRAGMENT));
+}
+
+class DummyAgent extends BaseAgent<unknown, unknown> {
+  public readonly emitter = new Emitter();
+  public memory = new UnconstrainedMemory();
+
+  protected _run(): Promise<unknown> {
+    return Promise.resolve("pong");
+  }
+}
+
+function createDummyAgent(): AnyAgent {
+  return new DummyAgent() as unknown as AnyAgent;
+}
 
 describe("OpenAIServer utils", () => {
   describe("openaiMessageToBeeAIMessage", () => {
     it("converts user messages correctly", () => {
       const msg = openaiMessageToBeeAIMessage({
         role: "user",
-        content: "Hello world"
+        content: "Hello world",
       });
       expect(msg).toBeInstanceOf(UserMessage);
       expect(msg.text).toBe("Hello world");
@@ -22,7 +46,7 @@ describe("OpenAIServer utils", () => {
     it("converts system messages correctly", () => {
       const msg = openaiMessageToBeeAIMessage({
         role: "system",
-        content: "You are a helpful assistant"
+        content: "You are a helpful assistant",
       });
       expect(msg).toBeInstanceOf(SystemMessage);
       expect(msg.text).toBe("You are a helpful assistant");
@@ -31,7 +55,7 @@ describe("OpenAIServer utils", () => {
     it("converts assistant messages correctly", () => {
       const msg = openaiMessageToBeeAIMessage({
         role: "assistant",
-        content: "Sure, I can help"
+        content: "Sure, I can help",
       });
       expect(msg).toBeInstanceOf(AssistantMessage);
       expect(msg.text).toBe("Sure, I can help");
@@ -47,10 +71,10 @@ describe("OpenAIServer utils", () => {
             type: "function",
             function: {
               name: "get_weather",
-              arguments: "{\"location\":\"New York\"}"
-            }
-          }
-        ]
+              arguments: '{"location":"New York"}',
+            },
+          },
+        ],
       });
       expect(msg).toBeInstanceOf(AssistantMessage);
       const toolCalls = (msg as AssistantMessage).getToolCalls();
@@ -63,7 +87,7 @@ describe("OpenAIServer utils", () => {
         role: "tool",
         content: "Sunny",
         tool_call_id: "call_123",
-        name: "get_weather"
+        name: "get_weather",
       });
       expect(msg).toBeInstanceOf(ToolMessage);
       const toolResults = (msg as ToolMessage).getToolResults();
@@ -132,8 +156,78 @@ describe("Responses API utils", () => {
           role: "invalid" as any,
           content: "test",
           type: "message",
-        })
+        }),
       ).toThrow("Invalid role: invalid");
     });
+  });
+});
+
+// Prevent express from actually binding a port. The serve() method calls
+// app.listen(port, host, cb); we capture and immediately invoke the callback.
+const { mockExpressApp, mockExpressRouter, mockExpressJson, listenMock } = vi.hoisted(() => {
+  const listenMock = vi.fn((_port: number, _host: string, cb?: () => void) => {
+    cb?.();
+    return { on: vi.fn() };
+  });
+  const mockExpressApp = vi.fn(() => ({
+    use: vi.fn(),
+    listen: listenMock,
+  }));
+  const mockExpressRouter = { use: vi.fn(), post: vi.fn() };
+  const mockExpressJson = vi.fn(() => vi.fn());
+  return { mockExpressApp, mockExpressRouter, mockExpressJson, listenMock };
+});
+
+vi.mock("express", () => ({
+  default: Object.assign(mockExpressApp, {
+    Router: vi.fn(() => mockExpressRouter),
+    json: mockExpressJson,
+  }),
+  Router: vi.fn(() => mockExpressRouter),
+  json: mockExpressJson,
+}));
+
+describe("OpenAIServer config & warnings", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let capturedWarnings: string[];
+
+  beforeEach(() => {
+    capturedWarnings = [];
+    listenMock.mockClear();
+    warnSpy = vi.spyOn(logger, "warn").mockImplementation((msg: unknown) => {
+      capturedWarnings.push(typeof msg === "string" ? msg : String(msg));
+      return logger;
+    });
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("defaults host to loopback and leaves apiKey unset", () => {
+    const config = new OpenAIServerConfig();
+    expect(config.host).toBe("127.0.0.1");
+    expect(config.apiKey).toBeUndefined();
+  });
+
+  it("warns when binding to a non-loopback host with no apiKey", async () => {
+    const server = new OpenAIServer({ host: "0.0.0.0", apiKey: undefined });
+    server.register(createDummyAgent(), { name: "dummy-model" });
+    await server.serve();
+    expect(hasInsecureWarning(capturedWarnings)).toBe(true);
+  });
+
+  it("does not warn on loopback host with no apiKey", async () => {
+    const server = new OpenAIServer({ host: "127.0.0.1", apiKey: undefined });
+    server.register(createDummyAgent(), { name: "dummy-model" });
+    await server.serve();
+    expect(hasInsecureWarning(capturedWarnings)).toBe(false);
+  });
+
+  it("does not warn on non-loopback host when apiKey is set", async () => {
+    const server = new OpenAIServer({ host: "0.0.0.0", apiKey: "secret" });
+    server.register(createDummyAgent(), { name: "dummy-model" });
+    await server.serve();
+    expect(hasInsecureWarning(capturedWarnings)).toBe(false);
   });
 });

--- a/typescript/tests/adapters/openai/serve/server.test.ts
+++ b/typescript/tests/adapters/openai/serve/server.test.ts
@@ -5,6 +5,7 @@
 
 import { describe, it, expect } from "vitest";
 import { openaiMessageToBeeAIMessage } from "@/adapters/openai/serve/utils.js";
+import { openaiInputToBeeAIMessage } from "@/adapters/openai/serve/responses_utils.js";
 import { UserMessage, SystemMessage, AssistantMessage, ToolMessage } from "@/backend/message.js";
 
 describe("OpenAIServer utils", () => {
@@ -69,6 +70,70 @@ describe("OpenAIServer utils", () => {
       expect(toolResults).toHaveLength(1);
       expect(toolResults[0].toolName).toBe("get_weather");
       expect(toolResults[0].toolCallId).toBe("call_123");
+    });
+  });
+});
+
+describe("Responses API utils", () => {
+  describe("openaiInputToBeeAIMessage", () => {
+    it("converts user messages correctly", () => {
+      const msg = openaiInputToBeeAIMessage({
+        role: "user",
+        content: "Hello",
+        type: "message",
+      });
+      expect(msg).toBeInstanceOf(UserMessage);
+      expect(msg.text).toBe("Hello");
+    });
+
+    it("converts system messages correctly", () => {
+      const msg = openaiInputToBeeAIMessage({
+        role: "system",
+        content: "Be helpful",
+        type: "message",
+      });
+      expect(msg).toBeInstanceOf(SystemMessage);
+      expect(msg.text).toBe("Be helpful");
+    });
+
+    it("converts developer messages to SystemMessage", () => {
+      const msg = openaiInputToBeeAIMessage({
+        role: "developer",
+        content: "Developer instruction",
+        type: "message",
+      });
+      expect(msg).toBeInstanceOf(SystemMessage);
+      expect(msg.text).toBe("Developer instruction");
+    });
+
+    it("converts assistant messages correctly", () => {
+      const msg = openaiInputToBeeAIMessage({
+        role: "assistant",
+        content: "I can help",
+        type: "message",
+      });
+      expect(msg).toBeInstanceOf(AssistantMessage);
+      expect(msg.text).toBe("I can help");
+    });
+
+    it("handles null content as empty string", () => {
+      const msg = openaiInputToBeeAIMessage({
+        role: "user",
+        content: null,
+        type: "message",
+      });
+      expect(msg).toBeInstanceOf(UserMessage);
+      expect(msg.text).toBe("");
+    });
+
+    it("throws on invalid role", () => {
+      expect(() =>
+        openaiInputToBeeAIMessage({
+          role: "invalid" as any,
+          content: "test",
+          type: "message",
+        })
+      ).toThrow("Invalid role: invalid");
     });
   });
 });

--- a/typescript/tests/adapters/openai/serve/server.test.ts
+++ b/typescript/tests/adapters/openai/serve/server.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2025 © BeeAI a Series of LF Projects, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from "vitest";
+import { openaiMessageToBeeAIMessage } from "@/adapters/openai/serve/utils.js";
+import { UserMessage, SystemMessage, AssistantMessage, ToolMessage } from "@/backend/message.js";
+
+describe("OpenAIServer utils", () => {
+  describe("openaiMessageToBeeAIMessage", () => {
+    it("converts user messages correctly", () => {
+      const msg = openaiMessageToBeeAIMessage({
+        role: "user",
+        content: "Hello world"
+      });
+      expect(msg).toBeInstanceOf(UserMessage);
+      expect(msg.text).toBe("Hello world");
+    });
+
+    it("converts system messages correctly", () => {
+      const msg = openaiMessageToBeeAIMessage({
+        role: "system",
+        content: "You are a helpful assistant"
+      });
+      expect(msg).toBeInstanceOf(SystemMessage);
+      expect(msg.text).toBe("You are a helpful assistant");
+    });
+
+    it("converts assistant messages correctly", () => {
+      const msg = openaiMessageToBeeAIMessage({
+        role: "assistant",
+        content: "Sure, I can help"
+      });
+      expect(msg).toBeInstanceOf(AssistantMessage);
+      expect(msg.text).toBe("Sure, I can help");
+    });
+
+    it("converts assistant tool calls correctly", () => {
+      const msg = openaiMessageToBeeAIMessage({
+        role: "assistant",
+        content: null,
+        tool_calls: [
+          {
+            id: "call_123",
+            type: "function",
+            function: {
+              name: "get_weather",
+              arguments: "{\"location\":\"New York\"}"
+            }
+          }
+        ]
+      });
+      expect(msg).toBeInstanceOf(AssistantMessage);
+      const toolCalls = (msg as AssistantMessage).getToolCalls();
+      expect(toolCalls).toHaveLength(1);
+      expect(toolCalls[0].toolName).toBe("get_weather");
+    });
+
+    it("converts tool messages correctly", () => {
+      const msg = openaiMessageToBeeAIMessage({
+        role: "tool",
+        content: "Sunny",
+        tool_call_id: "call_123",
+        name: "get_weather"
+      });
+      expect(msg).toBeInstanceOf(ToolMessage);
+      const toolResults = (msg as ToolMessage).getToolResults();
+      expect(toolResults).toHaveLength(1);
+      expect(toolResults[0].toolName).toBe("get_weather");
+      expect(toolResults[0].toolCallId).toBe("call_123");
+    });
+  });
+});


### PR DESCRIPTION
### Which issue(s) does this pull-request address?

Closes: #1479

### Description

Adds an OpenAI-compatible server adapter for TypeScript, porting the functionality from the existing Python implementation (`python/beeai_framework/adapters/openai/serve`).

This exposes any BeeAI agent as a standard OpenAI `/v1/chat/completions` and `/v1/responses` endpoint, enabling integration with tools like Watsonx Orchestrate that consume these APIs (ref: discussion #1008).

**What's included:**
- `OpenAIServer` class following the same pattern as the existing `A2AServer` and `MCPServer` adapters, using `BaseAgent` as the interim abstraction. Configurable via `api: "chat-completion" | "responses"`.
- `ChatCompletionAPI`: Express-based router handling `/v1/chat/completions` with both non-streaming and SSE streaming responses.
- `ResponsesAPI`: Express-based router handling the newer `/v1/responses` endpoint, matching the Python implementation's object formats and streaming event sequences (`response.created`, `response.in_progress`, etc.).
- Message conversion utilities (`openaiMessageToBeeAIMessage` and `openaiInputToBeeAIMessage`) to translate between OpenAI and BeeAI message formats.
- Example usage at `examples/serve/openai.ts` and `examples/serve/openai_responses.ts`.
- Unit tests (11/11 passing).

**No breaking changes.**

### Checklist

#### General
- [x] I have read the appropriate contributor guide
- [x] I have signed off on my commit
- [x] Commit messages and PR title follow conventional commits
- [x] Appropriate label(s) added to PR: `TypeScript`

#### Code quality checks
- [ ] Code quality checks pass: `mise check` — `yarn tsc --noEmit` passes cleanly (0 errors from this PR; 2 pre-existing errors in `watsonx/backend/chat.ts`). Full `mise check` could not run locally due to missing `pipx`/GitHub API auth in tool setup.

#### Testing
- [x] Unit tests pass
- [ ] E2E tests pass — no E2E tests needed; consistent with existing serve adapters (`A2AServer`, `MCPServer`) which have no E2E tests. However, both endpoints have been manually verified end-to-end via `curl` against a local Ollama instance (`granite4:micro`), confirming both string/array inputs and proper JSON output formats.
- [x] Tests are included (for bug fixes or new features)

#### Documentation
- [ ] Documentation is updated
- [ ] Embedme embeds code examples in docs