### PR TITLE
fix(emitter): keep an unset group_id unset when cloning

### DIFF
--- a/python/beeai_framework/emitter/emitter.py
+++ b/python/beeai_framework/emitter/emitter.py
@@ -281,12 +281,12 @@ class Emitter:
 
     async def clone(self) -> "Emitter":
         cloned = Emitter(
-            str(self._group_id),
-            self.namespace.copy(),
-            self.creator if self.creator else None,
-            self.context.copy(),
-            self.trace.model_copy() if self.trace else None,
-            self._events.copy(),
+            group_id=self._group_id,
+            namespace=self.namespace.copy(),
+            creator=self.creator,
+            context=self.context.copy(),
+            trace=self.trace.model_copy() if self.trace else None,
+            events=self._events.copy(),
         )
         for listener in self._listeners:
             cloned.on(listener.raw, listener.callback, listener.options.model_copy() if listener.options else None)

--- a/python/tests/test_emitter.py
+++ b/python/tests/test_emitter.py
@@ -64,6 +64,52 @@ async def test_clone() -> None:
     assert clone.events is not emitter.events
 
 
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_clone_preserves_group_id() -> None:
+    emitter = Emitter(group_id="test_group", namespace=["namespace"])
+    clone = await emitter.clone()
+
+    assert clone._group_id == "test_group"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_clone_keeps_absent_group_id_absent() -> None:
+    # Agents build their emitter without a group id, so the clone must not turn
+    # the absent value into something truthy.
+    emitter = Emitter(namespace=["namespace"])
+    assert emitter._group_id is None
+
+    clone = await emitter.clone()
+
+    assert clone._group_id is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_clone_emits_events_without_a_group_id() -> None:
+    emitter = Emitter(namespace=["app"])
+    clone = await emitter.clone()
+
+    group_ids: list[str | None] = []
+    clone.on("*", lambda _, event: group_ids.append(event.group_id))
+    await clone.emit("a", 1)
+
+    assert group_ids == [None]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_child_of_clone_inherits_absent_group_id() -> None:
+    emitter = Emitter(namespace=["app"])
+    clone = await emitter.clone()
+
+    child = clone.child(namespace=["child"])
+
+    assert child._group_id is None
+
+
 class TestEventsPropagation:
     @pytest.mark.unit
     @pytest.mark.asyncio


### PR DESCRIPTION
### Which issue(s) does this pull-request address?

Closes: #1581

### Description

`Emitter.clone()` built the clone with the group id passed positionally through `str()`:

```python
cloned = Emitter(
    str(self._group_id),
    ...
)
```

`group_id` is `str | None` and defaults to `None`, so when it was unset the clone received the literal string `"None"`. `_create_event()` stamps `group_id=self._group_id` onto every `EventMeta`, and `child()` does `group_id=group_id or self._group_id`, so the synthetic value propagated to every event emitted by the clone and by every emitter descended from it.

Measured on `main` (`21284d7`, Python 3.12.10):

| expression | before | after |
|---|---|---|
| `Emitter(namespace=["app"])._group_id` | `None` | `None` |
| `(await that.clone())._group_id` | `'None'` | `None` |
| `cl._group_id is None` | `False` | `True` |
| `bool(cl._group_id)` | `True` | `False` |
| `event.group_id` from the clone | `'None'` | `None` |
| `(await that.clone()).child(...)._group_id` | `'None'` | `None` |
| clone with `group_id="run-42"` | `'run-42'` | `'run-42'` |

Agents are the common case rather than an edge case. All nine `clone()` implementations do `cloned.emitter = await self.emitter.clone()` — the four adapter agents (`a2a`, `acp`, `agentstack`, `watsonx_orchestrate`), the four core agents (`lite`, `react`, `requirement`, `tool_calling`), and `context.py:281` — and agents build their emitter via `Emitter.root().child(namespace=["agent", "tool_calling"], creator=self, events=...)` with no group id. Events off a cloned agent looked like this:

```
run.agent.tool_calling.start     group_id='None'
agent.tool_calling.done          group_id='None'
```

Anything grouping or filtering by `group_id` therefore saw a spurious `"None"` group for cloned agents: `if meta.group_id:` became true, `meta.group_id is None` became false, and a dict keyed by group id gained a `"None"` bucket. Forwarding `meta.group_id` to a tracing backend recorded the string as-is.

The fix passes the constructor arguments by keyword and drops the coercion, so the absent value stays absent. `creator` no longer needs the `if self.creator else None` guard — the attribute is already `object | None`, so the conditional was a no-op.

The TypeScript emitter does `this.groupId = input?.groupId` (`typescript/src/emitter/emitter.ts:60`) and preserves the absent value through `child()` (`:80`) and `createSnapshot()` (`:254`), so this was a Python-only divergence and no TypeScript change is needed.

### Why the existing test missed it

`test_clone` constructs with `group_id="test_group"`, and a real group id round-trips through `str()` unchanged, so the only broken path — the default `None` — was never exercised. Four tests are added next to it:

| test | red before this change |
|---|---|
| `test_clone_keeps_absent_group_id_absent` | ✅ `AssertionError: assert 'None' is None` |
| `test_clone_emits_events_without_a_group_id` | ✅ `assert ['None'] == [None]` |
| `test_child_of_clone_inherits_absent_group_id` | ✅ `AssertionError: assert 'None' is None` |
| `test_clone_preserves_group_id` | green both ways — regression guard for the real-id path |

### Checklist

#### General
- [x] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [ ] [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes — I cannot set labels on this repo; please add `Python`.

#### Code quality checks
- [x] Code quality checks pass: `ruff check` and `ruff format --check` are clean on both changed files. `mypy beeai_framework/emitter/emitter.py` reports only four pre-existing findings unrelated to this diff (missing `deprecated`/`cachetools` stubs, `utils/schema.py:67`, `backend/chat.py:489`) — identical with the change reverted.

#### Testing
- [x] Unit tests pass — `python -m pytest -m unit`, run on Windows/Python 3.12.10:

  | | before | after |
  |---|---|---|
  | passed | 290 | 293 |
  | failed | 4 | 1 |
  | skipped | 4 | 4 |

  The 3 resolved failures are the new tests. The 1 remaining failure is the same in both runs and unrelated: `tests/tools/filesystem/test_read_edit.py::test_tools_route_through_installed_backend` fails with `ToolInputValidationError: 'path' must be absolute, got: '/tmp/virtual.txt'` — a POSIX path that is not absolute on Windows, so it is a platform artefact of my environment, not a regression.

  Two collection paths are excluded in my environment and in both runs equally: `beeai_framework/adapters/transformers` and `tests/backend/providers/test_transformers.py`, which fail to import with `ModuleNotFoundError: No module named 'outlines_core.fsm'` from the installed `outlines` package.
- [ ] E2E tests pass: `mise test:e2e` — not run; they require model-provider credentials I do not have. This change touches no provider code path.
- [x] Tests are included (for bug fixes or new features)

#### Documentation
- [ ] Documentation is updated — no doc change needed; the fix restores the documented `str | None` contract rather than altering it.
- [ ] Embedme embeds code examples in docs — no examples touched.
