### PR TITLE
fix(python): resolve pyrefly and ruff errors in merged tests

### DIFF
--- a/python/beeai_framework/middleware/trajectory.py
+++ b/python/beeai_framework/middleware/trajectory.py
@@ -27,7 +27,8 @@ from beeai_framework.utils.strings import to_json
 
 @runtime_checkable
 class Writeable(Protocol):
-    def write(self, s: str) -> int: ...
+    # Positional-only so standard file objects (io.StringIO, sys.stdout) satisfy the protocol.
+    def write(self, s: str, /) -> int: ...
 
 
 class TraceLevel(BaseModel):
@@ -325,7 +326,6 @@ def _logger_to_writeable(logger: Logger) -> Writeable:
 
 def _create_target(input: Writeable | Logger | bool | None) -> Writeable:
     if input is None or input is True:
-        # pyrefly: ignore [bad-return]
         return sys.stdout
     elif input is False:
 

--- a/python/tests/agents/test_tool_calling_agent.py
+++ b/python/tests/agents/test_tool_calling_agent.py
@@ -66,7 +66,7 @@ async def test_final_answer_tool_is_always_offered() -> None:
 
     await agent.run("anything")
 
-    offered_tools = {offered.name for offered in model.inputs[0].tools}
+    offered_tools = {offered.name for offered in (model.inputs[0].tools or [])}
     assert "final_answer" in offered_tools
     assert "weather_tool" in offered_tools
 

--- a/python/tests/middleware/test_stream_tool_call.py
+++ b/python/tests/middleware/test_stream_tool_call.py
@@ -16,7 +16,6 @@ from beeai_framework.tools import StringToolOutput, Tool
 from beeai_framework.tools.types import ToolRunOptions
 from beeai_framework.utils.strings import to_safe_word
 
-
 # ---------------------------------------------------------------------------
 # Minimal tool fixture
 # ---------------------------------------------------------------------------
@@ -37,7 +36,7 @@ class FakeSearchTool(Tool[SearchInput, ToolRunOptions, StringToolOutput]):
             creator=self,
         )
 
-    async def _run(self, input: SearchInput, options: ToolRunOptions, run: RunContext) -> StringToolOutput:
+    async def _run(self, input: SearchInput, options: ToolRunOptions | None, context: RunContext) -> StringToolOutput:
         return StringToolOutput(result=input.query)
 
 


### PR DESCRIPTION
## Summary

PRs #1504 (middleware tests) and #1513 (agent tests) were merged with test files that fail the Python type-check (`pyrefly`) and lint (`ruff`) steps — the heavy "Python - Lint, Build, Test" workflow had not run on those PRs before they were merged, so the failures were not caught and `main` is now red on those checks.

This PR fixes all of them (6 `pyrefly` errors + 1 `ruff` error).

## Changes

### `tests/agents/test_tool_calling_agent.py`
`ChatModelInput.tools` is typed `list[AnyTool] | None`, so iterating it directly is flagged as `not-iterable`. Guard with `or []`.

### `tests/middleware/test_stream_tool_call.py`
- `FakeSearchTool._run` did not match the base `Tool._run` signature (`bad-override`). Align it to `options: ToolRunOptions | None, context: RunContext`.
- Sort the import block (`ruff` `I001`).

### `beeai_framework/middleware/trajectory.py`
The `Writeable` protocol declared `write(self, s: str)`, which `io.StringIO` / `sys.stdout` do not satisfy because their `write` is positional-only — so passing a `StringIO` target in `test_trajectory.py` was flagged as `bad-argument-type` (4×). Make the protocol's `write` parameter positional-only, which:
- lets standard file objects satisfy `Writeable` (fixing the 4 `test_trajectory.py` errors), and
- removes a now-unnecessary `# pyrefly: ignore [bad-return]` on the `sys.stdout` return.

## Test plan

- [x] `poetry run pyrefly check` is clean on all touched files (0 errors)
- [x] `poetry run ruff check` / `ruff format --check` clean across the project
- [x] `poetry run pytest tests/agents tests/middleware -m unit` — 17 passed
- [x] No behavioural change: production change only relaxes a `Protocol` parameter to positional-only (backward compatible)

---

Signed-off-by: ibrahim <ihsanduvac@gmail.com>
