### PR TITLE
fix(internals): serialize nested dictionary values

### DIFF
--- a/python/beeai_framework/utils/strings.py
+++ b/python/beeai_framework/utils/strings.py
@@ -51,14 +51,16 @@ def to_json_serializable(input: Any, *, exclude_none: bool = False) -> Any:
     def apply_child(value: Any) -> Any:
         return to_json_serializable(value, exclude_none=exclude_none)
 
-    if isinstance(input, CustomJsonDump):
+    if input is None:
+        return None
+    elif isinstance(input, CustomJsonDump):
         return apply_child(input.to_json_safe())
     elif isinstance(input, BaseModel):
         return apply_child(input.model_dump(exclude_none=exclude_none))
     elif isinstance(input, list | set):  # set is not JSON serializable
         return [apply_child(v) for v in input if v is not None] if exclude_none else [apply_child(v) for v in input]
     elif isinstance(input, dict):
-        return {k: apply_child(v) for k, v in input.items() if v is not None} if exclude_none else input
+        return {k: apply_child(v) for k, v in input.items() if not exclude_none or v is not None}
     elif isinstance(input, str | bool | int | float):
         return input
     else:

--- a/python/tests/utils/test_strings.py
+++ b/python/tests/utils/test_strings.py
@@ -1,9 +1,29 @@
 # Copyright 2025 © BeeAI a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-import pytest
+import json
 
-from beeai_framework.utils.strings import validate_class_name
+import pytest
+from pydantic import BaseModel
+
+from beeai_framework.utils.strings import to_json_serializable, validate_class_name
+
+
+class NestedModel(BaseModel):
+    value: str
+
+
+def test_to_json_serializable_recurses_into_dict_values() -> None:
+    value = {"model": NestedModel(value="direct"), "items": [NestedModel(value="nested")]}
+
+    result = to_json_serializable(value)
+
+    assert result == {"model": {"value": "direct"}, "items": [{"value": "nested"}]}
+    json.dumps(result)
+
+
+def test_to_json_serializable_preserves_none_by_default() -> None:
+    assert to_json_serializable({"value": None, "items": [None]}) == {"value": None, "items": [None]}
 
 
 def test_validate_class_name_valid() -> None:


### PR DESCRIPTION
### Which issue(s) does this pull-request address?

No existing issue. `to_json_serializable()` returns dictionaries unchanged when `exclude_none=False`, allowing nested Pydantic models or other custom JSON values to escape conversion. Callers such as the MCP server can then receive a `structuredContent` value that is not JSON serializable.

### Description

- recursively serialize dictionary values in both `exclude_none` modes
- preserve `None` as JSON `null` while retaining the existing `exclude_none=True` filtering behavior
- add regression coverage for directly and indirectly nested Pydantic models, standard-library JSON encoding, and `None` values

### Checklist

#### General
- [x] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md)
- [x] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Appropriate label(s) added to PR: `Python`

#### Code quality checks
- [x] Ruff lint and format checks pass; Pyrefly reports 0 errors for the changed implementation and test files

#### Testing
- [x] `pytest tests/utils/test_strings.py tests/adapters/mcp/serve -q` (28 passed)
- [x] `pytest -m unit -n 16 -q --ignore=tests/backend/providers/test_transformers.py` (313 passed, 4 optional-tool skips)
- [ ] E2E tests pass: not run; this change is isolated to synchronous JSON conversion
- [x] Tests are included

#### Documentation
- [x] Documentation is not affected