### PR TITLE
fix(emitter): off() with a compiled regex should only remove the matching listener

### DIFF
--- a/python/beeai_framework/emitter/emitter.py
+++ b/python/beeai_framework/emitter/emitter.py
@@ -312,7 +312,7 @@ def _match_listener(
             return False
 
         if isinstance(matcher, re.Pattern) and isinstance(listener.raw, re.Pattern):
-            if matcher.pattern != listener.raw.pattern and matcher.flags != listener.raw.flags:
+            if matcher.pattern != listener.raw.pattern or matcher.flags != listener.raw.flags:
                 return False
         elif callable(matcher) and callable(listener.raw):
             if not is_same_function(matcher, listener.raw):

--- a/python/tests/test_emitter.py
+++ b/python/tests/test_emitter.py
@@ -190,6 +190,22 @@ class TestEventsPropagation:
 
     @pytest.mark.unit
     @pytest.mark.asyncio
+    async def test_off_compiled_regex_only_removes_matching(self) -> None:
+        import re
+
+        emitter, calls_a, calls_b = Emitter(), [], []
+        emitter.on(re.compile("aaa"), lambda data, __: calls_a.append(data))
+        emitter.on(re.compile("bbb"), lambda data, __: calls_b.append(data))
+
+        # Removing the "bbb" listener must not remove the unrelated "aaa" one.
+        emitter.off(re.compile("bbb"))
+        await emitter.emit("aaa", 1)
+
+        assert calls_a == [1]
+        assert calls_b == []
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
     async def test_options(self) -> None:
         emitter, calls = Emitter(), []
 

--- a/python/tests/test_emitter.py
+++ b/python/tests/test_emitter.py
@@ -197,9 +197,11 @@ class TestEventsPropagation:
         emitter.on(re.compile("aaa"), lambda data, __: calls_a.append(data))
         emitter.on(re.compile("bbb"), lambda data, __: calls_b.append(data))
 
-        # Removing the "bbb" listener must not remove the unrelated "aaa" one.
+        # Removing the "bbb" listener must not remove the unrelated "aaa" one...
         emitter.off(re.compile("bbb"))
         await emitter.emit("aaa", 1)
+        # ...and the "bbb" listener must actually be gone (emitting it is a no-op).
+        await emitter.emit("bbb", 2)
 
         assert calls_a == [1]
         assert calls_b == []


### PR DESCRIPTION
## Problem

`Emitter.off()` with a compiled `re.Pattern` matcher removes **every** regex-registered listener, not just the matching one.

The helper `_match_listener` returns `True` when a listener should be removed. For the regex branch (`python/beeai_framework/emitter/emitter.py`):

```python
if isinstance(matcher, re.Pattern) and isinstance(listener.raw, re.Pattern):
    if matcher.pattern != listener.raw.pattern and matcher.flags != listener.raw.flags:
        return False
```

Two compiled regexes are equal iff **both** `pattern` and `flags` match, so they are *different* (a non-match → must `return False`) iff `pattern != ... OR flags != ...`. The code uses `and`, so it only reports a non-match when **both** the pattern *and* the flags differ. Since regexes compiled from a `str` all share the same default flags (`re.UNICODE`), the `flags !=` term is almost always `False`, so the whole condition is `False` and the function falls through to `return True` — treating any two distinct regex listeners as "equal".

## Reproduction

```python
emitter.on(re.compile("aaa"), cb_a)
emitter.on(re.compile("bbb"), cb_b)
emitter.off(re.compile("bbb"))   # intend to remove only cb_b
await emitter.emit("aaa", 1)
```

- **Before:** `cb_a` is also removed → never fires (`calls_a == []`).
- **After:** only `cb_b` removed → `cb_a` fires (`calls_a == [1]`).

## Fix

```python
if matcher.pattern != listener.raw.pattern or matcher.flags != listener.raw.flags:
    return False
```

Identical `pattern`+`flags` still matches (removable); differing patterns no longer match — verified.

## Test

Added `test_off_compiled_regex_only_removes_matching` to `TestEventsPropagation` in `python/tests/test_emitter.py`. It fails on the current code (`calls_a == []`) and passes after the fix. Full suite green: `cd python && pytest tests/test_emitter.py` → 15 passed. (The existing `test_regex` uses a `str` matcher, which flows through the string branch and is unaffected. The TypeScript `Emitter` has no `off()`, so this is Python-only.)
