### PR TITLE
fix(serializer): prevent unsafe deserialization paths

### DIFF
--- a/typescript/src/internals/helpers/object.ts
+++ b/typescript/src/internals/helpers/object.ts
@@ -31,15 +31,21 @@ export function hasProps<T>(keys: (keyof T)[]) {
   return (target: T | undefined) => keys.every((key) => hasProp(target, key));
 }
 
+const UnsafePathKeys = new Set<keyof any>(["__proto__"]);
+
 export function setProp(target: unknown, paths: readonly (keyof any)[], value: unknown) {
   for (const entry of paths.entries()) {
     const [idx, key] = entry as [number, keyof object];
+    if (UnsafePathKeys.has(key)) {
+      throw new TypeError(`Cannot assign unsafe object path key "${String(key)}"`);
+    }
+
     if (!R.isPlainObject(target) && !R.isArray(target)) {
       throw new TypeError("Only plain objects and arrays are supported!");
     }
 
     const isLast = idx === paths.length - 1;
-    const newValue = isLast ? value : (target[key] ?? {});
+    const newValue = isLast ? value : hasProp(target, key) ? target[key] : {};
     Object.assign(target, { [key]: newValue });
     target = target[key];
   }

--- a/typescript/src/serializer/serializer.test.ts
+++ b/typescript/src/serializer/serializer.test.ts
@@ -203,6 +203,50 @@ describe("Serializer", () => {
     expect(deserialized.a === deserialized.a.c).toBeTruthy();
   });
 
+  it('Rejects deserialization path key "__proto__"', async () => {
+    const payload = `{
+      "__version": "0.0.0",
+      "__root": {
+        "__proto__": {
+          "__serializer": true,
+          "__class": "Object",
+          "__ref": "1",
+          "__value": {
+            "isAdmin": true
+          }
+        }
+      }
+    }`;
+
+    await expect(Serializer.deserialize(payload)).rejects.toThrow(
+      'Cannot assign unsafe object path key "__proto__"',
+    );
+    expect({}).not.toHaveProperty("isAdmin");
+  });
+
+  it("Preserves constructor and prototype as data keys", async () => {
+    const payload = JSON.stringify({
+      __version: "0.0.0",
+      __root: {
+        constructor: {
+          label: "metadata",
+        },
+        prototype: {
+          enabled: true,
+        },
+      },
+    });
+
+    const deserialized = await Serializer.deserialize<{
+      constructor: { label: string };
+      prototype: { enabled: boolean };
+    }>(payload);
+
+    expect(deserialized.constructor).toStrictEqual({ label: "metadata" });
+    expect(deserialized.prototype).toStrictEqual({ enabled: true });
+    expect({}).not.toHaveProperty("enabled");
+  });
+
   describe("Loading", () => {
     const json = JSON.stringify({
       __version: "0.0.0",


### PR DESCRIPTION
## Summary
- reject unsafe object path keys in `setProp` before nested assignment
- add serializer regression coverage for `__proto__`, `constructor`, and `prototype` paths
- close the public TypeScript serializer prototype-pollution tracker

Fixes #1532.

## Verification
- `yarn vitest src/serializer/serializer.test.ts --run`
- `yarn vitest run src`
- `yarn tsc --noEmit`
- `yarn eslint src/internals/helpers/object.ts src/serializer/serializer.test.ts`
- `yarn prettier --log-level warn --check .`
- `NODE_OPTIONS=--max-old-space-size=16384 yarn tsup`