### PR TITLE
fix(adapters): expose LiteLLM proxy response cost

### DIFF
--- a/python/beeai_framework/adapters/litellm/chat.py
+++ b/python/beeai_framework/adapters/litellm/chat.py
@@ -310,6 +310,8 @@ class LiteLLMChatModel(ChatModel, ABC):
                     completion_tokens_cost_usd=completion_tokens_cost_usd,
                     total_cost_usd=prompt_tokens_cost_usd + completion_tokens_cost_usd,
                 )
+            if (response_cost := chunk.get("response_cost")) is not None:
+                cost.total_cost_usd = float(response_cost)
 
         output: list[AnyMessage] = []
         if update:

--- a/python/tests/backend/providers/test_litellm_chat.py
+++ b/python/tests/backend/providers/test_litellm_chat.py
@@ -13,6 +13,7 @@ from litellm.types.utils import (
     Delta,
     Message,
     StreamingChoices,
+    Usage,
 )
 
 from beeai_framework.adapters.litellm.chat import LiteLLMChatModel
@@ -108,6 +109,30 @@ def _make_tool_call(
 
 
 class TestTransformOutput:
+    @pytest.mark.unit
+    def test_proxy_response_cost_overrides_local_estimate(
+        self,
+        model: _TestLiteLLMChatModel,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "beeai_framework.adapters.litellm.chat.cost_per_token",
+            lambda **_: (0.01, 0.02),
+        )
+        response = LiteLLMModelResponse(
+            id="chatcmpl-cost",
+            model="test",
+            choices=[Choices(finish_reason="stop", index=0, message=Message(content="hello", role="assistant"))],
+            usage=Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+            response_cost=0.123,
+        )
+
+        result = model._transform_output(response)
+
+        assert result.cost.prompt_tokens_usd == pytest.approx(0.01)
+        assert result.cost.completion_tokens_cost_usd == pytest.approx(0.02)
+        assert result.cost.total_cost_usd == pytest.approx(0.123)
+
     @pytest.mark.unit
     def test_content_only(self, model: _TestLiteLLMChatModel) -> None:
         response = LiteLLMModelResponse(


### PR DESCRIPTION
## Summary / Problem

Closes #1614

When a LiteLLM proxy supplies its authoritative per-call `response_cost`, the LiteLLM adapter currently ignores it and reports only the locally calculated token-price estimate in `ChatModelOutput.cost.total_cost_usd`.

## Changes

- Read `response_cost` from each LiteLLM response and expose it as `ChatModelOutput.cost.total_cost_usd`.
- Preserve the existing prompt/completion token cost estimates for the cost breakdown.
- Add a regression test covering the proxy value overriding the local total.

## Tests

- `python -m pytest -p syrupy -p pytest_asyncio.plugin -o addopts='--snapshot-patch-pycharm-diff' -m unit tests/backend/providers/test_litellm_chat.py -q` — 13 passed, 1 warning.
- `python -m ruff check beeai_framework/adapters/litellm/chat.py tests/backend/providers/test_litellm_chat.py` — passed.
- `python -m ruff format --check beeai_framework/adapters/litellm/chat.py tests/backend/providers/test_litellm_chat.py` — passed.
- `python -m pyrefly check beeai_framework/adapters/litellm/chat.py tests/backend/providers/test_litellm_chat.py` — 0 errors (3 suppressed).
- `python -m build` — passed; sdist and wheel built successfully.
- GitHub Actions `Lint & Build & Test` — passed, including `mise common:check`, `mise python:check`, `mise python:build`, and `mise python:test:unit`.
- Full unit suite with four workers — 267 passed, 6 skipped, 6 failed, and 5 collection errors in the Windows host environment. The failures/errors are limited to missing optional adapter dependencies (`a2a`, `uvicorn`, and `outlines`), missing `tzdata`, and POSIX-only shell command expectations (`sh`, `cat`, and similar); all LiteLLM tests passed in that run.
- End-to-end tests were not run because they require the Ollama models specified by the contributor guide.

## Compatibility / Known limitations

Responses without a numeric `response_cost` continue to use the existing local token-based estimate. The change does not add or remove public fields and does not alter request or streaming behavior.

## Issue link

https://github.com/i-am-bee/beeai-framework/issues/1614
