### PR TITLE
fix(utils): report timeout duration in seconds

### DIFF
--- a/python/beeai_framework/utils/cancellation.py
+++ b/python/beeai_framework/utils/cancellation.py
@@ -46,7 +46,7 @@ class AbortSignal(BaseModel):
         signal = cls()
 
         loop = asyncio.get_event_loop()
-        loop.call_later(duration, lambda *args: signal._abort(f"Operation timed out after {duration} ms"))
+        loop.call_later(duration, lambda *args: signal._abort(f"Operation timed out after {duration} s"))
 
         return signal
 

--- a/python/tests/utils/test_cancellation.py
+++ b/python/tests/utils/test_cancellation.py
@@ -1,0 +1,30 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+
+import pytest
+
+from beeai_framework.utils import AbortSignal
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_timeout_reason_uses_seconds() -> None:
+    # loop.call_later() takes seconds, so the abort reason must not label the
+    # duration as milliseconds.
+    signal = AbortSignal.timeout(0.01)
+    await asyncio.sleep(0.05)
+
+    assert signal.aborted
+    assert signal.reason == "Operation timed out after 0.01 s"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_manual_abort_reason() -> None:
+    signal = AbortSignal()
+    signal._abort("custom reason")
+
+    assert signal.aborted
+    assert signal.reason == "custom reason"


### PR DESCRIPTION
## What changed

`AbortSignal.timeout()` schedules its abort via `loop.call_later(duration, ...)`, where `duration` is expressed in **seconds** — but the abort reason message said `"Operation timed out after {duration} ms"`, which reports the wrong unit.

This PR fixes the message to use the correct unit (`s`), so e.g. `AbortSignal.timeout(0.01)` produces `"Operation timed out after 0.01 s"`.

## Why

The mismatch is user-facing: any code that surfaces the abort reason (for example, retry logic or error reporting) would display a misleading duration. The message now matches what `call_later` actually received.

## Tests

Added `python/tests/utils/test_cancellation.py`:

- `test_timeout_reason_uses_seconds` — asserts the reason for a sub-second timeout is reported in seconds, not milliseconds (fails on the old code, passes now).
- `test_manual_abort_reason` — guards the manual abort path.

Verified: new tests red → green; full `tests/utils` suite passes (53 passed); `ruff check` clean.

Note: one pre-existing failure in `tests/backend/test_chatmodel.py::test_cache_cleared_on_tool_call_error` reproduces on a clean `main` and is unrelated to this change.

Fixes #1574
