### PR TITLE
test(agents): add unit tests for ToolCallingAgent and LiteAgent

### DIFF
--- a/python/tests/agents/__init__.py
+++ b/python/tests/agents/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0

--- a/python/tests/agents/_scripted.py
+++ b/python/tests/agents/_scripted.py
@@ -12,6 +12,7 @@ from beeai_framework.backend import (
     ChatModelOutput,
     MessageToolCallContent,
 )
+from beeai_framework.backend.constants import ProviderName
 from beeai_framework.backend.types import ChatModelInput
 from beeai_framework.context import RunContext
 from beeai_framework.tools import tool
@@ -25,10 +26,6 @@ class ScriptedChatModel(ChatModel):
     case the final response is replayed indefinitely.
     """
 
-    model_id = "scripted_model"
-    # pyrefly: ignore [bad-override]
-    provider_id = "ollama"
-
     def __init__(self, responses: list[list[AnyMessage]], *, repeat_last: bool = False) -> None:
         super().__init__()
         self._responses = list(responses)
@@ -37,11 +34,18 @@ class ScriptedChatModel(ChatModel):
         self.inputs: list[ChatModelInput] = []
 
     @property
+    def model_id(self) -> str:
+        return "scripted_model"
+
+    @property
+    def provider_id(self) -> ProviderName:
+        return "ollama"
+
+    @property
     def call_count(self) -> int:
         return len(self.inputs)
 
-    # pyrefly: ignore [bad-param-name-override]
-    async def _create(self, input: ChatModelInput, _: RunContext) -> ChatModelOutput:
+    async def _create(self, input: ChatModelInput, run: RunContext) -> ChatModelOutput:
         self.inputs.append(input)
         if self._responses:
             self._last = self._responses.pop(0)
@@ -49,9 +53,15 @@ class ScriptedChatModel(ChatModel):
             raise AssertionError("ScriptedChatModel ran out of scripted responses")
         return ChatModelOutput(output=list(self._last))
 
-    # pyrefly: ignore [bad-param-name-override]
-    async def _create_stream(self, input: ChatModelInput, context: RunContext) -> AsyncGenerator[ChatModelOutput]:
-        yield await self._create(input, context)
+    async def _create_stream(self, input: ChatModelInput, run: RunContext) -> AsyncGenerator[ChatModelOutput]:
+        yield await self._create(input, run)
+
+    async def clone(self) -> "ScriptedChatModel":
+        # Agents clone their llm when cloned; without this the clone would share our state.
+        cloned = ScriptedChatModel([list(response) for response in self._responses], repeat_last=self._repeat_last)
+        cloned._last = list(self._last)
+        cloned.inputs = list(self.inputs)
+        return cloned
 
 
 def tool_call_message(tool_name: str, args: dict[str, Any], *, call_id: str = "call_1") -> AssistantMessage:

--- a/python/tests/agents/_scripted.py
+++ b/python/tests/agents/_scripted.py
@@ -1,0 +1,71 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from beeai_framework.backend import (
+    AnyMessage,
+    AssistantMessage,
+    ChatModel,
+    ChatModelOutput,
+    MessageToolCallContent,
+)
+from beeai_framework.backend.types import ChatModelInput
+from beeai_framework.context import RunContext
+from beeai_framework.tools import tool
+
+
+class ScriptedChatModel(ChatModel):
+    """A ChatModel that replays a pre-scripted sequence of outputs (no real LLM).
+
+    Each ``run`` consumes the next list of messages from ``responses``. When the script is
+    exhausted it raises (to surface test mistakes) unless ``repeat_last`` is set, in which
+    case the final response is replayed indefinitely.
+    """
+
+    model_id = "scripted_model"
+    # pyrefly: ignore [bad-override]
+    provider_id = "ollama"
+
+    def __init__(self, responses: list[list[AnyMessage]], *, repeat_last: bool = False) -> None:
+        super().__init__()
+        self._responses = list(responses)
+        self._repeat_last = repeat_last
+        self._last: list[AnyMessage] = []
+        self.inputs: list[ChatModelInput] = []
+
+    @property
+    def call_count(self) -> int:
+        return len(self.inputs)
+
+    # pyrefly: ignore [bad-param-name-override]
+    async def _create(self, input: ChatModelInput, _: RunContext) -> ChatModelOutput:
+        self.inputs.append(input)
+        if self._responses:
+            self._last = self._responses.pop(0)
+        elif not self._repeat_last:
+            raise AssertionError("ScriptedChatModel ran out of scripted responses")
+        return ChatModelOutput(output=list(self._last))
+
+    # pyrefly: ignore [bad-param-name-override]
+    async def _create_stream(self, input: ChatModelInput, context: RunContext) -> AsyncGenerator[ChatModelOutput]:
+        yield await self._create(input, context)
+
+
+def tool_call_message(tool_name: str, args: dict[str, Any], *, call_id: str = "call_1") -> AssistantMessage:
+    """Build an assistant message that requests a single tool call."""
+    return AssistantMessage(MessageToolCallContent(id=call_id, tool_name=tool_name, args=json.dumps(args)))
+
+
+def final_answer_message(text: str) -> AssistantMessage:
+    """Build an assistant message that calls the ToolCallingAgent ``final_answer`` tool."""
+    return tool_call_message("final_answer", {"response": text}, call_id="call_final")
+
+
+@tool()
+def weather_tool(city: str) -> str:
+    """Returns the weather for a city."""
+
+    return f"sunny in {city}"

--- a/python/tests/agents/test_lite_agent.py
+++ b/python/tests/agents/test_lite_agent.py
@@ -1,0 +1,80 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from beeai_framework.agents import AgentError
+from beeai_framework.agents.lite.agent import LiteAgent
+from beeai_framework.backend import AssistantMessage, ToolMessage
+from tests.agents._scripted import ScriptedChatModel, tool_call_message, weather_tool
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_returns_text_answer_without_tools() -> None:
+    model = ScriptedChatModel([[AssistantMessage("The answer is 42")]])
+    agent = LiteAgent(llm=model)
+
+    output = await agent.run("What is the answer?")
+
+    assert isinstance(output.output[-1], AssistantMessage)
+    assert output.output[-1].text == "The answer is 42"
+    assert model.call_count == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_executes_tool_then_answers() -> None:
+    model = ScriptedChatModel(
+        [
+            [tool_call_message("weather_tool", {"city": "Prague"})],
+            [AssistantMessage("It is sunny in Prague")],
+        ]
+    )
+    agent = LiteAgent(llm=model, tools=[weather_tool])
+
+    output = await agent.run("What is the weather in Prague?")
+
+    assert isinstance(output.output[-1], AssistantMessage)
+    assert output.output[-1].text == "It is sunny in Prague"
+    assert model.call_count == 2
+
+    tool_results = [
+        content.result
+        for message in output.output
+        if isinstance(message, ToolMessage)
+        for content in message.get_tool_results()
+    ]
+    assert "sunny in Prague" in tool_results
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_raises_when_max_iterations_exceeded() -> None:
+    # The model keeps calling a tool and never produces a tool-free answer, so the agent
+    # should give up after max_iterations. Distinct args keep each iteration unique.
+    model = ScriptedChatModel(
+        [
+            [tool_call_message("weather_tool", {"city": "Prague"}, call_id="c1")],
+            [tool_call_message("weather_tool", {"city": "Brno"}, call_id="c2")],
+        ],
+        repeat_last=True,
+    )
+    agent = LiteAgent(llm=model, tools=[weather_tool])
+
+    with pytest.raises(AgentError):
+        await agent.run("solve this", max_iterations=2)
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_conversation_is_persisted_to_memory() -> None:
+    model = ScriptedChatModel([[AssistantMessage("hello there")]])
+    agent = LiteAgent(llm=model)
+
+    assert agent.memory.is_empty()
+    await agent.run("hi")
+
+    assert any(
+        isinstance(message, AssistantMessage) and message.text == "hello there" for message in agent.memory.messages
+    )

--- a/python/tests/agents/test_lite_agent.py
+++ b/python/tests/agents/test_lite_agent.py
@@ -78,3 +78,18 @@ async def test_conversation_is_persisted_to_memory() -> None:
     assert any(
         isinstance(message, AssistantMessage) and message.text == "hello there" for message in agent.memory.messages
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_cloning_the_agent_does_not_share_model_state() -> None:
+    model = ScriptedChatModel([[AssistantMessage("from the clone")]], repeat_last=True)
+    agent = LiteAgent(llm=model)
+
+    clone = await agent.clone()
+    output = await clone.run("hi")
+
+    # The clone runs against its own copied model, leaving the original untouched.
+    assert isinstance(output.output[-1], AssistantMessage)
+    assert output.output[-1].text == "from the clone"
+    assert model.call_count == 0

--- a/python/tests/agents/test_tool_calling_agent.py
+++ b/python/tests/agents/test_tool_calling_agent.py
@@ -1,0 +1,108 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from beeai_framework.agents import AgentError
+from beeai_framework.agents.tool_calling.agent import ToolCallingAgent
+from beeai_framework.backend import AssistantMessage, ToolMessage
+from tests.agents._scripted import (
+    ScriptedChatModel,
+    final_answer_message,
+    tool_call_message,
+    weather_tool,
+)
+
+# ToolCallingAgent is deprecated in favour of RequirementAgent but still shipped; we test it
+# intentionally, so silence the expected deprecation warning for this module.
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_returns_final_answer_directly() -> None:
+    model = ScriptedChatModel([[final_answer_message("The answer is 42")]])
+    agent = ToolCallingAgent(llm=model)
+
+    output = await agent.run("What is the answer?")
+
+    assert output.state.result is not None
+    assert output.state.result.text == "The answer is 42"
+    assert output.output_structured is output.state.result
+    assert model.call_count == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_executes_tool_then_final_answer() -> None:
+    model = ScriptedChatModel(
+        [
+            [tool_call_message("weather_tool", {"city": "Prague"})],
+            [final_answer_message("It is sunny in Prague")],
+        ]
+    )
+    agent = ToolCallingAgent(llm=model, tools=[weather_tool])
+
+    output = await agent.run("What is the weather in Prague?")
+
+    assert output.state.result is not None
+    assert output.state.result.text == "It is sunny in Prague"
+    assert model.call_count == 2
+
+    tool_results = [
+        content.result
+        for message in output.state.memory.messages
+        if isinstance(message, ToolMessage)
+        for content in message.get_tool_results()
+    ]
+    assert "sunny in Prague" in tool_results
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_final_answer_tool_is_always_offered() -> None:
+    model = ScriptedChatModel([[final_answer_message("done")]])
+    agent = ToolCallingAgent(llm=model, tools=[weather_tool])
+
+    await agent.run("anything")
+
+    offered_tools = {offered.name for offered in model.inputs[0].tools}
+    assert "final_answer" in offered_tools
+    assert "weather_tool" in offered_tools
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_raises_when_max_iterations_exceeded() -> None:
+    # The agent never receives a final_answer, so it should give up after max_iterations.
+    # Distinct args avoid the cycle-detection path so the loop runs to the iteration limit.
+    model = ScriptedChatModel(
+        [
+            [tool_call_message("weather_tool", {"city": "Prague"}, call_id="c1")],
+            [tool_call_message("weather_tool", {"city": "Brno"}, call_id="c2")],
+        ],
+        repeat_last=True,
+    )
+    agent = ToolCallingAgent(llm=model, tools=[weather_tool])
+
+    with pytest.raises(AgentError):
+        await agent.run("solve this", max_iterations=2)
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_conversation_is_persisted_to_memory() -> None:
+    model = ScriptedChatModel([[final_answer_message("hello there")]])
+    agent = ToolCallingAgent(llm=model)
+
+    assert agent.memory.is_empty()
+    await agent.run("hi")
+
+    assert not agent.memory.is_empty()
+    recorded_tool_calls = [
+        content.tool_name
+        for message in agent.memory.messages
+        if isinstance(message, AssistantMessage)
+        for content in message.get_tool_calls()
+    ]
+    assert "final_answer" in recorded_tool_calls


### PR DESCRIPTION
## Summary

The `beeai_framework` agents package shipped with unit coverage for only a single agent (`tests/agents/test_requirements_reasoner.py`), leaving the other agent types untested. This PR adds focused, LLM-free unit tests for two of them: **`ToolCallingAgent`** and **`LiteAgent`**.

## Changes

### `tests/agents/_scripted.py` — shared test double (new)
A `ScriptedChatModel(ChatModel)` that replays a pre-scripted sequence of outputs instead of calling a real LLM, plus small builders (`tool_call_message`, `final_answer_message`) and a `weather_tool`. It records every call (`call_count`, `inputs`) so tests can assert on what the agent asked the model, and supports both the non-streaming (`_create`) and streaming (`_create_stream`) paths so it works for both agents.

### `tests/agents/test_tool_calling_agent.py` — new (5 tests)
- returns a direct final answer
- executes a tool, then produces the final answer
- always offers the `final_answer` tool alongside user tools
- raises `AgentError` when `max_iterations` is exceeded
- persists the conversation to the agent memory

### `tests/agents/test_lite_agent.py` — new (4 tests)
- returns a text answer without tools
- executes a tool, then answers
- raises `AgentError` when `max_iterations` is exceeded
- persists the conversation to the agent memory

`ToolCallingAgent` is deprecated (in favour of `RequirementAgent`) but still shipped, so it is covered to guard against regressions until it is removed; the expected `DeprecationWarning` is silenced at module scope.

## Test plan

- [x] New tests pass: `poetry run pytest tests/agents -m unit` (10 passed, incl. the pre-existing reasoner test)
- [x] `ruff check` / `ruff format --check` clean on `tests/agents/`
- [x] Full unit suite: no new failures or collection errors introduced (the only failure, `test_templates.py::test_render_function`, is a pre-existing local `zoneinfo`/tzdata issue unrelated to this change)
- [x] No production code changed — tests only

---

Signed-off-by: ibrahim <ihsanduvac@gmail.com>
