### PR TITLE
fix(emitter): propagate errors from emitter

### DIFF
--- a/python/beeai_framework/emitter/emitter.py
+++ b/python/beeai_framework/emitter/emitter.py
@@ -234,12 +234,23 @@ class Emitter:
         return lambda event: all(match_fn(event) for match_fn in matchers)
 
     async def emit(self, name: str, value: Any) -> None:
+        """Emit event, preserving the original error context on failure."""
+        event = None
         try:
             assert_valid_name(name)
             event = self._create_event(name)
             await self._invoke(value, event)
         except Exception as e:
-            raise EmitterError.ensure(e)
+            event_id = event.path if event else name
+            if original_error := getattr(value, "error", None):
+                message = f"Error during event emission. Event: {event_id}. Original error: {original_error}"
+            else:
+                message = f"Error during event emission. Event: {event_id}"
+            raise EmitterError.ensure(
+                e,
+                message=message,
+                event=event,
+            )
 
     async def _invoke(self, data: Any, event: EventMeta) -> None:
         async def run(ln: Listener) -> Any:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review and complete the sections below.
-->

### Which issue(s) does this pull-request address?

<!--
Please include a link to an issue in the tracker.  The issue describes the problem to be solved.  If there is no issue raised for this PR then either raise one with a summary and description of the problem or add a summary and description of the problem here
-->

Closes: #1578 

### Description

Errors that were previously swallowed by emitter and replaced with generic `"Emitter error"` are now preserved. Even if an exception is triggered when calling `assert_valid_name`, creating event, or calling `_invoke`.

The approach is slightly paranoid, but it should cover all possibilities explicitly. 

#### General
- [x] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [x] Code quality checks pass: `mise check` (`mise fix` to auto-fix)

#### Testing
- [x] Unit tests pass: `mise test:unit`
- [ ] E2E tests pass: `mise test:e2e`


#### Documentation
- [x] Documentation is updated
- [ ] Embedme embeds code examples in docs. To update after edits, run: Python `mise docs:fix`
