### PR TITLE
fix(chat): clear cached invalid tool call before retry

### DIFF
--- a/python/beeai_framework/backend/chat.py
+++ b/python/beeai_framework/backend/chat.py
@@ -570,6 +570,7 @@ class ChatModel(Runnable[ChatModelOutput]):
                             {"tempMessage": True},
                         )
                     )
+                    await cache_entry.delete()
                 elif self.retry_on_empty_response and isinstance(e, EmptyChatModelResponseError):
                     model_input.messages = model_input.messages.copy()
                     model_input.messages.append(AssistantMessage("", {"tempMessage": True}))

--- a/python/tests/backend/test_chatmodel_retry_cache.py
+++ b/python/tests/backend/test_chatmodel_retry_cache.py
@@ -1,0 +1,47 @@
+# Copyright 2025 BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import AsyncGenerator
+
+import pytest
+
+from beeai_framework.backend.chat import ChatModel
+from beeai_framework.backend.message import AssistantMessage, MessageToolCallContent, UserMessage
+from beeai_framework.backend.types import ChatModelInput, ChatModelOutput
+from beeai_framework.cache import SlidingCache
+from beeai_framework.context import RunContext
+
+
+class ToolCallRetryDummyModel(ChatModel):
+    model_id = "tool_call_retry_model"
+    # pyrefly: ignore [bad-override]
+    provider_id = "ollama"
+
+    def __init__(self) -> None:
+        super().__init__(cache=SlidingCache(size=4))
+        self.create_calls = 0
+
+    # pyrefly: ignore [bad-param-name-override]
+    async def _create(self, input: ChatModelInput, _: RunContext) -> ChatModelOutput:
+        self.create_calls += 1
+        if self.create_calls == 1:
+            return ChatModelOutput(
+                output=[AssistantMessage(MessageToolCallContent(id="call_1", tool_name="test_tool", args="not json"))]
+            )
+
+        return ChatModelOutput(output=[AssistantMessage("fixed tool call")])
+
+    # pyrefly: ignore [bad-param-name-override]
+    async def _create_stream(self, input: ChatModelInput, context: RunContext) -> AsyncGenerator[ChatModelOutput]:
+        yield await self._create(input, context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_chat_model_clears_cached_invalid_tool_call_before_retry() -> None:
+    chat_model = ToolCallRetryDummyModel()
+
+    response = await chat_model.run([UserMessage("call the tool")], max_retries=1)
+
+    assert response.get_text_content() == "fixed tool call"
+    assert chat_model.create_calls == 2


### PR DESCRIPTION
## Summary

- Clear the chat model cache entry before retrying `ChatModelToolCallError` recovery.
- Add a regression test that covers a cached malformed tool call followed by a successful retry.

## Why this matters

When invalid tool-call recovery appends correction messages, the retry should make a fresh model call. If the malformed response remains cached, the retry reads the same bad response again and the model never sees the correction messages.

Fixes #1554.

## Validation

- `python -m pytest tests/backend/test_chatmodel_retry_cache.py -q -o addopts=`
- `python -m ruff format --check beeai_framework/backend/chat.py tests/backend/test_chatmodel_retry_cache.py`
- `python -m ruff check beeai_framework/backend/chat.py tests/backend/test_chatmodel_retry_cache.py`