### PR TITLE
docs(tour): add TypeScript examples for caching and error handling

### DIFF
--- a/docs/src/content/docs/introduction/tour.mdx
+++ b/docs/src/content/docs/introduction/tour.mdx
@@ -970,7 +970,7 @@ import { UserMessage } from "beeai-framework/backend/message";
 import { SlidingCache } from "beeai-framework/cache/slidingCache";
 
 const llm = await ChatModel.fromName("ollama:granite3.3");
-llm.config({ cache: new SlidingCache({ size: 50 }) }); // Cache up to 50 responses
+llm.config({ cache: new SlidingCache<any>({ size: 50 }) }); // Cache up to 50 responses
 
 const messages = [new UserMessage("Hello, how are you?")];
 
@@ -1004,7 +1004,7 @@ import { OpenMeteoTool } from "beeai-framework/tools/weather/openMeteo";
 import { UnconstrainedCache } from "beeai-framework/cache/unconstrainedCache";
 
 // Cache all results from the weather API
-const weatherTool = new OpenMeteoTool({ cache: new UnconstrainedCache() });
+const weatherTool = new OpenMeteoTool({ cache: new UnconstrainedCache<any>() });
 ```
 
 </CodeGroup>
@@ -1050,9 +1050,9 @@ import { SlidingCache } from "beeai-framework/cache/slidingCache";
 import { UnconstrainedCache } from "beeai-framework/cache/unconstrainedCache";
 
 const llm = await ChatModel.fromName("ollama:granite3.3");
-llm.config({ cache: new SlidingCache({ size: 50 }) }); // Cache up to 50 responses
+llm.config({ cache: new SlidingCache<any>({ size: 50 }) }); // Cache up to 50 responses
 
-const weatherTool = new OpenMeteoTool({ cache: new UnconstrainedCache() });
+const weatherTool = new OpenMeteoTool({ cache: new UnconstrainedCache<any>() });
 
 const agent = new RequirementAgent({
   llm,

--- a/docs/src/content/docs/introduction/tour.mdx
+++ b/docs/src/content/docs/introduction/tour.mdx
@@ -965,7 +965,22 @@ asyncio.run(main())
 ```
 
 ```ts TypeScript [expandable]
-COMING SOON
+import { ChatModel } from "beeai-framework/backend/chat";
+import { UserMessage } from "beeai-framework/backend/message";
+import { SlidingCache } from "beeai-framework/cache/slidingCache";
+
+const llm = await ChatModel.fromName("ollama:granite3.3");
+llm.config({ cache: new SlidingCache({ size: 50 }) }); // Cache up to 50 responses
+
+const messages = [new UserMessage("Hello, how are you?")];
+
+// First call (miss)
+const res1 = await llm.create({ messages });
+// Second call with identical input (hit)
+const res2 = await llm.create({ messages });
+
+console.log("First:", res1.getTextContent());
+console.log("Second (cached):", res2.getTextContent());
 ```
 
 </CodeGroup>
@@ -985,7 +1000,11 @@ weather_tool = OpenMeteoTool(options={"cache": UnconstrainedCache()})
 ```
 
 ```ts TypeScript [expandable]
-COMING SOON
+import { OpenMeteoTool } from "beeai-framework/tools/weather/openMeteo";
+import { UnconstrainedCache } from "beeai-framework/cache/unconstrainedCache";
+
+// Cache all results from the weather API
+const weatherTool = new OpenMeteoTool({ cache: new UnconstrainedCache() });
 ```
 
 </CodeGroup>
@@ -1023,7 +1042,28 @@ asyncio.run(main())
 ```
 
 ```ts TypeScript [expandable]
-COMING SOON
+import { RequirementAgent } from "beeai-framework/agents/requirement/agent";
+import { ChatModel } from "beeai-framework/backend/chat";
+import { OpenMeteoTool } from "beeai-framework/tools/weather/openMeteo";
+import { UnconstrainedMemory } from "beeai-framework/memory/unconstrainedMemory";
+import { SlidingCache } from "beeai-framework/cache/slidingCache";
+import { UnconstrainedCache } from "beeai-framework/cache/unconstrainedCache";
+
+const llm = await ChatModel.fromName("ollama:granite3.3");
+llm.config({ cache: new SlidingCache({ size: 50 }) }); // Cache up to 50 responses
+
+const weatherTool = new OpenMeteoTool({ cache: new UnconstrainedCache() });
+
+const agent = new RequirementAgent({
+  llm,
+  tools: [weatherTool], // Tool with cache
+  memory: new UnconstrainedMemory(),
+  instructions: "Provide answers efficiently using cached results when possible.",
+});
+
+const response1 = await agent.run({ prompt: "What's the weather in New York?" });
+// Repeated request — weather tool cache should hit
+const response2 = await agent.run({ prompt: "What's the weather in New York?" });
 ```
 
 </CodeGroup>
@@ -1074,7 +1114,30 @@ if __name__ == "__main__":
 ```
 
 ```ts TypeScript [expandable]
-COMING SOON
+import { RequirementAgent } from "beeai-framework/agents/requirement/agent";
+import { ChatModel } from "beeai-framework/backend/chat";
+import { UnconstrainedMemory } from "beeai-framework/memory/unconstrainedMemory";
+import { OpenMeteoTool } from "beeai-framework/tools/weather/openMeteo";
+import { FrameworkError } from "beeai-framework/errors";
+
+try {
+  const agent = new RequirementAgent({
+    llm: await ChatModel.fromName("ollama:granite3.3"),
+    memory: new UnconstrainedMemory(),
+    tools: [new OpenMeteoTool()],
+    instructions: "You provide weather information.",
+  });
+
+  const response = await agent.run({ prompt: "What's the weather in Invalid-City-Name?" });
+  console.log(response.result.text);
+} catch (error) {
+  if (error instanceof FrameworkError) {
+    console.error("Framework error occurred:", error.explain());
+    console.error(error.stack);
+  } else {
+    console.error("Unexpected error:", error);
+  }
+}
 ```
 
 </CodeGroup>


### PR DESCRIPTION
## Summary

This PR fills in four TypeScript `COMING SOON` placeholder blocks in the Grand Tour documentation, addressing issue #1469.

### Changes

- **Caching LLM Calls** — uses `SlidingCache` configured via `llm.config()`, demonstrates cache miss vs hit with `llm.create()` and `getTextContent()`
- **Caching Tool Outputs** — uses `UnconstrainedCache` on `OpenMeteoTool` constructor
- **Using Cached Components in an Agent** — combines both patterns (sliding cache on LLM, unconstrained cache on tool) in a `RequirementAgent`
- **Handle Errors Gracefully** — wraps agent in try/catch, distinguishes `FrameworkError` (with `.explain()`) from unexpected errors

All examples follow the same patterns as the existing TypeScript examples in the tour and in `typescript/examples/cache/`.

Closes #1469