### PR TITLE
fix(adapters): default OpenAIServer to loopback and warn on unauthenticated bind (#1516)

### DIFF
--- a/python/beeai_framework/adapters/openai/serve/server.py
+++ b/python/beeai_framework/adapters/openai/serve/server.py
@@ -32,10 +32,16 @@ class OpenAIAPIType(StrEnum):
     RESPONSES = "responses"
 
 
+_LOOPBACK_HOSTS = ("127.0.0.1", "localhost", "::1")
+
+
 class OpenAIServerConfig(BaseModel):
     """Configuration for the OpenAIServerConfig."""
 
-    host: str = "0.0.0.0"
+    # Bind to loopback by default. The endpoints are unauthenticated unless `api_key`
+    # is set, so binding to all interfaces ("0.0.0.0") is opt-in to avoid exposing an
+    # unauthenticated server to the network by default.
+    host: str = "127.0.0.1"
     port: int = 9999
 
     api: OpenAIAPIType = OpenAIAPIType.CHAT_COMPLETION
@@ -95,6 +101,13 @@ class OpenAIServer(
                 memory_manager=self._memory_manager,
             )
         )
+
+        if self._config.api_key is None and self._config.host not in _LOOPBACK_HOSTS:
+            logger.warning(
+                f"OpenAIServer is binding to a non-loopback host ({self._config.host}) with no `api_key` set: "
+                f"the API will be reachable from the network without authentication. "
+                f"Set `api_key` in the config, or bind to 127.0.0.1, to avoid exposing it."
+            )
 
         uvicorn.run(api.app, host=self._config.host, port=self._config.port)
 

--- a/python/tests/adapters/openai/test_openai_server_config.py
+++ b/python/tests/adapters/openai/test_openai_server_config.py
@@ -1,0 +1,69 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Iterator
+from typing import Unpack
+
+import pytest
+
+from beeai_framework.adapters.openai.serve import server as server_mod
+from beeai_framework.adapters.openai.serve.server import OpenAIServer, OpenAIServerConfig, register
+from beeai_framework.backend.message import AnyMessage, AssistantMessage
+from beeai_framework.emitter import Emitter
+from beeai_framework.runnable import Runnable, RunnableOptions, RunnableOutput, runnable_entry
+
+
+class DummyRunnable(Runnable[RunnableOutput]):
+    @property
+    def emitter(self) -> Emitter:
+        return Emitter.root().child(namespace=["dummy"])
+
+    @runnable_entry
+    async def run(self, input: list[AnyMessage], /, **kwargs: Unpack[RunnableOptions]) -> RunnableOutput:
+        return RunnableOutput(output=[AssistantMessage(content="pong")])
+
+
+@pytest.fixture
+def captured_warnings(monkeypatch: pytest.MonkeyPatch) -> Iterator[list[str]]:
+    """Stub out uvicorn.run and capture warnings emitted during serve()."""
+    register()
+    monkeypatch.setattr(server_mod.uvicorn, "run", lambda *args, **kwargs: None)
+    warnings: list[str] = []
+    monkeypatch.setattr(server_mod.logger, "warning", lambda msg, *a, **k: warnings.append(str(msg)))
+    yield warnings
+
+
+def _serve(config: OpenAIServerConfig) -> None:
+    server = OpenAIServer(config=config)
+    server.register(DummyRunnable(), name="dummy-model")
+    server.serve()
+
+
+def _has_insecure_warning(warnings: list[str]) -> bool:
+    return any("without authentication" in w for w in warnings)
+
+
+@pytest.mark.unit
+def test_default_host_is_loopback() -> None:
+    config = OpenAIServerConfig()
+    assert config.host == "127.0.0.1"
+    assert config.api_key is None
+
+
+@pytest.mark.unit
+def test_warns_when_binding_non_loopback_without_api_key(captured_warnings: list[str]) -> None:
+    _serve(OpenAIServerConfig(host="0.0.0.0", api_key=None))
+    assert _has_insecure_warning(captured_warnings)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "config",
+    [
+        OpenAIServerConfig(host="127.0.0.1", api_key=None),
+        OpenAIServerConfig(host="0.0.0.0", api_key="secret"),
+    ],
+)
+def test_no_warning_on_loopback_or_with_api_key(captured_warnings: list[str], config: OpenAIServerConfig) -> None:
+    _serve(config)
+    assert not _has_insecure_warning(captured_warnings)


### PR DESCRIPTION
## Summary

Hardens the secure-by-default posture of the Python `OpenAIServer`, addressing the triage of #1516.

The server defaulted to `host="0.0.0.0"` with `api_key=None`, which binds an **unauthenticated** server to **all network interfaces** by default. Combined with the `/responses` endpoint keying conversation memory on a client-supplied `conversation_id`, that allowed unauthenticated cross-session access (IDOR) for anyone who could reach the port.

## Changes
- **Default `OpenAIServerConfig.host` → `127.0.0.1`** (loopback). Binding to all interfaces is now an explicit opt-in.
- **Warn loudly** when serving on a non-loopback host with no `api_key` set, so an intentional external bind without auth is hard to do silently.
- Unit tests for the secure default and the warning behavior.

## Notes
This is a **behavioral default change**: deployments that relied on the implicit `0.0.0.0` bind must now set `host="0.0.0.0"` explicitly (and should set `api_key`). This is the intended secure-default trade-off.

The deeper IDOR (unauthenticated `conversation_id` access when auth is off) is inherent to running with no API key; this PR makes that configuration loud and non-default rather than silent. Setting `api_key` enforces auth on all endpoints.

## Verification
- `ruff`, `pyrefly` clean; new tests pass (`tests/adapters/openai/test_openai_server_config.py`), existing OpenAI server tests still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)