### PR TITLE
fix(adapters): raise a clear error for Groq embeddings

### DIFF
--- a/docs/src/content/docs/modules/backend.mdx
+++ b/docs/src/content/docs/modules/backend.mdx
@@ -29,7 +29,7 @@ The following table depicts supported providers. Each provider requires specific
 | OpenAI         |  ✅  | ✅        | OPENAI_CHAT_MODEL<br/>OPENAI_EMBEDDING_MODEL<br/>OPENAI_API_BASE<br/>**OPENAI_API_KEY**<br/>OPENAI_ORGANIZATION<br/>OPENAI_API_HEADERS                                                                                                       |
 | IBM watsonx.ai |  ✅  | ✅        | WATSONX_CHAT_MODEL<br/>WATSONX_API_KEY<br/>**WATSONX_PROJECT_ID**<br/>WATSONX_SPACE_ID<br/>WATSONX_TOKEN<br/>WATSONX_ZENAPIKEY<br/>WATSONX_URL<br/>WATSONX_REGION |
 | Anthropic      |  ✅  | ✅        | ANTHROPIC_CHAT_MODEL<br/>**ANTHROPIC_API_KEY**<br/>ANTHROPIC_API_HEADERS |
-| Groq           |  ✅  | ✅        | GROQ_CHAT_MODEL<br/>GROQ_EMBEDDING_MODEL<br/>**GROQ_API_KEY** |
+| Groq           |  ✅  | ❌        | GROQ_CHAT_MODEL<br/>**GROQ_API_KEY** |
 | Amazon Bedrock |  ✅  | ✅        | AWS_CHAT_MODEL<br/>**AWS_BEDROCK_API_KEY**<br/>**AWS_ACCESS_KEY_ID**<br/>**AWS_SECRET_ACCESS_KEY**<br/>**AWS_REGION**<br/>AWS_API_HEADERS |
 | Google Vertex  |  ✅  | ✅        | GOOGLE_VERTEX_CHAT_MODEL<br/>**GOOGLE_VERTEX_PROJECT**<br/>**GOOGLE_VERTEX_LOCATION**<br/>GOOGLE_APPLICATION_CREDENTIALS<br/>GOOGLE_APPLICATION_CREDENTIALS_JSON<br/>GOOGLE_CREDENTIALS<br/>GOOGLE_VERTEX_API_HEADERS |
 | Azure OpenAI   |  ✅  | ✅        | AZURE_OPENAI_CHAT_MODEL<br/>**AZURE_OPENAI_API_KEY**<br/>**AZURE_OPENAI_API_BASE**<br/>**AZURE_OPENAI_API_VERSION**<br/>AZURE_AD_TOKEN<br/>AZURE_API_TYPE<br/>AZURE_API_HEADERS |

--- a/python/beeai_framework/adapters/groq/backend/embedding.py
+++ b/python/beeai_framework/adapters/groq/backend/embedding.py
@@ -1,8 +1,6 @@
 # Copyright 2025 © BeeAI a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-import os
-
 from typing_extensions import Unpack
 
 from beeai_framework.adapters.litellm.embedding import LiteLLMEmbeddingModel
@@ -11,6 +9,14 @@ from beeai_framework.backend.embedding import EmbeddingModelKwargs
 
 
 class GroqEmbeddingModel(LiteLLMEmbeddingModel):
+    """Groq does not expose a text embeddings API.
+
+    This class exists only to surface a clear, actionable error instead of a cryptic
+    provider failure when embeddings are requested for the ``groq`` provider (for example
+    via ``EmbeddingModel.from_name("groq")``). The previous default ``model_id`` pointed at
+    ``llama-3.1-8b-instant``, which is a Groq *chat* model and cannot serve embeddings.
+    """
+
     @property
     def provider_id(self) -> ProviderName:
         return "groq"
@@ -22,10 +28,7 @@ class GroqEmbeddingModel(LiteLLMEmbeddingModel):
         api_key: str | None = None,
         **kwargs: Unpack[EmbeddingModelKwargs],
     ) -> None:
