### PR TITLE
chore(utils): Set units to seconds in the abort message

### DIFF
--- a/python/beeai_framework/utils/cancellation.py
+++ b/python/beeai_framework/utils/cancellation.py
@@ -46,7 +46,7 @@ class AbortSignal(BaseModel):
         signal = cls()
 
         loop = asyncio.get_event_loop()
-        loop.call_later(duration, lambda *args: signal._abort(f"Operation timed out after {duration} ms"))
+        loop.call_later(duration, lambda *args: signal._abort(f"Operation timed out after {duration} s"))
 
         return signal
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review and complete the sections below.
-->

### Which issue(s) does this pull-request address?

https://github.com/i-am-bee/beeai-framework/issues/1574

Closes: #

### Description

Simple change in reported time units.

### Checklist

#### General
- [x] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [x] Code quality checks pass: `mise check` (`mise fix` to auto-fix)

#### Testing
- [x] Unit tests pass: `mise test:unit`
- [x] E2E tests pass: `mise test:e2e`
- [x] Tests are included (for bug fixes or new features)

#### Documentation
- [x] Documentation is updated
- [ ] Embedme embeds code examples in docs. To update after edits, run: Python `mise docs:fix`
