### PR TITLE
fix(adapters): support Responses API text content parts

### DIFF
--- a/python/beeai_framework/adapters/openai/serve/responses/_types.py
+++ b/python/beeai_framework/adapters/openai/serve/responses/_types.py
@@ -1,6 +1,6 @@
 # Copyright 2025 © BeeAI a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, TypeAlias
+from typing import Any, Literal, TypeAlias
 
 from pydantic import BaseModel, Field
 
@@ -12,13 +12,18 @@ class BaseEvent(BaseModel):
 # request
 
 
+class ResponsesRequestInputTextContent(BaseModel):
+    type: Literal["input_text"] = Field("input_text", description="The type of the content part.")
+    text: str = Field(..., description="The text content.")
+
+
 class ResponsesRequestInputMessage(BaseEvent):
     role: str = Field(
         ...,
         description="The role of the message input. One of 'user', 'assistant', 'system', or 'developer'.",
         pattern="^(user|assistant|developer|system)$",
     )
-    content: str | None = Field(
+    content: str | list[ResponsesRequestInputTextContent] | None = Field(
         None,
         description="Input to the model, used to generate a response. Can also contain previous assistant responses.",
     )

--- a/python/beeai_framework/adapters/openai/serve/responses/_utils.py
+++ b/python/beeai_framework/adapters/openai/serve/responses/_utils.py
@@ -1,24 +1,38 @@
 # Copyright 2025 © BeeAI a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import cast
+
 import beeai_framework.adapters.openai.serve.responses._types as openai_api
 from beeai_framework.backend import AssistantMessage, SystemMessage
 from beeai_framework.backend.message import (
     AnyMessage,
+    AssistantMessageContent,
+    MessageTextContent,
     UserMessage,
+    UserMessageContent,
 )
 from beeai_framework.logger import Logger
 
 logger = Logger(__name__)
 
 
+def _message_content(message: openai_api.ResponsesRequestInputMessage) -> str | list[MessageTextContent]:
+    if isinstance(message.content, str) or message.content is None:
+        return message.content or ""
+
+    return [MessageTextContent(text=part.text) for part in message.content]
+
+
 def openai_input_to_beeai_message(message: openai_api.ResponsesRequestInputMessage) -> AnyMessage:
+    content = _message_content(message)
+
     match message.role:
         case "user":
-            return UserMessage(message.content or "")
+            return UserMessage(cast(str | list[UserMessageContent], content))
         case "system" | "developer":
-            return SystemMessage(message.content or "")
+            return SystemMessage(content)
         case "assistant":
-            return AssistantMessage(message.content or "")
+            return AssistantMessage(cast(str | list[AssistantMessageContent], content))
         case _:
             raise ValueError(f"Invalid role: {message.role}")

--- a/python/tests/adapters/openai/test_responses_utils.py
+++ b/python/tests/adapters/openai/test_responses_utils.py
@@ -47,6 +47,23 @@ def test_none_content_defaults_to_empty_string() -> None:
 
 
 @pytest.mark.unit
+def test_input_text_content_parts_are_converted_to_message_text_content() -> None:
+    msg = ResponsesRequestInputMessage(
+        role="user",
+        content=[
+            {"type": "input_text", "text": "hello"},
+            {"type": "input_text", "text": " world"},
+        ],
+    )
+    result = openai_input_to_beeai_message(msg)
+
+    assert isinstance(result, UserMessage)
+    text_parts = [part for part in result.content if isinstance(part, MessageTextContent)]
+    assert [part.text for part in text_parts] == ["hello", " world"]
+    assert result.text == "hello world"
+
+
+@pytest.mark.unit
 def test_openai_input_to_beeai_message_invalid_role() -> None:
     msg = ResponsesRequestInputMessage.model_construct(role="unknown", content="x")
 


### PR DESCRIPTION
Closes: #1589

### Description

Accept OpenAI Responses API `EasyInputMessage` content arrays containing `input_text` parts. The request model now validates these parts, and the conversion path preserves their order as BeeAI text content for user, system, developer, and assistant messages. Existing string and `None` content behavior is unchanged.

### Validation

- `python -m pytest tests/adapters/openai/test_responses_utils.py -m unit -q -o addopts=` — 7 passed
- `python -m ruff check --quiet` — passed
- `python -m ruff format --quiet --check` — passed
- `python -m pyrefly check beeai_framework/adapters/openai/serve/responses/_types.py beeai_framework/adapters/openai/serve/responses/_utils.py tests/adapters/openai/test_responses_utils.py` — 0 errors
- `python -m build` — passed
- Broader unit run excluding the Transformers-only module: 292 passed, 6 skipped; 4 unrelated Windows platform failures remain because the tests invoke Unix commands/paths.

### Checklist

- [x] Python contributor guide reviewed
- [x] Commit is signed off with DCO
- [x] Conventional commit title and message
- [x] Regression test included
- [x] No external API or model call required