### PR TITLE
fix(adapters): default VertexAI allow_prompt_caching to False

### DIFF
--- a/python/beeai_framework/adapters/vertexai/backend/chat.py
+++ b/python/beeai_framework/adapters/vertexai/backend/chat.py
@@ -29,6 +29,10 @@ class VertexAIChatModel(LiteLLMChatModel):
         credentials: str | dict[str, Any] | None = None,
         **kwargs: Unpack[ChatModelKwargs],
     ) -> None:
+        # Ref: https://github.com/BerriAI/litellm/issues/17696
+        if kwargs.get("allow_prompt_caching") is None:
+            kwargs["allow_prompt_caching"] = False
+
         super().__init__(
             model_id if model_id else os.getenv("GOOGLE_VERTEX_CHAT_MODEL", "gemini-2.0-flash-lite-001"),
             provider_id="vertex_ai",

--- a/python/tests/backend/test_chatmodel.py
+++ b/python/tests/backend/test_chatmodel.py
@@ -186,6 +186,13 @@ def test_chat_model_from(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GOOGLE_VERTEX_PROJECT", "myproject")
     vertexai_chat_model = ChatModel.from_name("vertexai:gemini-2.0-flash-lite-001", vertex_location="test")
     assert isinstance(vertexai_chat_model, VertexAIChatModel)
+    # Ref: https://github.com/BerriAI/litellm/issues/17696
+    assert vertexai_chat_model.allow_prompt_caching is False
+
+    vertexai_chat_model_explicit = ChatModel.from_name(
+        "vertexai:gemini-2.0-flash-lite-001", vertex_location="test", allow_prompt_caching=True
+    )
+    assert vertexai_chat_model_explicit.allow_prompt_caching is True
 
     monkeypatch.setenv("ANTHROPIC_API_KEY", "apikey")
     anthropic_chat_model = ChatModel.from_name("anthropic:claude-3-haiku-20240307")


### PR DESCRIPTION
LiteLLM's VertexAI prompt caching has a known bug (BerriAI/litellm#17696) that can produce incorrect responses. Default allow_prompt_caching to False for VertexAIChatModel unless explicitly set, matching the existing GeminiChatModel workaround for the same issue.

Split out of i-am-bee/beeai-framework#1453 per review feedback - this is a real fix but changes default behavior for every VertexAI user and shouldn't ride in on an evaluation-focused PR.

<!--
Thank you for your pull request. Please review and complete the sections below.
-->

### Which issue(s) does this pull-request address?

<!--
Please include a link to an issue in the tracker.  The issue describes the problem to be solved.  If there is no issue raised for this PR then either raise one with a summary and description of the problem or add a summary and description of the problem here
-->

Closes: #

### Description

<!-- Provide a description of the change, pay special attention to describing any breaking changes.  The description describes the resolution to the problem described in the linked issue (or to the problem outlined in this PR). -->

### Checklist

#### General
- [x] I have read the appropriate contributor guide: [Python](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
/ [TypeScript](https://github.com/i-am-bee/beeai-framework/blob/main/CONTRIBUTING.md)
- [x] I have signed off on my commit: [Python instructions](https://github.com/i-am-bee/beeai-framework/blob/main/python/CONTRIBUTING.md#developer-certificate-of-origin-dco) / [TypeScript instructions](https://github.com/i-am-bee/beeai-framework/blob/main/typescript/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Appropriate label(s) added to PR: `Python` for Python changes, `TypeScript` for TypeScript changes

#### Code quality checks
- [x] Code quality checks pass: `mise check` (`mise fix` to auto-fix)

#### Testing
- [x] Unit tests pass: `mise test:unit`
- [ ] E2E tests pass: `mise test:e2e`
- [x] Tests are included (for bug fixes or new features)

#### Documentation
- [x] Documentation is updated
