### PR TITLE
feat(adapters): add OrcaRouter provider for Python and TypeScript

### DIFF
--- a/docs/src/content/docs/modules/backend.mdx
+++ b/docs/src/content/docs/modules/backend.mdx
@@ -38,6 +38,7 @@ The following table depicts supported providers. Each provider requires specific
 | MistralAI      |  ✅  | ✅        | MISTRALAI_CHAT_MODEL<br/>MISTRALAI_EMBEDDING_MODEL<br />**MISTRALAI_API_KEY**<br />MISTRALAI_API_BASE |
 | Transformers   |  ✅  | ✅        | TRANSFORMERS_CHAT_MODEL<br/>HF_TOKEN|
 | MiniMax        |  ✅  | ❌        | MINIMAX_CHAT_MODEL<br/>**MINIMAX_API_KEY**<br/>MINIMAX_API_BASE<br/>MINIMAX_API_HEADERS |
+| OrcaRouter     |  ✅  | ❌        | ORCAROUTER_CHAT_MODEL<br/>**ORCAROUTER_API_KEY**<br/>ORCAROUTER_API_BASE<br/>ORCAROUTER_API_HEADERS |
 
 <Tip>
 If you don't see your provider raise an issue [here](https://github.com/i-am-bee/beeai-framework/issues).

--- a/python/beeai_framework/adapters/orcarouter/__init__.py
+++ b/python/beeai_framework/adapters/orcarouter/__init__.py
@@ -1,0 +1,6 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+from beeai_framework.adapters.orcarouter.backend.chat import OrcaRouterChatModel
+
+__all__ = ["OrcaRouterChatModel"]

--- a/python/beeai_framework/adapters/orcarouter/backend/__init__.py
+++ b/python/beeai_framework/adapters/orcarouter/backend/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0

--- a/python/beeai_framework/adapters/orcarouter/backend/chat.py
+++ b/python/beeai_framework/adapters/orcarouter/backend/chat.py
@@ -1,0 +1,58 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+from typing_extensions import Unpack
+
+from beeai_framework.adapters.litellm import LiteLLMChatModel, utils
+from beeai_framework.backend.chat import ChatModelKwargs
+from beeai_framework.backend.constants import ProviderName
+from beeai_framework.logger import Logger
+
+logger = Logger(__name__)
+
+ORCAROUTER_API_BASE = "https://api.orcarouter.ai/v1"
+
+
+class OrcaRouterChatModel(LiteLLMChatModel):
+    """
+    A chat model implementation for the OrcaRouter provider, leveraging LiteLLM.
+
+    OrcaRouter exposes an OpenAI-compatible API. This adapter routes requests
+    through LiteLLM's OpenAI provider with the OrcaRouter base URL.
+
+    Models are addressed as ``orcarouter/auto`` (the smart routing router) or
+    any model from the public catalog, e.g. ``deepseek/deepseek-v4-flash``.
+    """
+
+    @property
+    def provider_id(self) -> ProviderName:
+        return "orcarouter"
+
+    def __init__(
+        self,
+        model_id: str | None = None,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        **kwargs: Unpack[ChatModelKwargs],
+    ) -> None:
+        super().__init__(
+            model_id if model_id else os.getenv("ORCAROUTER_CHAT_MODEL", "orcarouter/auto"),
+            provider_id="openai",
+            **kwargs,
+        )
+
+        self._assert_setting_value("api_key", api_key, envs=["ORCAROUTER_API_KEY"])
+        self._assert_setting_value(
+            "base_url",
+            base_url,
+            envs=["ORCAROUTER_API_BASE"],
+            aliases=["api_base"],
+            allow_empty=True,
+            fallback=ORCAROUTER_API_BASE,
+        )
+        self._settings["extra_headers"] = utils.parse_extra_headers(
+            self._settings.get("extra_headers"), os.getenv("ORCAROUTER_API_HEADERS")
+        )

