### PR TITLE
chore: allow Python 3.14 by relaxing version constraint

### DIFF
--- a/python/beeai_framework/emitter/emitter.py
+++ b/python/beeai_framework/emitter/emitter.py
@@ -292,12 +292,12 @@ class Emitter:
 
     async def clone(self) -> "Emitter":
         cloned = Emitter(
-            str(self._group_id),
-            self.namespace.copy(),
-            self.creator if self.creator else None,
-            self.context.copy(),
-            self.trace.model_copy() if self.trace else None,
-            self._events.copy(),
+            group_id=self._group_id,
+            namespace=self.namespace.copy(),
+            creator=self.creator if self.creator else None,
+            context=self.context.copy(),
+            trace=self.trace.model_copy() if self.trace else None,
+            events=self._events.copy(),
         )
         for listener in self._listeners:
             cloned.on(listener.raw, listener.callback, listener.options.model_copy() if listener.options else None)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -9,7 +9,7 @@ maintainers = [
     { name = "Tomas Dvorak", email = "toomas2d@gmail.com" },
     { name = "Lukáš Janeček", email = "xjacka@gmail.com" }
 ]
-requires-python = ">=3.11,<3.14"
+requires-python = ">=3.11,<3.15"
 
 [project.urls]
 homepage = "https://framework.beeai.dev/"

--- a/python/tests/test_emitter.py
+++ b/python/tests/test_emitter.py
@@ -64,6 +64,26 @@ async def test_clone() -> None:
     assert clone.events is not emitter.events
 
 
+async def test_clone_without_group_id() -> None:
+    emitter = Emitter(namespace=["app"])
+    assert emitter._group_id is None
+
+    clone = await emitter.clone()
+    assert clone._group_id is None
+    assert clone._group_id is emitter._group_id
+
+    event_meta = None
+
+    async def capture(data, event):
+        nonlocal event_meta
+        event_meta = event
+
+    clone.on("*", capture)
+    await clone.emit("test", 1)
+    assert event_meta is not None
+    assert event_meta.group_id is None
+
+
 class TestEventsPropagation:
     @pytest.mark.unit
     @pytest.mark.asyncio


### PR DESCRIPTION
Updates `requires-python` from `>=3.11,<3.14` to `>=3.11,<3.15` to support Python 3.14 installations.

Fixes #1588