### PR TITLE
fix(emitter): preserve unset group id when cloning

### DIFF
--- a/python/beeai_framework/emitter/emitter.py
+++ b/python/beeai_framework/emitter/emitter.py
@@ -281,7 +281,7 @@ class Emitter:
 
     async def clone(self) -> "Emitter":
         cloned = Emitter(
-            str(self._group_id),
+            self._group_id,
             self.namespace.copy(),
             self.creator if self.creator else None,
             self.context.copy(),

--- a/python/tests/test_emitter.py
+++ b/python/tests/test_emitter.py
@@ -64,6 +64,26 @@ async def test_clone() -> None:
     assert clone.events is not emitter.events
 
 
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_clone_preserves_unset_group_id() -> None:
+    emitter = Emitter(namespace=["namespace"])
+    assert emitter._group_id is None
+
+    clone = await emitter.clone()
+
+    assert clone._group_id is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_clone_preserves_set_group_id() -> None:
+    emitter = Emitter(group_id="test_group", namespace=["namespace"])
+    clone = await emitter.clone()
+
+    assert clone._group_id == "test_group"
+
+
 class TestEventsPropagation:
     @pytest.mark.unit
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`Emitter.clone()` built the cloned emitter by passing `str(self._group_id)`. Since `group_id` is `str | None` and defaults to `None`, an unset group id became the literal string `"None"` — a truthy, meaningless value that changed event semantics after cloning (e.g. `EventMeta.group_id` would suddenly be `"None"` instead of `None`).

The fix passes the group id through unchanged, so a clone of an emitter without a group id keeps `None`.

## Changes

- `python/beeai_framework/emitter/emitter.py`: `clone()` now passes `self._group_id` directly instead of `str(self._group_id)`.
- `python/tests/test_emitter.py`: regression tests — cloning preserves both an unset (`None`) and a set group id.

## Tests

`python -m pytest tests/test_emitter.py` → 18 passed. Dependent clone consumers (lite agent, token/summarize/sliding memory) → 33 passed. `ruff check` on changed files → clean.

Fixes #1581
