### PR TITLE
fix(emitter): match compiled regex anywhere in the event path

### DIFF
--- a/python/beeai_framework/emitter/emitter.py
+++ b/python/beeai_framework/emitter/emitter.py
@@ -206,7 +206,7 @@ class Emitter:
             matchers.append(lambda _: True)
         elif isinstance(matcher, re.Pattern):
             match_nested = True if match_nested is None else match_nested
-            matchers.append(lambda event: matcher.match(event.path) is not None)
+            matchers.append(lambda event: matcher.search(event.path) is not None)
         elif callable(matcher):
             match_nested = False if match_nested is None else match_nested
             matchers.append(matcher)

--- a/python/tests/test_emitter.py
+++ b/python/tests/test_emitter.py
@@ -1,6 +1,7 @@
 # Copyright 2025 © BeeAI a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
+import re
 from typing import Any
 
 import pytest
@@ -187,6 +188,21 @@ class TestEventsPropagation:
 
         await emitter.emit("c", "c")
         assert calls == [1]
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_compiled_regex_matches_anywhere_in_path(self) -> None:
+        # A compiled regex should match anywhere in the event path (like the
+        # TypeScript sibling's `.test()`), not only when anchored at the start.
+        root = Emitter.root()
+        hits: list[str] = []
+        root.on(
+            re.compile(r"watsonx"),
+            lambda _, event: hits.append(event.path),
+            EmitterOptions(match_nested=True),
+        )
+        await root.child(namespace=["backend", "watsonx", "chat"]).emit("start", 1)
+        assert hits == ["backend.watsonx.chat.start"]
 
     @pytest.mark.unit
     @pytest.mark.asyncio


### PR DESCRIPTION
Closes #1556

## Problem

`Emitter._create_matcher` handles a compiled `re.Pattern` with `matcher.match()`:

```python
matchers.append(lambda event: matcher.match(event.path) is not None)
```

`re.Pattern.match` anchors at the **start** of the string, so a regex listener only fires when the pattern matches from the beginning of the event path. The TypeScript sibling (`typescript/src/emitter/emitter.ts`) uses `matcher.test()` (search anywhere), and the shipped example `emitter.on(re.compile(r"watsonx"), ...)` (`examples/emitter/matchers.py`) is meant to match a segment in the middle of a path such as `backend.watsonx.chat.start` — which never matches under `.match()`.

## Fix

Use `matcher.search()` (matches anywhere). `.search` is a superset of `.match`, so no previously-anchored pattern regresses.

```python
-            matchers.append(lambda event: matcher.match(event.path) is not None)
+            matchers.append(lambda event: matcher.search(event.path) is not None)
```

## Tests

Added `TestEventsPropagation::test_compiled_regex_matches_anywhere_in_path`. The existing `test_regex` uses a plain string (which routes through the string-name branch), so the `re.Pattern` path was untested.

Before the fix the new test fails (listener never fires); after, it passes:

```
$ pytest tests/test_emitter.py -k "regex or anywhere"
2 passed
```
