### PR TITLE
feat: add Plivo tools for SMS and voice calls

### DIFF
--- a/docs/src/content/docs/modules/tools.mdx
+++ b/docs/src/content/docs/modules/tools.mdx
@@ -29,6 +29,8 @@ Ready-to-use tools that provide immediate functionality for common agent tasks:
 | [FileEdit](#file-edit) | Overwrite or search-and-replace a text file with a unified diff                                     |
 | [Glob](#glob)          | List files matching a glob pattern                                                                  |
 | [Grep](#grep)          | Recursively search files for a regex (uses ripgrep when available)                                  |
+| [PlivoSendMessage](#plivo) | Send an SMS text message to a phone number using Plivo                                          |
+| [PlivoMakeCall](#plivo)    | Place an outbound phone call using Plivo                                                         |
 
 ➕ [Request additional built-in tools](https://github.com/i-am-bee/beeai-framework/discussions)
 
@@ -1259,6 +1261,57 @@ The output shape is the same regardless of which backend ran — the `used_ripgr
 <Tip>
 Combine these tools with the [ACP Zed adapter](/integrations/acp-zed) to expose a coding agent inside the [Zed](https://zed.dev/) editor — file reads/writes route through Zed's unsaved buffers, shell commands open in Zed's terminal widget, all without changing your tool code.
 </Tip>
+
+<Heading level={3} id="plivo">Plivo SMS and voice tools</Heading>
+
+Use the Plivo tools to let an agent send SMS text messages and place outbound phone calls through the [Plivo](https://www.plivo.com/) cloud communications platform. `PlivoSendMessage` sends an SMS to a phone number, and `PlivoMakeCall` places a call that runs the answer XML hosted at a public URL when the call connects.
+
+Both tools read your Plivo credentials from the environment. Set `PLIVO_AUTH_ID` and `PLIVO_AUTH_TOKEN` (find them in the [Plivo console](https://console.plivo.com/)), and set `PLIVO_SRC` to the sender number or ID used for outgoing SMS. See the [Plivo API documentation](https://www.plivo.com/docs/) for details.
+
+<CodeGroup>
+
+```py Python [expandable]
+import asyncio
+
+from beeai_framework.tools.plivo.call import PlivoMakeCallTool, PlivoMakeCallToolInput
+from beeai_framework.tools.plivo.sms import PlivoSendMessageTool, PlivoSendMessageToolInput
+
+
+async def main() -> None:
+    sms = PlivoSendMessageTool()
+    sms_result = await sms.run(
+        PlivoSendMessageToolInput(to="+14150000001", text="Your order has shipped.")
+    )
+    print(sms_result.get_text_content())
+
+    call = PlivoMakeCallTool()
+    call_result = await call.run(
+        PlivoMakeCallToolInput(to="+14150000001", answer_url="https://example.com/answer.xml")
+    )
+    print(call_result.get_text_content())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+```ts TypeScript [expandable]
+import { PlivoSendMessageTool } from "beeai-framework/tools/plivo/sms";
+import { PlivoMakeCallTool } from "beeai-framework/tools/plivo/call";
+
+const sms = new PlivoSendMessageTool();
+const smsResult = await sms.run({ to: "+14150000001", text: "Your order has shipped." });
+console.info(smsResult.getTextContent());
+
+const call = new PlivoMakeCallTool();
+const callResult = await call.run({
+  to: "+14150000001",
+  answer_url: "https://example.com/answer.xml",
+});
+console.info(callResult.getTextContent());
+```
+
+</CodeGroup>
 
 ---
 

--- a/python/beeai_framework/tools/plivo/AGENTS.md
+++ b/python/beeai_framework/tools/plivo/AGENTS.md
@@ -1,0 +1,20 @@
+# Plivo tools — integration notes
+
+Plivo tools for the BeeAI framework: outbound SMS and outbound voice calls.
+
+## Tools
+- `PlivoSendMessage` — sends an SMS via `POST https://api.plivo.com/v1/Account/{auth_id}/Message/`. Success is HTTP `202` (message *queued*, not yet delivered).
+- `PlivoMakeCall` — places an outbound call via `POST https://api.plivo.com/v1/Account/{auth_id}/Call/`. Success is HTTP `201`. On answer, Plivo fetches `answer_url`, which must return Plivo answer XML (e.g. a `<Speak>` element).
+
+## Configuration
+Credentials are read from the environment, never hardcoded:
+- `PLIVO_AUTH_ID` — Plivo Auth ID (also the account segment of the REST path).
+- `PLIVO_AUTH_TOKEN` — Plivo Auth Token.
+- `PLIVO_SRC` — the default sender. For **SMS** this is the `src`: a Plivo number, a short code, or (where the destination country allows) an alphanumeric sender ID. For **calls** this is the `from` caller ID, which must be a voice-capable Plivo number in E.164 — alphanumeric sender IDs are not valid caller IDs.
+
+Auth is HTTP Basic (`auth_id:auth_token`). Numbers are E.164 (with `+`).
+
+Get credentials from the [Plivo console](https://cx.plivo.com/?utm_source=github&utm_medium=oss&utm_campaign=beeai-framework); see the [Plivo API docs](https://www.plivo.com/docs/) for the Message and Call endpoints. This is a REST integration (no audio streaming).
+
+## License / contribution
+Apache-2.0. Commits are DCO `Signed-off-by`.

--- a/python/beeai_framework/tools/plivo/__init__.py
+++ b/python/beeai_framework/tools/plivo/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+from beeai_framework.tools.plivo.call import PlivoMakeCallTool, PlivoMakeCallToolInput
+from beeai_framework.tools.plivo.sms import PlivoSendMessageTool, PlivoSendMessageToolInput
+
+__all__ = [
+    "PlivoMakeCallTool",
+    "PlivoMakeCallToolInput",
+    "PlivoSendMessageTool",
+    "PlivoSendMessageToolInput",
+]

--- a/python/beeai_framework/tools/plivo/call.py
+++ b/python/beeai_framework/tools/plivo/call.py
@@ -1,0 +1,66 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from typing import Any, Self
+
+import httpx
+from pydantic import BaseModel, Field
+
+from beeai_framework.context import RunContext
+from beeai_framework.emitter.emitter import Emitter
+from beeai_framework.logger import Logger
+from beeai_framework.tools import JSONToolOutput
+from beeai_framework.tools.errors import ToolError
+from beeai_framework.tools.tool import Tool
+from beeai_framework.tools.types import ToolRunOptions
+
+logger = Logger(__name__)
+
+
+class PlivoMakeCallToolInput(BaseModel):
+    to: str = Field(description="Destination phone number to call in E.164 format, e.g. +14150000001.")
+    answer_url: str = Field(
+        description="Publicly reachable URL that returns Plivo answer XML (e.g. a <Speak> element) when the call is answered."
+    )
+
+
+class PlivoMakeCallTool(Tool[PlivoMakeCallToolInput, ToolRunOptions, JSONToolOutput[dict[str, Any]]]):
+    name = "PlivoMakeCall"
+    description = "Place an outbound phone call using Plivo that runs the answer XML at the given URL when answered."
+    input_schema = PlivoMakeCallToolInput
+
+    async def clone(self) -> Self:
+        tool = self.__class__(options=self.options)
+        tool.name = self.name
+        tool.description = self.description
+        tool.input_schema = self.input_schema
+        tool.middlewares.extend(self.middlewares)
+        tool._cache = await self.cache.clone()
+        return tool
+
+    def _create_emitter(self) -> Emitter:
+        return Emitter.root().child(
+            namespace=["tool", "plivo", "call"],
+            creator=self,
+        )
+
+    async def _run(
+        self, input: PlivoMakeCallToolInput, options: ToolRunOptions | None, context: RunContext
+    ) -> JSONToolOutput[dict[str, Any]]:
+        auth_id = os.environ.get("PLIVO_AUTH_ID")
+        auth_token = os.environ.get("PLIVO_AUTH_TOKEN")
+        src = os.environ.get("PLIVO_SRC")
+        if not auth_id or not auth_token or not src:
+            raise ToolError("PLIVO_AUTH_ID, PLIVO_AUTH_TOKEN, and PLIVO_SRC must be set.")
+
+        logger.debug(f"Placing Plivo call to {input.to}")
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"https://api.plivo.com/v1/Account/{auth_id}/Call/",
+                auth=(auth_id, auth_token),
+                json={"from": src, "to": input.to, "answer_url": input.answer_url},
+                headers={"Content-Type": "application/json", "Accept": "application/json"},
+            )
+            response.raise_for_status()
+            return JSONToolOutput(response.json())

--- a/python/beeai_framework/tools/plivo/sms.py
+++ b/python/beeai_framework/tools/plivo/sms.py
@@ -1,0 +1,64 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from typing import Any, Self
+
+import httpx
+from pydantic import BaseModel, Field
+
+from beeai_framework.context import RunContext
+from beeai_framework.emitter.emitter import Emitter
+from beeai_framework.logger import Logger
+from beeai_framework.tools import JSONToolOutput
+from beeai_framework.tools.errors import ToolError
+from beeai_framework.tools.tool import Tool
+from beeai_framework.tools.types import ToolRunOptions
+
+logger = Logger(__name__)
+
+
+class PlivoSendMessageToolInput(BaseModel):
+    to: str = Field(description="Recipient phone number in E.164 format, e.g. +14150000001.")
+    text: str = Field(description="The text body of the SMS message to send.")
+
+
+class PlivoSendMessageTool(Tool[PlivoSendMessageToolInput, ToolRunOptions, JSONToolOutput[dict[str, Any]]]):
+    name = "PlivoSendMessage"
+    description = "Send an SMS text message to a phone number using Plivo."
+    input_schema = PlivoSendMessageToolInput
+
+    async def clone(self) -> Self:
+        tool = self.__class__(options=self.options)
+        tool.name = self.name
+        tool.description = self.description
+        tool.input_schema = self.input_schema
+        tool.middlewares.extend(self.middlewares)
+        tool._cache = await self.cache.clone()
+        return tool
+
+    def _create_emitter(self) -> Emitter:
+        return Emitter.root().child(
+            namespace=["tool", "plivo", "sms"],
+            creator=self,
+        )
+
+    async def _run(
+        self, input: PlivoSendMessageToolInput, options: ToolRunOptions | None, context: RunContext
+    ) -> JSONToolOutput[dict[str, Any]]:
+        auth_id = os.environ.get("PLIVO_AUTH_ID")
+        auth_token = os.environ.get("PLIVO_AUTH_TOKEN")
+        src = os.environ.get("PLIVO_SRC")
+        if not auth_id or not auth_token or not src:
+            raise ToolError("PLIVO_AUTH_ID, PLIVO_AUTH_TOKEN, and PLIVO_SRC must be set.")
+
+        logger.debug(f"Sending Plivo SMS to {input.to}")
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"https://api.plivo.com/v1/Account/{auth_id}/Message/",
+                auth=(auth_id, auth_token),
+                json={"src": src, "dst": input.to, "text": input.text, "type": "sms"},
+                headers={"Content-Type": "application/json", "Accept": "application/json"},
+            )
+            response.raise_for_status()
+            return JSONToolOutput(response.json())

--- a/typescript/src/tools/plivo/AGENTS.md
+++ b/typescript/src/tools/plivo/AGENTS.md
@@ -1,0 +1,20 @@
+# Plivo tools — integration notes
+
+Plivo tools for the BeeAI framework: outbound SMS and outbound voice calls.
+
+## Tools
+- `PlivoSendMessage` — sends an SMS via `POST https://api.plivo.com/v1/Account/{auth_id}/Message/`. Success is HTTP `202` (message *queued*, not yet delivered).
+- `PlivoMakeCall` — places an outbound call via `POST https://api.plivo.com/v1/Account/{auth_id}/Call/`. Success is HTTP `201`. On answer, Plivo fetches `answer_url`, which must return Plivo answer XML (e.g. a `<Speak>` element).
+
+## Configuration
+Credentials are read from the environment, never hardcoded:
+- `PLIVO_AUTH_ID` — Plivo Auth ID (also the account segment of the REST path).
+- `PLIVO_AUTH_TOKEN` — Plivo Auth Token.
+- `PLIVO_SRC` — the default sender. For **SMS** this is the `src`: a Plivo number, a short code, or (where the destination country allows) an alphanumeric sender ID. For **calls** this is the `from` caller ID, which must be a voice-capable Plivo number in E.164 — alphanumeric sender IDs are not valid caller IDs.
+
+Auth is HTTP Basic (`auth_id:auth_token`). Numbers are E.164 (with `+`).
+
+Get credentials from the [Plivo console](https://cx.plivo.com/?utm_source=github&utm_medium=oss&utm_campaign=beeai-framework); see the [Plivo API docs](https://www.plivo.com/docs/) for the Message and Call endpoints. This is a REST integration (no audio streaming).
+
+## License / contribution
+Apache-2.0. Commits are DCO `Signed-off-by`.

--- a/typescript/src/tools/plivo/call.ts
+++ b/typescript/src/tools/plivo/call.ts
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2025 © BeeAI a Series of LF Projects, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  BaseToolOptions,
+  BaseToolRunOptions,
+  ToolEmitter,
+  JSONToolOutput,
+  Tool,
+  ToolError,
+  ToolInput,
+} from "@/tools/base.js";
+import { z } from "zod";
+import { RunContext } from "@/context.js";
+import { Emitter } from "@/emitter/emitter.js";
+
+type ToolOptions = BaseToolOptions;
+type ToolRunOptions = BaseToolRunOptions;
+
+export class PlivoMakeCallToolOutput extends JSONToolOutput<Record<string, any>> {}
+
+export class PlivoMakeCallTool extends Tool<
+  PlivoMakeCallToolOutput,
+  ToolOptions,
+  ToolRunOptions
+> {
+  name = "PlivoMakeCall";
+  description =
+    "Place an outbound phone call using Plivo that runs the answer XML at the given URL when answered.";
+
+  inputSchema() {
+    return z
+      .object({
+        to: z
+          .string()
+          .min(1)
+          .describe("Destination phone number to call in E.164 format, e.g. +14150000001."),
+        answer_url: z
+          .string()
+          .url()
+          .describe(
+            "Publicly reachable URL that returns Plivo answer XML (e.g. a <Speak> element) when the call is answered.",
+          ),
+      })
+      .strip();
+  }
+
+  public readonly emitter: ToolEmitter<ToolInput<this>, PlivoMakeCallToolOutput> =
+    Emitter.root.child({
+      namespace: ["tool", "plivo", "call"],
+      creator: this,
+    });
+
+  static {
+    this.register();
+  }
+
+  public constructor(options: Partial<ToolOptions> = {}) {
+    super(options);
+  }
+
+  protected async _run(
+    { to, answer_url: answerUrl }: ToolInput<this>,
+    _options: Partial<BaseToolRunOptions>,
+    run: RunContext<this>,
+  ) {
+    const authId = process.env.PLIVO_AUTH_ID;
+    const authToken = process.env.PLIVO_AUTH_TOKEN;
+    const src = process.env.PLIVO_SRC;
+    if (!authId || !authToken || !src) {
+      throw new ToolError("PLIVO_AUTH_ID, PLIVO_AUTH_TOKEN, and PLIVO_SRC must be set.");
+    }
+
+    const response = await fetch(`https://api.plivo.com/v1/Account/${authId}/Call/`, {
+      method: "POST",
+      headers: {
+        Authorization: `Basic ${Buffer.from(`${authId}:${authToken}`).toString("base64")}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({ from: src, to, answer_url: answerUrl }),
+      signal: run.signal,
+    });
+
+    if (!response.ok) {
+      throw new ToolError("Request to Plivo Call API has failed!", [
+        new Error(await response.text()),
+      ]);
+    }
+
+    return new PlivoMakeCallToolOutput(await response.json());
+  }
+}

--- a/typescript/src/tools/plivo/sms.ts
+++ b/typescript/src/tools/plivo/sms.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2025 © BeeAI a Series of LF Projects, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  BaseToolOptions,
+  BaseToolRunOptions,
+  ToolEmitter,
+  JSONToolOutput,
+  Tool,
+  ToolError,
+  ToolInput,
+} from "@/tools/base.js";
+import { z } from "zod";
+import { RunContext } from "@/context.js";
+import { Emitter } from "@/emitter/emitter.js";
+
+type ToolOptions = BaseToolOptions;
+type ToolRunOptions = BaseToolRunOptions;
+
+export class PlivoSendMessageToolOutput extends JSONToolOutput<Record<string, any>> {}
+
+export class PlivoSendMessageTool extends Tool<
+  PlivoSendMessageToolOutput,
+  ToolOptions,
+  ToolRunOptions
+> {
+  name = "PlivoSendMessage";
+  description = "Send an SMS text message to a phone number using Plivo.";
+
+  inputSchema() {
+    return z
+      .object({
+        to: z.string().min(1).describe("Recipient phone number in E.164 format, e.g. +14150000001."),
+        text: z.string().min(1).describe("The text body of the SMS message to send."),
+      })
+      .strip();
+  }
+
+  public readonly emitter: ToolEmitter<ToolInput<this>, PlivoSendMessageToolOutput> =
+    Emitter.root.child({
+      namespace: ["tool", "plivo", "sms"],
+      creator: this,
+    });
+
+  static {
+    this.register();
+  }
+
+  public constructor(options: Partial<ToolOptions> = {}) {
+    super(options);
+  }
+
+  protected async _run(
+    { to, text }: ToolInput<this>,
+    _options: Partial<BaseToolRunOptions>,
+    run: RunContext<this>,
+  ) {
+    const authId = process.env.PLIVO_AUTH_ID;
+    const authToken = process.env.PLIVO_AUTH_TOKEN;
+    const src = process.env.PLIVO_SRC;
+    if (!authId || !authToken || !src) {
+      throw new ToolError("PLIVO_AUTH_ID, PLIVO_AUTH_TOKEN, and PLIVO_SRC must be set.");
+    }
+
+    const response = await fetch(`https://api.plivo.com/v1/Account/${authId}/Message/`, {
+      method: "POST",
+      headers: {
+        Authorization: `Basic ${Buffer.from(`${authId}:${authToken}`).toString("base64")}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({ src, dst: to, text }),
+      signal: run.signal,
+    });
+
+    if (!response.ok) {
+      throw new ToolError("Request to Plivo Message API has failed!", [
+        new Error(await response.text()),
+      ]);
+    }
+
+    return new PlivoSendMessageToolOutput(await response.json());
+  }
+}


### PR DESCRIPTION
### Which issue(s) does this pull-request address?

Closes: #1568

### Description

Adds a native Plivo tool so a BeeAI agent can send SMS and place outbound voice calls, with Python and TypeScript parity. Follows the existing weather (openmeteo) tool pattern, an input model plus a Tool subclass whose `_run` calls the Plivo REST API.

- `PlivoSendMessage` — send an SMS to a phone number
- `PlivoMakeCall` — place an outbound call that runs answer XML from a given URL

Files: `python/beeai_framework/tools/plivo/` (`sms.py`, `call.py`, `__init__.py`) and `typescript/src/tools/plivo/` (`sms.ts`, `call.ts`). Credentials are read from the environment (`PLIVO_AUTH_ID`, `PLIVO_AUTH_TOKEN`, `PLIVO_SRC`). The change is additive and no existing behavior changes.

Verified against a live Plivo account by setting up an agent — `PlivoSendMessage` sent a real SMS end to end, and `PlivoMakeCall` placed a real outbound call.

### Checklist

#### General
- [x] I have read the appropriate contributor guide (Python / TypeScript)
- [x] I have signed off on my commit (DCO)
- [x] Commit messages and PR title follow conventional commits
- [x] Appropriate label(s) added to PR: `Python` and `TypeScript`

#### Testing
- [x] Verified end to end against a live Plivo account (SMS delivered, outbound call placed)