--- a/python/beeai_framework/backend/constants.py
+++ b/python/beeai_framework/backend/constants.py
@@ -25,6 +25,7 @@ ProviderName = Literal[
     "deepseek",
     "qwen",
     "minimax",
+    "orcarouter",
 ]
 ProviderHumanName = Literal[
     "AgentStack",
@@ -46,6 +47,7 @@ ProviderHumanName = Literal[
     "Deepseek",
     "Qwen",
     "MiniMax",
+    "OrcaRouter",
 ]
 
 ModelTypes = Literal["embedding", "chat"]
@@ -98,4 +100,5 @@ BackendProviders = {
     "Deepseek": ProviderDef(name="Deepseek", module="deepseek", aliases=["deepseek"]),
     "Qwen": ProviderDef(name="Qwen", module="qwen", aliases=["qwen", "dashscope"]),
     "MiniMax": ProviderDef(name="MiniMax", module="minimax", aliases=["minimax"]),
+    "OrcaRouter": ProviderDef(name="OrcaRouter", module="orcarouter", aliases=["orcarouter"]),
 }

--- a/python/examples/backend/providers/orcarouter.py
+++ b/python/examples/backend/providers/orcarouter.py
@@ -1,0 +1,101 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+
+from dotenv import load_dotenv
+from pydantic import BaseModel, Field
+
+from beeai_framework.adapters.orcarouter import OrcaRouterChatModel
+from beeai_framework.backend import ChatModel, ChatModelNewTokenEvent, UserMessage
+from beeai_framework.emitter import EventMeta
+from beeai_framework.errors import AbortError
+from beeai_framework.parsers.field import ParserField
+from beeai_framework.parsers.line_prefix import LinePrefixParser, LinePrefixParserNode
+from beeai_framework.utils import AbortSignal
+
+
+async def orcarouter_from_name() -> None:
+    llm = ChatModel.from_name("orcarouter:orcarouter/auto")
+    user_message = UserMessage("what states are part of New England?")
+    response = await llm.run([user_message])
+    print(response.get_text_content())
+
+
+async def orcarouter_sync() -> None:
+    llm = OrcaRouterChatModel("orcarouter/auto")
+    user_message = UserMessage("what is the capital of Massachusetts?")
+    response = await llm.run([user_message])
+    print(response.get_text_content())
+
+
+async def orcarouter_stream() -> None:
+    llm = OrcaRouterChatModel("orcarouter/auto")
+    user_message = UserMessage("How many islands make up the country of Cape Verde?")
+    response = await llm.run([user_message], stream=True)
+    print(response.get_text_content())
+
+
+async def orcarouter_stream_abort() -> None:
+    llm = OrcaRouterChatModel("orcarouter/auto")
+    user_message = UserMessage("What is the smallest of the Cape Verde islands?")
+
+    try:
+        response = await llm.run([user_message], stream=True, signal=AbortSignal.timeout(0.5))
+
+        if response is not None:
+            print(response.get_text_content())
+        else:
+            print("No response returned.")
+    except AbortError as err:
+        print(f"Aborted: {err}")
+
+
+async def orcarouter_structure() -> None:
+    class TestSchema(BaseModel):
+        answer: str = Field(description="your final answer")
+
+    llm = OrcaRouterChatModel("orcarouter/auto")
+    user_message = UserMessage("How many islands make up the country of Cape Verde?")
+    response = await llm.run([user_message], response_format=TestSchema)
+    print(response.output_structured)
+
+
+async def orcarouter_stream_parser() -> None:
+    llm = OrcaRouterChatModel("orcarouter/auto")
+
+    parser = LinePrefixParser(
+        nodes={
+            "test": LinePrefixParserNode(
+                prefix="Prefix: ", field=ParserField.from_type(str), is_start=True, is_end=True
+            )
+        }
+    )
+
+    async def on_new_token(data: ChatModelNewTokenEvent, event: EventMeta) -> None:
+        await parser.add(chunk=data.value.get_text_content())
+
+    user_message = UserMessage("Produce 3 lines each starting with 'Prefix: ' followed by a sentence and a new line.")
+    await llm.run([user_message], stream=True).observe(lambda emitter: emitter.on("new_token", on_new_token))
+    result = await parser.end()
+    print(result)
+
+
+async def main() -> None:
+    print("*" * 10, "orcarouter_from_name")
+    await orcarouter_from_name()
+    print("*" * 10, "orcarouter_sync")
+    await orcarouter_sync()
+    print("*" * 10, "orcarouter_stream")
+    await orcarouter_stream()
+    print("*" * 10, "orcarouter_stream_abort")
+    await orcarouter_stream_abort()
+    print("*" * 10, "orcarouter_structure")
+    await orcarouter_structure()
+    print("*" * 10, "orcarouter_stream_parser")
+    await orcarouter_stream_parser()
+
+
+if __name__ == "__main__":
+    load_dotenv()
+    asyncio.run(main())

--- a/python/tests/adapters/orcarouter/__init__.py
+++ b/python/tests/adapters/orcarouter/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0

--- a/python/tests/adapters/orcarouter/test_orcarouter_chat.py
+++ b/python/tests/adapters/orcarouter/test_orcarouter_chat.py
@@ -1,0 +1,105 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from beeai_framework.adapters.orcarouter.backend.chat import ORCAROUTER_API_BASE, OrcaRouterChatModel
+from beeai_framework.backend.chat import ChatModel
+from beeai_framework.backend.constants import BackendProviders
+
+
+class TestOrcaRouterProviderRegistration:
+    """Test that OrcaRouter is properly registered as a provider."""
+
+    def test_orcarouter_in_backend_providers(self) -> None:
+        assert "OrcaRouter" in BackendProviders
+        provider = BackendProviders["OrcaRouter"]
+        assert provider.name == "OrcaRouter"
+        assert provider.module == "orcarouter"
+        assert "orcarouter" in provider.aliases
+
+    def test_provider_def_has_correct_structure(self) -> None:
+        provider = BackendProviders["OrcaRouter"]
+        assert hasattr(provider, "name")
+        assert hasattr(provider, "module")
+        assert hasattr(provider, "aliases")
+
+
+class TestOrcaRouterChatModelInit:
+    """Test OrcaRouterChatModel initialization."""
+
+    @patch.dict(os.environ, {"ORCAROUTER_API_KEY": "test-key-123"})
+    def test_default_model_id(self) -> None:
+        model = OrcaRouterChatModel()
+        assert model.model_id == "orcarouter/auto"
+
+    @patch.dict(os.environ, {"ORCAROUTER_API_KEY": "test-key-123"})
+    def test_custom_model_id(self) -> None:
+        model = OrcaRouterChatModel("deepseek/deepseek-v4-flash")
+        assert model.model_id == "deepseek/deepseek-v4-flash"
+
+    @patch.dict(
+        os.environ,
+        {"ORCAROUTER_API_KEY": "test-key-123", "ORCAROUTER_CHAT_MODEL": "anthropic/claude-opus-4.7"},
+    )
+    def test_model_from_env(self) -> None:
+        model = OrcaRouterChatModel()
+        assert model.model_id == "anthropic/claude-opus-4.7"
+
+    @patch.dict(os.environ, {"ORCAROUTER_API_KEY": "test-key-123"})
+    def test_provider_id(self) -> None:
+        model = OrcaRouterChatModel()
+        assert model.provider_id == "orcarouter"
+
+    @patch.dict(os.environ, {"ORCAROUTER_API_KEY": "test-key-123"})
+    def test_default_base_url(self) -> None:
+        model = OrcaRouterChatModel()
+        assert model._settings.get("base_url") == ORCAROUTER_API_BASE
+
+    @patch.dict(
+        os.environ,
+        {"ORCAROUTER_API_KEY": "test-key-123", "ORCAROUTER_API_BASE": "https://custom.orcarouter.ai/v1"},
+    )
+    def test_custom_base_url_from_env(self) -> None:
+        model = OrcaRouterChatModel()
+        assert model._settings.get("base_url") == "https://custom.orcarouter.ai/v1"
+
+    @patch.dict(os.environ, {"ORCAROUTER_API_KEY": "test-key-123"})
+    def test_custom_base_url_param(self) -> None:
+        model = OrcaRouterChatModel(base_url="https://proxy.example.com/v1")
+        assert model._settings.get("base_url") == "https://proxy.example.com/v1"
+
+    @patch.dict(os.environ, {"ORCAROUTER_API_KEY": "test-key-123"})
+    def test_api_key_stored(self) -> None:
+        model = OrcaRouterChatModel()
+        assert model._settings.get("api_key") == "test-key-123"
+
+    def test_missing_api_key_raises(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("ORCAROUTER_API_KEY", None)
+            with pytest.raises(ValueError, match=r"api_key.*required"):
+                OrcaRouterChatModel()
+
+    @patch.dict(os.environ, {"ORCAROUTER_API_KEY": "test-key-123"})
+    def test_explicit_api_key(self) -> None:
+        model = OrcaRouterChatModel(api_key="explicit-key")
+        assert model._settings.get("api_key") == "explicit-key"
+
+
+class TestOrcaRouterModelLoading:
+    """Test that OrcaRouter models can be loaded via the factory method."""
+
+    @patch.dict(os.environ, {"ORCAROUTER_API_KEY": "test-key-123"})
+    def test_load_from_name(self) -> None:
+        model = ChatModel.from_name("orcarouter:orcarouter/auto")
+        assert isinstance(model, OrcaRouterChatModel)
+        assert model.model_id == "orcarouter/auto"
+
+    @patch.dict(os.environ, {"ORCAROUTER_API_KEY": "test-key-123"})
+    def test_load_from_alias(self) -> None:
+        model = ChatModel.from_name("orcarouter:deepseek/deepseek-v4-flash")
+        assert isinstance(model, OrcaRouterChatModel)
+        assert model.model_id == "deepseek/deepseek-v4-flash"

--- a/typescript/examples/backend/providers/orcarouter.ts
+++ b/typescript/examples/backend/providers/orcarouter.ts
@@ -1,0 +1,128 @@
+import "dotenv/config";
+import { OrcaRouterChatModel } from "beeai-framework/adapters/orcarouter/backend/chat";
+import "dotenv/config.js";
+import { ToolMessage, UserMessage } from "beeai-framework/backend/message";
+import { ChatModel } from "beeai-framework/backend/chat";
+import { AbortError } from "beeai-framework/errors";
+import { z } from "zod";
+import { OpenMeteoTool } from "beeai-framework/tools/weather/openMeteo";
+
+const llm = new OrcaRouterChatModel(
+  "orcarouter/auto",
+  // {},
+  // {
+  //   apiKey: "ORCAROUTER_API_KEY",
+  //   baseURL: "https://api.orcarouter.ai/v1",
+  // },
+);
+
+llm.config({
+  parameters: {
+    temperature: 0.7,
+    maxTokens: 1024,
+    topP: 1,
+  },
+});
+
+async function orcarouterFromName() {
+  const orcarouterLLM = await ChatModel.fromName("orcarouter:orcarouter/auto");
+  const response = await orcarouterLLM.create({
+    messages: [new UserMessage("what states are part of New England?")],
+  });
+  console.info(response.getTextContent());
+}
+
+async function orcarouterSync() {
+  const response = await llm.create({
+    messages: [new UserMessage("what is the capital of Massachusetts?")],
+  });
+  console.info(response.getTextContent());
+}
+
+async function orcarouterStream() {
+  const response = await llm.create({
+    messages: [new UserMessage("How many islands make up the country of Cape Verde?")],
+    stream: true,
+  });
+  console.info(response.getTextContent());
+}
+
+async function orcarouterStreamAbort() {
+  try {
+    const response = await llm.create({
+      messages: [new UserMessage("What is the smallest of the Cape Verde islands?")],
+      stream: true,
+      signal: AbortSignal.timeout(500),
+    });
+    console.info(response.getTextContent());
+  } catch (error) {
+    if (error instanceof AbortError) {
+      console.info("Aborted.");
+    }
+  }
+}
+
+async function orcarouterStructure() {
+  const response = await llm.create({
+    messages: [new UserMessage("How many islands make up the country of Cape Verde?")],
+    output: {
+      type: "object",
+      schema: z.object({
+        answer: z.string(),
+      }),
+    },
+  });
+  console.info(response.getTextContent());
+}
+
+async function orcarouterWithTool() {
+  const response = await llm.create({
+    messages: [new UserMessage("What is the current weather in Salzburg?")],
+    tools: [new OpenMeteoTool()],
+  });
+  console.info(response.getTextContent());
+}
+
+async function orcarouterToolCalls() {
+  const response = await llm.create({
+    messages: [new UserMessage("What is the current weather in Salzburg?")],
+    tools: [new OpenMeteoTool()],
+  });
+  const toolResults = await Promise.all(
+    response.getToolCalls().map(async (toolCall) => {
+      const result = await toolCall.tool.run(toolCall.input);
+      return new ToolMessage({
+        toolCallId: toolCall.id,
+        toolResult: result.getTextContent(),
+      });
+    }),
+  );
+  const response2 = await llm.create({
+    messages: [
+      new UserMessage("What is the current weather in Salzburg?"),
+      ...response.getMessages(),
+      ...toolResults,
+    ],
+    tools: [new OpenMeteoTool()],
+  });
+  console.info(response2.getTextContent());
+}
+
+async function main() {
+  console.log("*".repeat(10), "orcarouterFromName");
+  await orcarouterFromName();
+  console.log("*".repeat(10), "orcarouterSync");
+  await orcarouterSync();
+  console.log("*".repeat(10), "orcarouterStream");
+  await orcarouterStream();
+  console.log("*".repeat(10), "orcarouterStreamAbort");
+  await orcarouterStreamAbort();
+  console.log("*".repeat(10), "orcarouterStructure");
+  await orcarouterStructure();
+  console.log("*".repeat(10), "orcarouterWithTool");
+  await orcarouterWithTool();
+  console.log("*".repeat(10), "orcarouterToolCalls");
+  await orcarouterToolCalls();
+}
+
+main().catch(console.error);

--- a/typescript/src/adapters/orcarouter/backend/chat.ts
+++ b/typescript/src/adapters/orcarouter/backend/chat.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2025 © BeeAI a Series of LF Projects, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { OpenAIProvider } from "@ai-sdk/openai";
+import {
+  OrcaRouterClient,
+  OrcaRouterClientSettings,
+} from "@/adapters/orcarouter/backend/client.js";
+import { VercelChatModel } from "@/adapters/vercel/backend/chat.js";
+import { getEnv } from "@/internals/env.js";
+import { ChatModelParameters } from "@/backend/chat.js";
+
+type OrcaRouterParameters = Parameters<OpenAIProvider["chat"]>;
+export type OrcaRouterChatModelId = NonNullable<OrcaRouterParameters[0]>;
+
+export class OrcaRouterChatModel extends VercelChatModel {
+  constructor(
+    modelId: OrcaRouterChatModelId = getEnv("ORCAROUTER_CHAT_MODEL", "orcarouter/auto"),
+    parameters: ChatModelParameters = {},
+    client?: OrcaRouterClient | OrcaRouterClientSettings,
+  ) {
+    const model = OrcaRouterClient.ensure(client).instance.chat(modelId);
+    super(model);
+    Object.assign(this.parameters, parameters ?? {});
+  }
+
+  static {
+    this.register();
+  }
+}

--- a/typescript/src/adapters/orcarouter/backend/client.ts
+++ b/typescript/src/adapters/orcarouter/backend/client.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2025 © BeeAI a Series of LF Projects, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createOpenAI, OpenAIProvider, OpenAIProviderSettings } from "@ai-sdk/openai";
+import { getEnv } from "@/internals/env.js";
+import { BackendClient } from "@/backend/client.js";
+import { parseHeadersFromEnv, vercelFetcher } from "@/adapters/vercel/backend/utils.js";
+
+const ORCAROUTER_API_BASE = "https://api.orcarouter.ai/v1";
+
+export type OrcaRouterClientSettings = OpenAIProviderSettings;
+
+export class OrcaRouterClient extends BackendClient<OrcaRouterClientSettings, OpenAIProvider> {
+  protected create(): OpenAIProvider {
+    return createOpenAI({
+      ...this.settings,
+      apiKey: this.settings?.apiKey || getEnv("ORCAROUTER_API_KEY"),
+      baseURL: this.settings?.baseURL || getEnv("ORCAROUTER_API_BASE", ORCAROUTER_API_BASE),
+      headers: {
+        ...parseHeadersFromEnv("ORCAROUTER_API_HEADERS"),
+        ...this.settings?.headers,
+      },
+      fetch: vercelFetcher(this.settings?.fetch),
+    });
+  }
+}

--- a/typescript/src/backend/constants.ts
+++ b/typescript/src/backend/constants.ts
@@ -39,6 +39,11 @@ export const BackendProviders = {
     module: "minimax",
     aliases: ["minimax"] as string[],
   },
+  OrcaRouter: {
+    name: "OrcaRouter",
+    module: "orcarouter",
+    aliases: ["orcarouter"] as string[],
+  },
 } as const;
 
 export type ProviderName = (typeof BackendProviders)[keyof typeof BackendProviders]["module"];

