### PR TITLE
feat(adapters): propagate error context through `_meta` on MCP tool errors

### DIFF
--- a/python/beeai_framework/adapters/mcp/serve/server.py
+++ b/python/beeai_framework/adapters/mcp/serve/server.py
@@ -169,7 +169,16 @@ def _tool_factory(
 ) -> MCPNativeTool:
     async def run(**kwargs: Any) -> MCPCallToolResult:
         cloned_tool = await tool.clone()
-        output: ToolOutput = await cloned_tool.run(kwargs)
+        try:
+            output: ToolOutput = await cloned_tool.run(kwargs)
+        except Exception as e:
+            error_context = getattr(e, "context", None) or {}
+            meta = {"error_context": error_context} if error_context else None
+            return MCPCallToolResult(
+                content=[MCPTextContent(type="text", text=f"Error executing tool {tool.name}: {e}")],
+                isError=True,
+                _meta=meta,
+            )
 
         return MCPCallToolResult(
             content=[MCPTextContent(type="text", text=output.get_text_content())],
@@ -195,7 +204,9 @@ def _tool_factory(
         # The FastMCP server allows either returning a structured output or a message. We want to support both.
         # Based on https://github.com/modelcontextprotocol/python-sdk
         # ... return a tuple of (content, structured_data)
-        lambda result: (result.content, result.structuredContent),
+        # Error results are passed through as CallToolResult so the lowlevel server
+        # preserves isError and _meta (the tuple path reconstructs with isError=False).
+        lambda result: result if result.isError else (result.content, result.structuredContent),
     )
 
     return mcp_tool

--- a/python/beeai_framework/tools/mcp/mcp.py
+++ b/python/beeai_framework/tools/mcp/mcp.py
@@ -98,7 +98,11 @@ class MCPTool(Tool[BaseModel, ToolRunOptions, JSONToolOutput]):
                 data_result = result.content
 
         if result.isError:
-            raise ToolError(to_json(data_result, indent=4, sort_keys=False))
+            error_context = (result.meta or {}).get("error_context")
+            raise ToolError(
+                to_json(data_result, indent=4, sort_keys=False),
+                context=error_context if isinstance(error_context, dict) else None,
+            )
 
         return JSONToolOutput(data_result)
 

--- a/python/tests/adapters/mcp/__init__.py
+++ b/python/tests/adapters/mcp/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0

--- a/python/tests/adapters/mcp/serve/__init__.py
+++ b/python/tests/adapters/mcp/serve/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0

--- a/python/tests/adapters/mcp/serve/test_tool_factory.py
+++ b/python/tests/adapters/mcp/serve/test_tool_factory.py
@@ -1,0 +1,140 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+import pytest
+
+pytest.importorskip("mcp", reason="Optional module [mcp] not installed.")
+from mcp.types import CallToolResult, TextContent
+from pydantic import BaseModel
+
+from beeai_framework.adapters.mcp.serve.server import _tool_factory
+from beeai_framework.context import RunContext
+from beeai_framework.emitter import Emitter
+from beeai_framework.tools import ToolError
+from beeai_framework.tools.tool import Tool
+from beeai_framework.tools.types import StringToolOutput, ToolRunOptions
+from beeai_framework.utils.strings import to_safe_word
+
+
+class DummyInput(BaseModel):
+    value: str = ""
+
+
+class SuccessTool(Tool[DummyInput, ToolRunOptions, StringToolOutput]):
+    name = "success_tool"
+    description = "Returns a string"
+    input_schema = DummyInput
+
+    def _create_emitter(self) -> Emitter:
+        return Emitter.root().child(namespace=["tool", "custom", to_safe_word(self.name)], creator=self)
+
+    async def _run(self, input: DummyInput, options: Any, context: RunContext) -> StringToolOutput:
+        return StringToolOutput("ok")
+
+
+class FailingTool(Tool[DummyInput, ToolRunOptions, StringToolOutput]):
+    name = "failing_tool"
+    description = "Always fails"
+    input_schema = DummyInput
+
+    def _create_emitter(self) -> Emitter:
+        return Emitter.root().child(namespace=["tool", "custom", to_safe_word(self.name)], creator=self)
+
+    async def _run(self, input: DummyInput, options: Any, context: RunContext) -> StringToolOutput:
+        raise ToolError("something went wrong", context={"request_id": "abc-123"})
+
+
+class FailingToolNoContext(Tool[DummyInput, ToolRunOptions, StringToolOutput]):
+    name = "failing_tool_no_ctx"
+    description = "Fails without context"
+    input_schema = DummyInput
+
+    def _create_emitter(self) -> Emitter:
+        return Emitter.root().child(namespace=["tool", "custom", to_safe_word(self.name)], creator=self)
+
+    async def _run(self, input: DummyInput, options: Any, context: RunContext) -> StringToolOutput:
+        raise RuntimeError("unexpected failure")
+
+
+class TestToolFactory:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_success_returns_result_with_meta(self) -> None:
+        mcp_tool = _tool_factory(SuccessTool())
+        result = await mcp_tool.run({"value": "test"})
+
+        assert isinstance(result, CallToolResult)
+        assert not result.isError
+        assert result.meta == {"is_empty": False}
+        assert len(result.content) == 1
+        assert isinstance(result.content[0], TextContent)
+        assert result.content[0].text == "ok"
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_error_returns_error_result_with_context_in_meta(self) -> None:
+        mcp_tool = _tool_factory(FailingTool())
+        result = await mcp_tool.run({"value": "test"})
+
+        assert isinstance(result, CallToolResult)
+        assert result.isError
+        assert isinstance(result.content[0], TextContent)
+        assert "something went wrong" in result.content[0].text
+        assert result.meta is not None
+        assert result.meta["error_context"]["request_id"] == "abc-123"
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_error_without_explicit_context_still_has_tool_name(self) -> None:
+        mcp_tool = _tool_factory(FailingToolNoContext())
+        result = await mcp_tool.run({"value": "test"})
+
+        assert isinstance(result, CallToolResult)
+        assert result.isError
+        # ToolError.ensure() always adds the tool name to context
+        assert result.meta == {"error_context": {"name": "failing_tool_no_ctx"}}
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_error_message_includes_tool_name(self) -> None:
+        mcp_tool = _tool_factory(FailingTool())
+        result = await mcp_tool.run({"value": "test"})
+
+        assert isinstance(result.content[0], TextContent)
+        assert result.content[0].text.startswith("Error executing tool failing_tool: ")
+
+    @pytest.mark.unit
+    def test_convert_result_passes_through_error_results(self) -> None:
+        mcp_tool = _tool_factory(SuccessTool())
+        convert_result = mcp_tool.fn_metadata.convert_result
+
+        error_result = CallToolResult(
+            content=[TextContent(type="text", text="error")],
+            isError=True,
+            _meta={"error_context": {"key": "val"}},
+        )
+        converted = convert_result(error_result)
+
+        assert isinstance(converted, CallToolResult)
+        assert converted.isError
+        assert converted.meta == {"error_context": {"key": "val"}}
+
+    @pytest.mark.unit
+    def test_convert_result_returns_tuple_for_success(self) -> None:
+        mcp_tool = _tool_factory(SuccessTool())
+        convert_result = mcp_tool.fn_metadata.convert_result
+
+        success_result = CallToolResult(
+            content=[TextContent(type="text", text="ok")],
+            isError=False,
+            _meta={"is_empty": False},
+        )
+        converted = convert_result(success_result)
+
+        assert isinstance(converted, tuple)
+        assert len(converted) == 2
+        content, structured = converted
+        assert content == success_result.content
+        assert structured == success_result.structuredContent

--- a/python/tests/tools/test_mcp_tool.py
+++ b/python/tests/tools/test_mcp_tool.py
@@ -130,10 +130,12 @@ class TestMCPTool:
         # Arrange
         tool = MCPTool(session=mock_client_session, tool=mock_tool_info)
 
-        error_result = MagicMock(spec=CallToolResult)
-        error_result.isError = True
-        error_result.content = {"error": "test error"}
-        error_result.structuredContent = {"code": 500}
+        structured_content = {"code": 500}
+        error_result = CallToolResult(
+            content=[TextContent(type="text", text="test error")],
+            structuredContent=structured_content,
+            isError=True,
+        )
         mock_client_session.call_tool.return_value = error_result
 
         class Input(BaseModel):
@@ -143,11 +145,35 @@ class TestMCPTool:
 
         # Act & Assert
         with pytest.raises(ToolError) as exc_info:
-            # We test _run directly to isolate the change
             await tool._run(input_data=Input(), options=None, context=context)
 
-        assert exc_info.value.message == to_json(error_result.structuredContent, indent=4, sort_keys=False)
+        assert exc_info.value.message == to_json(structured_content, indent=4, sort_keys=False)
         mock_client_session.call_tool.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_mcp_tool_run_with_error_context(
+        self, mock_client_session: AsyncMock, mock_tool_info: MCPToolInfo
+    ) -> None:
+        tool = MCPTool(session=mock_client_session, tool=mock_tool_info)
+
+        error_context = {"request_id": "abc-123", "endpoint": "/api/v1"}
+        error_result = CallToolResult(
+            content=[TextContent(type="text", text="something went wrong")],
+            isError=True,
+            _meta={"error_context": error_context},
+        )
+        mock_client_session.call_tool.return_value = error_result
+
+        class Input(BaseModel):
+            pass
+
+        context = MagicMock(spec=RunContext)
+
+        with pytest.raises(ToolError) as exc_info:
+            await tool._run(input_data=Input(), options=None, context=context)
+
+        assert exc_info.value.context == error_context
 
 
 # Calculator Tool Tests


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review and complete the sections below.
-->

### Description

<!-- Provide a description of the change, pay special attention to describing any breaking changes.  The description describes the resolution to the problem described in the linked issue (or to the problem outlined in this PR). -->

When a tool raises a `ToolError` with a `context` dict, the error context is now transported across the MCP boundary via the `_meta` field on `CallToolResult`. The server-side `_tool_factory` catches exceptions early, preserving the `context` dict in `_meta`. The client-side `MCPTool._run()` restores it onto the reconstructed `ToolError`.

### Checklist

#### General
- [x] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [x] Code quality checks pass: `mise check` (`mise fix` to auto-fix)

#### Testing
- [x] Unit tests pass: `mise test:unit`
- [ ] E2E tests pass: `mise test:e2e`
- [x] Tests are included (for bug fixes or new features)

#### Documentation
- [ ] Documentation is updated
- [ ] Embedme embeds code examples in docs. To update after edits, run: Python `mise docs:fix`
