### PR TITLE
feat(adapters): report ReAct tool calls to WatsonX Orchestrate

### DIFF
--- a/python/beeai_framework/adapters/watsonx_orchestrate/serve/_factories/_react_agent.py
+++ b/python/beeai_framework/adapters/watsonx_orchestrate/serve/_factories/_react_agent.py
@@ -2,14 +2,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+from pydantic import BaseModel
+
 from beeai_framework.adapters.watsonx_orchestrate.serve.agent import (
     WatsonxOrchestrateServerAgent,
     WatsonxOrchestrateServerAgentEmitFn,
     WatsonxOrchestrateServerAgentMessageEvent,
     WatsonxOrchestrateServerAgentThinkEvent,
+    WatsonxOrchestrateServerAgentToolCallEvent,
+    WatsonxOrchestrateServerAgentToolResponse,
 )
 from beeai_framework.agents.react import ReActAgent, ReActAgentUpdateEvent
 from beeai_framework.backend import AnyMessage
+from beeai_framework.emitter import EmitterOptions, EventMeta
+from beeai_framework.tools import Tool, ToolStartEvent, ToolSuccessEvent
 from beeai_framework.utils.cloneable import Cloneable
 
 
@@ -20,14 +26,49 @@ class WatsonxOrchestrateServerReActAgent(WatsonxOrchestrateServerAgent[ReActAgen
 
     async def _stream(self, input: list[AnyMessage], emit: WatsonxOrchestrateServerAgentEmitFn) -> None:
         cloned_agent = await self._agent.clone() if isinstance(self._agent, Cloneable) else self._agent
-        async for data, event in cloned_agent.run(input):
+
+        async def on_tool_start(data: ToolStartEvent, meta: EventMeta) -> None:
+            assert meta.trace, "ToolStartEvent must have trace"
+            assert isinstance(meta.creator, Tool)
+
+            await emit(
+                WatsonxOrchestrateServerAgentToolCallEvent(
+                    id=meta.trace.run_id,
+                    name=meta.creator.name,
+                    args=data.input.model_dump() if isinstance(data.input, BaseModel) else data.input,
+                )
+            )
+
+        async def on_tool_success(data: ToolSuccessEvent, meta: EventMeta) -> None:
+            assert meta.trace, "ToolSuccessEvent must have trace"
+            assert isinstance(meta.creator, Tool)
+
+            await emit(
+                WatsonxOrchestrateServerAgentToolResponse(
+                    name=meta.creator.name, id=meta.trace.run_id, result=data.output.get_text_content()
+                )
+            )
+
+        # Tool events are emitted by the nested tool runs, which the run's own event stream
+        # (match_nested=False) does not surface, so they are subscribed to explicitly.
+        run = cloned_agent.run(input).on(
+            lambda event: isinstance(event.creator, Tool) and event.name == "start",
+            on_tool_start,
+            EmitterOptions(match_nested=True),
+        )
+        run = run.on(
+            lambda event: isinstance(event.creator, Tool) and event.name == "success",
+            on_tool_success,
+            EmitterOptions(match_nested=True),
+        )
+
+        async for data, event in run:
             match (data, event.name):
                 case (ReActAgentUpdateEvent(), "partial_update"):
                     update = data.update.value
                     if not isinstance(update, str):
                         update = update.get_text_content()
                     match data.update.key:
-                        # TODO: ReAct agent does not use native-tool calling capabilities (ignore or simulate?)
                         case "thought":
                             await emit(WatsonxOrchestrateServerAgentThinkEvent(text=update))
                         case "final_answer":

--- a/python/tests/adapters/watsonx_orchestrate/test_react_factory.py
+++ b/python/tests/adapters/watsonx_orchestrate/test_react_factory.py
@@ -1,0 +1,165 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import AsyncGenerator
+
+import pytest
+
+from beeai_framework.adapters.watsonx_orchestrate.serve._factories._react_agent import (
+    WatsonxOrchestrateServerReActAgent,
+)
+from beeai_framework.adapters.watsonx_orchestrate.serve.agent import (
+    WatsonxOrchestrateServerAgentEvent,
+    WatsonxOrchestrateServerAgentMessageEvent,
+    WatsonxOrchestrateServerAgentThinkEvent,
+    WatsonxOrchestrateServerAgentToolCallEvent,
+    WatsonxOrchestrateServerAgentToolResponse,
+)
+from beeai_framework.agents.react import ReActAgent
+from beeai_framework.backend import AssistantMessage, ChatModel, ChatModelOutput, UserMessage
+from beeai_framework.backend.constants import ProviderName
+from beeai_framework.backend.types import ChatModelInput
+from beeai_framework.context import RunContext
+from beeai_framework.memory import UnconstrainedMemory
+from beeai_framework.tools import tool
+
+
+class _ReActScriptedModel(ChatModel):
+    """Replays pre-scripted ReAct-formatted completions instead of calling a real LLM."""
+
+    def __init__(self, responses: list[str]) -> None:
+        super().__init__()
+        self._responses = list(responses)
+
+    @property
+    def model_id(self) -> str:
+        return "react-scripted"
+
+    @property
+    def provider_id(self) -> ProviderName:
+        return "ollama"
+
+    def _next(self) -> str:
+        if not self._responses:
+            raise AssertionError("_ReActScriptedModel ran out of scripted responses")
+        return self._responses.pop(0)
+
+    async def _create(self, input: ChatModelInput, run: RunContext) -> ChatModelOutput:
+        return ChatModelOutput(output=[AssistantMessage(self._next())])
+
+    async def _create_stream(self, input: ChatModelInput, run: RunContext) -> AsyncGenerator[ChatModelOutput]:
+        yield ChatModelOutput(output=[AssistantMessage(self._next())])
+
+
+@tool()
+def weather_tool(city: str) -> str:
+    """Returns the weather for a city."""
+
+    return f"sunny in {city}"
+
+
+def _build_agent() -> ReActAgent:
+    model = _ReActScriptedModel(
+        [
+            'Thought: I should look up the weather.\nFunction Name: weather_tool\nFunction Input: {"city": "Prague"}\n',
+            "Thought: I have the weather now.\nFinal Answer: It is sunny in Prague.\n",
+        ]
+    )
+    return ReActAgent(llm=model, tools=[weather_tool], memory=UnconstrainedMemory())
+
+
+async def _collect_events(agent: ReActAgent) -> list[WatsonxOrchestrateServerAgentEvent]:
+    served = WatsonxOrchestrateServerReActAgent(agent)
+    events: list[WatsonxOrchestrateServerAgentEvent] = []
+
+    async def emit(event: WatsonxOrchestrateServerAgentEvent) -> None:
+        events.append(event)
+
+    await served._stream([UserMessage("What is the weather in Prague?")], emit)
+    return events
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_tool_calls_are_surfaced_as_native_tool_events() -> None:
+    events = await _collect_events(_build_agent())
+
+    tool_calls = [e for e in events if isinstance(e, WatsonxOrchestrateServerAgentToolCallEvent)]
+    tool_responses = [e for e in events if isinstance(e, WatsonxOrchestrateServerAgentToolResponse)]
+
+    # The ReAct agent invokes real Tool objects, so its tool activity is reported to
+    # WatsonX Orchestrate as native tool-call / tool-response events.
+    assert len(tool_calls) == 1
+    assert tool_calls[0].name == "weather_tool"
+    assert tool_calls[0].args == {"city": "Prague"}
+
+    assert len(tool_responses) == 1
+    assert tool_responses[0].name == "weather_tool"
+    assert "sunny in Prague" in tool_responses[0].result
+
+    # The call and its response share the tool run id, so consumers can correlate them.
+    assert tool_calls[0].id == tool_responses[0].id
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_thoughts_and_final_answer_are_still_emitted() -> None:
+    events = await _collect_events(_build_agent())
+
+    thoughts = "".join(e.text for e in events if isinstance(e, WatsonxOrchestrateServerAgentThinkEvent))
+    messages = "".join(e.text for e in events if isinstance(e, WatsonxOrchestrateServerAgentMessageEvent))
+
+    assert "look up the weather" in thoughts
+    assert "sunny in Prague" in messages
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_tool_call_precedes_its_response_and_the_final_answer() -> None:
+    events = await _collect_events(_build_agent())
+    kinds = [type(e) for e in events]
+
+    call_at = kinds.index(WatsonxOrchestrateServerAgentToolCallEvent)
+    response_at = kinds.index(WatsonxOrchestrateServerAgentToolResponse)
+    answer_at = kinds.index(WatsonxOrchestrateServerAgentMessageEvent)
+
+    assert call_at < response_at < answer_at
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_each_tool_call_gets_its_own_correlation_id() -> None:
+    model = _ReActScriptedModel(
+        [
+            'Thought: Check Prague first.\nFunction Name: weather_tool\nFunction Input: {"city": "Prague"}\n',
+            'Thought: Now check Brno.\nFunction Name: weather_tool\nFunction Input: {"city": "Brno"}\n',
+            "Thought: I have both.\nFinal Answer: Sunny in Prague and Brno.\n",
+        ]
+    )
+    events = await _collect_events(ReActAgent(llm=model, tools=[weather_tool], memory=UnconstrainedMemory()))
+
+    calls = [e for e in events if isinstance(e, WatsonxOrchestrateServerAgentToolCallEvent)]
+    responses = [e for e in events if isinstance(e, WatsonxOrchestrateServerAgentToolResponse)]
+
+    assert [call.args for call in calls] == [{"city": "Prague"}, {"city": "Brno"}]
+    assert len(responses) == 2
+
+    # Each tool run reports its own id, so a consumer can pair every response with its own
+    # call rather than relying on ordering.
+    assert calls[0].id != calls[1].id
+    assert {call.id: call.args["city"] for call in calls} == {
+        response.id: response.result.removeprefix("sunny in ") for response in responses
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_no_tool_events_when_agent_answers_directly() -> None:
+    model = _ReActScriptedModel(["Thought: I already know this.\nFinal Answer: 42.\n"])
+    agent = ReActAgent(llm=model, tools=[weather_tool], memory=UnconstrainedMemory())
+
+    events = await _collect_events(agent)
+
+    assert not [e for e in events if isinstance(e, WatsonxOrchestrateServerAgentToolCallEvent)]
+    assert not [e for e in events if isinstance(e, WatsonxOrchestrateServerAgentToolResponse)]
+    assert "42" in "".join(e.text for e in events if isinstance(e, WatsonxOrchestrateServerAgentMessageEvent))


### PR DESCRIPTION
## Summary

`WatsonxOrchestrateServerReActAgent` forwarded only the agent's thoughts and its final answer, so any tool the ReAct agent actually ran was invisible to WatsonX Orchestrate. This resolves the `# TODO: ReAct agent does not use native-tool calling capabilities (ignore or simulate?)` in that factory.

**Why neither "ignore" nor "simulate" is needed:** the premise behind the TODO is real — the default ReAct runner has `use_native_tool_calling = False` and parses tool calls out of the model's text rather than using the model's tool-calling API. But that only concerns how the *model* is prompted. ReAct still executes real `Tool` objects (`react/runners/default/runner.py`), and the base `Tool` emits `start` / `success` for every run (`tools/tool.py`), so the actual tool activity can be reported as-is — no synthesising from parser keys required.

**Why it was missing:** a run's own event stream is created with `match_nested=False` (`context.py`, `Run.__init__`), so nested tool events never reach the `async for` loop. The sibling `_tool_calling_agent.py` and `_requirement_agent.py` factories already work around this by subscribing explicitly with `EmitterOptions(match_nested=True)`.

## Changes

### `serve/_factories/_react_agent.py`
Applies the same pattern the sibling factories use: subscribes to nested `ToolStartEvent` / `ToolSuccessEvent` and emits each tool run as a `WatsonxOrchestrateServerAgentToolCallEvent` followed by its `WatsonxOrchestrateServerAgentToolResponse`, correlated by the tool run id. Thought and final-answer forwarding is untouched.

No new event types or protocol changes — both event models already existed and are already produced by the other two factories. This works for both ReAct runners, since `use_native_tool_calling` affects only how the model is called, not how tools are executed.

Unlike the siblings there is no `final_answer` tool to filter out: in ReAct the final answer arrives through the text parser (`case "final_answer"`), not as a tool.

### `tests/adapters/watsonx_orchestrate/test_react_factory.py` (new — 5 tests)
- tool call and tool response carry the right name, args and result, and share a correlation id
- thoughts and the final answer are still emitted
- the tool call precedes its response, which precedes the final answer
- multiple tool calls each get their own correlation id, and each response pairs back to its own call
- no tool events when the agent answers without using a tool

## Test plan

- [x] `pytest tests/adapters/watsonx_orchestrate -m unit` — 16 passed (5 new + 11 existing)
- [x] Confirmed the new tests **fail against `main`**: the two tool-event tests report `assert 0 == 1`, i.e. no tool events at all today
- [x] Confirmed the multi-call test discriminates: swapping the tool run id for the trace group id makes it fail (`ids collide`) while the single-call assertions stay green
- [x] `pyrefly check` clean (0 errors); `ruff check` / `ruff format --check` clean
- [x] Full unit suite: no new failures (the only failure, `test_templates.py::test_render_function`, is a pre-existing local `zoneinfo`/tzdata issue)
- [x] No live WatsonX Orchestrate instance needed to verify any of this

---

Signed-off-by: ibrahim <ihsanduvac@gmail.com>
