### PR TITLE
fix(emitter): pass group_id by keyword to avoid str(None) on clone

### DIFF
--- a/python/beeai_framework/emitter/emitter.py
+++ b/python/beeai_framework/emitter/emitter.py
@@ -292,12 +292,12 @@ class Emitter:
 
     async def clone(self) -> "Emitter":
         cloned = Emitter(
-            str(self._group_id),
-            self.namespace.copy(),
-            self.creator if self.creator else None,
-            self.context.copy(),
-            self.trace.model_copy() if self.trace else None,
-            self._events.copy(),
+            group_id=self._group_id,
+            namespace=self.namespace.copy(),
+            creator=self.creator if self.creator else None,
+            context=self.context.copy(),
+            trace=self.trace.model_copy() if self.trace else None,
+            events=self._events.copy(),
         )
         for listener in self._listeners:
             cloned.on(listener.raw, listener.callback, listener.options.model_copy() if listener.options else None)

--- a/python/tests/test_emitter.py
+++ b/python/tests/test_emitter.py
@@ -64,6 +64,26 @@ async def test_clone() -> None:
     assert clone.events is not emitter.events
 
 
+async def test_clone_without_group_id() -> None:
+    emitter = Emitter(namespace=["app"])
+    assert emitter._group_id is None
+
+    clone = await emitter.clone()
+    assert clone._group_id is None
+    assert clone._group_id is emitter._group_id
+
+    event_meta = None
+
+    async def capture(data, event):
+        nonlocal event_meta
+        event_meta = event
+
+    clone.on("*", capture)
+    await clone.emit("test", 1)
+    assert event_meta is not None
+    assert event_meta.group_id is None
+
+
 class TestEventsPropagation:
     @pytest.mark.unit
     @pytest.mark.asyncio


### PR DESCRIPTION
When `group_id` is `None` (the default), `str(None)` produces the literal string `'None'` on clone, corrupting every event emitted by the cloned emitter and its descendants.

### Changes
- Pass constructor arguments by keyword in `Emitter.clone()` instead of positionally, so `group_id=None` stays `None`.
- Added test `test_clone_without_group_id` that exercises the default-`None` path, which the existing test (always uses `group_id="test_group"`) never covered.

Fixes #1581