-        super().__init__(
-            model_id if model_id else os.getenv("GROQ_EMBEDDING_MODEL", "llama-3.1-8b-instant"),
-            provider_id="groq",
-            **kwargs,
+        raise NotImplementedError(
+            "Groq does not provide an embeddings API, so embeddings are not supported for the 'groq' provider. "
+            "Use a provider that offers embeddings instead (e.g. OpenAI, Ollama, watsonx, Gemini, or MistralAI)."
         )
-
-        self._assert_setting_value("api_key", api_key, envs=["GROQ_API_KEY"])

--- a/python/examples/backend/providers/groq.py
+++ b/python/examples/backend/providers/groq.py
@@ -2,7 +2,7 @@ import asyncio
 
 from pydantic import BaseModel, Field
 
-from beeai_framework.adapters.groq import GroqChatModel, GroqEmbeddingModel
+from beeai_framework.adapters.groq import GroqChatModel
 from beeai_framework.backend import ChatModel, ChatModelNewTokenEvent, UserMessage
 from beeai_framework.emitter import EventMeta
 from beeai_framework.errors import AbortError
@@ -80,9 +80,6 @@ async def groq_stream_parser() -> None:
 async def groq_cloning() -> None:
     llm = GroqChatModel("llama-3.1-8b-instant")
     await llm.clone()
-
-    embedding_llm = GroqEmbeddingModel()
-    await embedding_llm.clone()
 
 
 async def main() -> None:

--- a/python/tests/adapters/groq/__init__.py
+++ b/python/tests/adapters/groq/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0

--- a/python/tests/adapters/groq/test_groq_embedding.py
+++ b/python/tests/adapters/groq/test_groq_embedding.py
@@ -1,0 +1,21 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from beeai_framework.adapters.groq import GroqEmbeddingModel
+from beeai_framework.backend.embedding import EmbeddingModel
+
+
+@pytest.mark.unit
+def test_groq_embedding_model_is_unsupported() -> None:
+    """Groq has no embeddings API, so instantiation must fail with a clear error."""
+    with pytest.raises(NotImplementedError, match="does not provide an embeddings API"):
+        GroqEmbeddingModel()
+
+
+@pytest.mark.unit
+def test_groq_embedding_model_from_name_is_unsupported() -> None:
+    """Resolving the embedding model by provider name surfaces the same clear error."""
+    with pytest.raises(NotImplementedError, match="does not provide an embeddings API"):
+        EmbeddingModel.from_name("groq")


### PR DESCRIPTION
### Description
https://github.com/i-am-bee/beeai-framework/issues/1537
The `GroqEmbeddingModel` shipped with a default `model_id` of `"llama-3.1-8b-instant"`, which is a Groq **chat** model — not an embedding model. Worse, **Groq does not expose a text embeddings API at all** ([Groq models](https://console.groq.com/docs/models)), so constructing the model without an explicit `model_id` (e.g. `EmbeddingModel.from_name("groq")` or `GroqEmbeddingModel()`) produced a cryptic provider failure on the first request.

This PR makes the limitation explicit instead of failing obscurely:

- **`GroqEmbeddingModel.__init__` now raises a clear `NotImplementedError`** explaining that Groq has no embeddings API and pointing to providers that do (OpenAI, Ollama, watsonx, Gemini, MistralAI). Because the dynamic model loader resolves the same class, this also covers `EmbeddingModel.from_name("groq")`.
- **Removes the broken `GroqEmbeddingModel()` usage** from `python/examples/backend/providers/groq.py`.
- **Updates the supported-providers table** in `docs/src/content/docs/modules/backend.mdx`: Groq embedding `✅ → ❌`, and drops the misleading `GROQ_EMBEDDING_MODEL` env var.
- **Adds unit tests** (`python/tests/adapters/groq/`) asserting both construction paths raise the clear error.

**No breaking change for working code:** there was no valid Groq embedding configuration before, so any prior usage already failed at runtime — now it fails immediately with an actionable message.

> Note: the TypeScript `GroqEmbeddingModel` already requires an explicit `modelId` (it throws `ValueError("Missing modelId!")` otherwise), so it never carried the invalid-default bug. Making the TS side consistently reject Groq embeddings can be a separate follow-up.

### Checklist

#### General
- [x] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md) / [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [x] Code quality checks pass: `mise check` (`mise fix` to auto-fix)

#### Testing
- [x] Unit tests pass: `mise test:unit`
- [ ] E2E tests pass: `mise test:e2e`
- [x] Tests are included (for bug fixes or new features)

#### Documentation
- [x] Documentation is updated
- [ ] Embedme embeds code examples in docs. To update after edits, run: Python `mise docs:fix`