### PR TITLE
fix(emitter): distinguish regex listeners by pattern OR flags in off()

### DIFF
--- a/python/beeai_framework/emitter/emitter.py
+++ b/python/beeai_framework/emitter/emitter.py
@@ -312,7 +312,7 @@ def _match_listener(
             return False
 
         if isinstance(matcher, re.Pattern) and isinstance(listener.raw, re.Pattern):
-            if matcher.pattern != listener.raw.pattern and matcher.flags != listener.raw.flags:
+            if matcher.pattern != listener.raw.pattern or matcher.flags != listener.raw.flags:
                 return False
         elif callable(matcher) and callable(listener.raw):
             if not is_same_function(matcher, listener.raw):

--- a/python/tests/test_emitter.py
+++ b/python/tests/test_emitter.py
@@ -1,6 +1,7 @@
 # Copyright 2025 © BeeAI a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
+import re
 from typing import Any
 
 import pytest
@@ -187,6 +188,23 @@ class TestEventsPropagation:
 
         await emitter.emit("c", "c")
         assert calls == [1]
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_regex_off_distinguishes_flags(self) -> None:
+        emitter, calls = Emitter(), []
+
+        emitter.on(re.compile("c"), lambda data, __: calls.append(("plain", data)))
+        emitter.on(re.compile("c", re.IGNORECASE), lambda data, __: calls.append(("ci", data)))
+
+        await emitter.emit("c", 1)
+        assert calls == [("plain", 1), ("ci", 1)]
+
+        # Removing only the case-insensitive listener must leave the plain one.
+        emitter.off(re.compile("c", re.IGNORECASE))
+        calls.clear()
+        await emitter.emit("c", 2)
+        assert calls == [("plain", 2)]
 
     @pytest.mark.unit
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- `Emitter.off()` matched compiled-regex listeners with an `and` condition over pattern AND flags, so two listeners sharing a pattern but differing in flags (e.g. `re.IGNORECASE`) could not be removed independently — removing one removed the match test for both.
- Changed to `or` so a listener is only excluded when BOTH pattern and flags differ.

## Test plan
- Added `test_regex_off_distinguishes_flags` to `python/tests/test_emitter.py`.
- Fail-before/pass-after verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>