### PR TITLE
fix(adapters): use valid Bedrock default model ID instead of Groq alias

### DIFF
--- a/python/.env.example
+++ b/python/.env.example
@@ -61,7 +61,7 @@ BEEAI_LOG_LEVEL=INFO
 # AWS_ACCESS_KEY_ID=your-aws-access-key
 # AWS_SECRET_ACCESS_KEY=your-secret-access-key
 # AWS_REGION=your-aws-region
-# AWS_CHAT_MODEL=llama-3.1-8b-instant
+# AWS_CHAT_MODEL=meta.llama3-70b-instruct-v1:0
 # AWS_API_HEADERS="secret-header=1234"
 
 

--- a/python/beeai_framework/adapters/amazon_bedrock/backend/chat.py
+++ b/python/beeai_framework/adapters/amazon_bedrock/backend/chat.py
@@ -30,7 +30,7 @@ class AmazonBedrockChatModel(LiteLLMChatModel):
         **kwargs: Unpack[ChatModelKwargs],
     ) -> None:
         super().__init__(
-            (model_id if model_id else os.getenv("AWS_CHAT_MODEL", "llama-3.1-8b-instant")),
+            (model_id if model_id else os.getenv("AWS_CHAT_MODEL", "meta.llama3-70b-instruct-v1:0")),
             provider_id="bedrock",
             **kwargs,
         )

--- a/python/tests/backend/providers/test_amazon_bedrock.py
+++ b/python/tests/backend/providers/test_amazon_bedrock.py
@@ -1,0 +1,34 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from beeai_framework.adapters.amazon_bedrock import AmazonBedrockChatModel
+
+
+class TestAmazonBedrockChatModel:
+    """Unit tests for the AmazonBedrockChatModel class."""
+
+    @pytest.mark.unit
+    def test_default_model_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The default model ID must be a valid Amazon Bedrock model ID, not a Groq alias."""
+        monkeypatch.delenv("AWS_CHAT_MODEL", raising=False)
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test_access_key_id")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test_secret_access_key")
+        monkeypatch.setenv("AWS_REGION", "us-east-1")
+
+        model = AmazonBedrockChatModel()
+
+        assert model.model_id == "meta.llama3-70b-instruct-v1:0"
+
+    @pytest.mark.unit
+    def test_default_model_id_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The default model ID can be overridden via the AWS_CHAT_MODEL environment variable."""
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test_access_key_id")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test_secret_access_key")
+        monkeypatch.setenv("AWS_REGION", "us-east-1")
+        monkeypatch.setenv("AWS_CHAT_MODEL", "amazon.titan-text-lite-v1")
+
+        model = AmazonBedrockChatModel()
+
+        assert model.model_id == "amazon.titan-text-lite-v1"


### PR DESCRIPTION
### Which issue(s) does this pull-request address?

Closes: #1517

### Description

Thank you for BeeAI Framework and the care put into Python/TypeScript parity.

The Python `AmazonBedrockChatModel` default model ID was `llama-3.1-8b-instant`, which is actually the **Groq** adapter's default alias — not a valid Amazon Bedrock model ID. When a user constructs `AmazonBedrockChatModel()` without an explicit `model_id`/`AWS_CHAT_MODEL`, LiteLLM forwards `bedrock/llama-3.1-8b-instant` and Bedrock rejects it with a validation error.

This appears to have been copy-pasted from the Groq adapter, which uses the same literal. The **TypeScript sibling is already correct** (`typescript/src/adapters/amazon-bedrock/backend/chat.ts` uses `meta.llama3-70b-instruct-v1:0`), and the Python adapter's own README also documents `meta.llama3-70b-instruct-v1:0`. This PR fills that one gap so the Python default matches its TS sibling, the adapter README, and a real Bedrock model.

**Changes** (minimal, 2 source lines + 1 test):
- `python/beeai_framework/adapters/amazon_bedrock/backend/chat.py` — default `AWS_CHAT_MODEL` fallback → `meta.llama3-70b-instruct-v1:0`
- `python/.env.example` — `AWS_CHAT_MODEL` example line → `meta.llama3-70b-instruct-v1:0`
- `python/tests/backend/providers/test_amazon_bedrock.py` — regression unit test (default + env-override)

The chosen ID is verified against the AWS Bedrock model card: **Llama 3 70B Instruct**, model ID `meta.llama3-70b-instruct-v1:0`, `bedrock-runtime` endpoint, lifecycle **Active**, supports Invoke + Converse.

### Before / After

| Item | Before | After |
|------|--------|-------|
| `AmazonBedrockChatModel().model_id` (no env) | ❌ `llama-3.1-8b-instant` (Groq alias) | ✅ `meta.llama3-70b-instruct-v1:0` |
| Equals `GroqChatModel().model_id` | ❌ identical (copy-paste) | ✅ no longer identical |
| Default ID valid on Bedrock | ❌ `ValidationException` on `.create()` | ✅ valid Bedrock model ID |
| `.env.example` `AWS_CHAT_MODEL` | ❌ `llama-3.1-8b-instant` | ✅ `meta.llama3-70b-instruct-v1:0` |
| Matches TS sibling + adapter README | ❌ mismatch | ✅ consistent |
| Explicit `model_id` / `AWS_CHAT_MODEL` override | ✅ honored | ✅ honored (unchanged) |
| Public API / constructor signature | ✅ | ✅ unchanged |

### Reproduction (before the fix)

```python
import os
os.environ["AWS_ACCESS_KEY_ID"] = "x"
os.environ["AWS_SECRET_ACCESS_KEY"] = "y"
os.environ["AWS_REGION"] = "us-east-1"

from beeai_framework.adapters.amazon_bedrock import AmazonBedrockChatModel
from beeai_framework.adapters.groq import GroqChatModel

print(AmazonBedrockChatModel().model_id)  # 'llama-3.1-8b-instant'  <- Groq alias
print(GroqChatModel().model_id)            # 'llama-3.1-8b-instant'  <- identical
```

### Test (before / after on the same new test)

Reverting only the source fix (keeping the new test) makes the regression test fail, proving it catches the bug:

```
>       assert model.model_id == "meta.llama3-70b-instruct-v1:0"
E       AssertionError: assert 'llama-3.1-8b-instant' == 'meta.llama3-...instruct-v1:0'
E         - meta.llama3-70b-instruct-v1:0
E         + llama-3.1-8b-instant
FAILED tests/backend/providers/test_amazon_bedrock.py::...::test_default_model_id
```

With the fix in place:

```
tests/backend/providers/test_amazon_bedrock.py::TestAmazonBedrockChatModel::test_default_model_id PASSED
tests/backend/providers/test_amazon_bedrock.py::TestAmazonBedrockChatModel::test_default_model_id_from_env PASSED
2 passed
```

Full backend suite (new test + existing `test_chatmodel.py`) passes locally; `ruff check` and `ruff format --check` clean on the changed files.

### Checklist

#### General
- [x] I have read the appropriate contributor guide
- [x] I have signed off on my commit (DCO)
- [x] Commit messages and PR title follow conventional commits
- [x] Appropriate label(s) added to PR: `Python`

#### Testing
- [x] Unit tests pass
- [x] Tests are included

---

This contribution was prepared with the help of an AI agent (Claude Code); a human reviewed the change, the rationale, and the test results before submitting.