--- a/typescript/tests/e2e/adapters/orcarouter.test.ts
+++ b/typescript/tests/e2e/adapters/orcarouter.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2025 © BeeAI a Series of LF Projects, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { BackendProviders } from "@/backend/constants.js";
+import { OrcaRouterChatModel } from "@/adapters/orcarouter/backend/chat.js";
+import { OrcaRouterClient } from "@/adapters/orcarouter/backend/client.js";
+
+describe("OrcaRouter Provider Registration", () => {
+  it("should be registered in BackendProviders", () => {
+    expect(BackendProviders.OrcaRouter).toBeDefined();
+    expect(BackendProviders.OrcaRouter.name).toBe("OrcaRouter");
+    expect(BackendProviders.OrcaRouter.module).toBe("orcarouter");
+    expect(BackendProviders.OrcaRouter.aliases).toContain("orcarouter");
+  });
+});
+
+describe("OrcaRouterClient", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("should create client with explicit settings", () => {
+    const client = new OrcaRouterClient({
+      apiKey: "test-key",
+      baseURL: "https://api.orcarouter.ai/v1",
+    });
+    expect(client).toBeDefined();
+    expect(client.instance).toBeDefined();
+  });
+
+  it("should create client from env vars", () => {
+    process.env.ORCAROUTER_API_KEY = "test-key";
+    process.env.ORCAROUTER_API_BASE = "https://api.orcarouter.ai/v1";
+    const client = OrcaRouterClient.ensure();
+    expect(client).toBeDefined();
+    expect(client.instance).toBeDefined();
+  });
+});
+
+describe("OrcaRouterChatModel", () => {
+  it("should create model instance", () => {
+    const model = new OrcaRouterChatModel("orcarouter/auto", {}, { apiKey: "test-key" });
+    expect(model).toBeInstanceOf(OrcaRouterChatModel);
+    expect(model.modelId).toBe("orcarouter/auto");
+  });
+
+  it("should use default model id from env", () => {
+    process.env.ORCAROUTER_CHAT_MODEL = "deepseek/deepseek-v4-flash";
+    const model = new OrcaRouterChatModel(undefined, {}, { apiKey: "test-key" });
+    expect(model.modelId).toBe("deepseek/deepseek-v4-flash");
+  });
+});


### PR DESCRIPTION
## Summary

Adds [OrcaRouter](https://www.orcarouter.ai) as a first-class backend provider, mirroring the existing `MiniMax` adapter so it can be used through the same unified `ChatModel` interface and `ChatModel.from_name` factory.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

### Changes

- **Python**: new `beeai_framework.adapters.orcarouter` package with `OrcaRouterChatModel` (backed by LiteLLM's OpenAI-compatible path), registered in `BackendProviders` (`orcarouter` alias). Default model is `orcarouter/auto`, base URL `https://api.orcarouter.ai/v1`, key from `ORCAROUTER_API_KEY`.
- **TypeScript**: new `typescript/src/adapters/orcarouter` adapter (`OrcaRouterChatModel` + `OrcaRouterClient` on `@ai-sdk/openai`), registered in the TS `BackendProviders`.
- **Examples**: `python/examples/backend/providers/orcarouter.py` and `typescript/examples/backend/providers/orcarouter.ts` following the existing provider example layout.
- **Tests**: unit/registration tests for Python (`tests/adapters/orcarouter/`) and TypeScript (`tests/e2e/adapters/orcarouter.test.ts`).
- **Docs**: added OrcaRouter to the supported-providers table in `docs/src/content/docs/modules/backend.mdx`.

### Verification

- Python: `ruff check`, `ruff format --check`, `pyrefly check` clean; 198 adapter/backend/agents/utils tests pass (incl. 14 new OrcaRouter tests).
- TypeScript: `tsc --noEmit`, `eslint`, `prettier --check` clean; 306 unit + 5 new OrcaRouter e2e tests pass.
- Live: `ChatModel.from_name("orcarouter:deepseek/deepseek-v4-flash")` and streaming via `orcarouter/auto` both returned successful responses against the OrcaRouter API.

### Notes

Models are addressed in OrcaRouter's namespaced format (e.g. `orcarouter/auto`, `deepseek/deepseek-v4-flash`). I'm an engineer on the OrcaRouter team.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter
