### PR TITLE
fix(internals): define properties directly in setProp

### DIFF
--- a/typescript/src/internals/helpers/object.test.ts
+++ b/typescript/src/internals/helpers/object.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2025 © BeeAI a Series of LF Projects, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { setProp } from "@/internals/helpers/object.js";
+
+describe("setProp", () => {
+  it("sets a shallow value", () => {
+    const target: any = {};
+    setProp(target, ["a"], 1);
+    expect(target).toEqual({ a: 1 });
+  });
+
+  it("creates intermediate objects for a nested path", () => {
+    const target: any = {};
+    setProp(target, ["a", "b", "c"], "x");
+    expect(target).toEqual({ a: { b: { c: "x" } } });
+  });
+
+  it("writes into arrays without disturbing length", () => {
+    const target: any = [1, 2, 3];
+    setProp(target, [1], "y");
+    expect(target).toEqual([1, "y", 3]);
+    expect(target.length).toBe(3);
+  });
+
+  it("rejects __proto__ as a path key", () => {
+    const target: any = {};
+    expect(() => setProp(target, ["__proto__", "polluted"], true)).toThrowError(TypeError);
+    expect(({} as any).polluted).toBeUndefined();
+  });
+
+  describe("prototype integrity", () => {
+    afterEach(() => {
+      delete (Object.prototype as any).intercepted;
+      delete (Object.prototype as any).polluted;
+    });
+
+    it("does not reach Object.prototype via constructor/prototype", () => {
+      const target: any = {};
+      setProp(target, ["constructor", "prototype", "polluted"], true);
+
+      // The walk creates plain own properties instead of following the inherited
+      // constructor, so nothing escapes onto Object.prototype.
+      expect(({} as any).polluted).toBeUndefined();
+      expect(Object.hasOwn(target, "constructor")).toBe(true);
+    });
+
+    it("ignores an inherited setter and always creates an own property", () => {
+      let sideEffect: unknown = undefined;
+      Object.defineProperty(Object.prototype, "intercepted", {
+        configurable: true,
+        set(v: unknown) {
+          sideEffect = v;
+        },
+      });
+
+      const target: any = {};
+      setProp(target, ["intercepted"], "value");
+
+      // Object.assign would have invoked the inherited setter and created no own
+      // property; defineProperty writes straight onto the target.
+      expect(sideEffect).toBeUndefined();
+      expect(Object.hasOwn(target, "intercepted")).toBe(true);
+      expect(target.intercepted).toBe("value");
+    });
+  });
+
+  describe("legitimate data keys", () => {
+    it("allows 'constructor' and 'prototype' as ordinary leaf keys", () => {
+      // These are valid property names in user data -- e.g. deepCopy() feeds setProp
+      // arbitrary keys from traverseObject() -- so they must not be blanket-rejected.
+      const target: any = {};
+      setProp(target, ["constructor"], "legit");
+      setProp(target, ["prototype"], 42);
+
+      expect(target.constructor).toBe("legit");
+      expect(target.prototype).toBe(42);
+      expect(({} as any).constructor).toBe(Object);
+    });
+  });
+});

--- a/typescript/src/internals/helpers/object.ts
+++ b/typescript/src/internals/helpers/object.ts
@@ -46,7 +46,16 @@ export function setProp(target: unknown, paths: readonly (keyof any)[], value: u
 
     const isLast = idx === paths.length - 1;
     const newValue = isLast ? value : hasProp(target, key) ? target[key] : {};
-    Object.assign(target, { [key]: newValue });
+    // Define the property directly rather than assigning it. `Object.assign` uses [[Set]],
+    // which walks the prototype chain and invokes an inherited setter if one exists for this
+    // key -- so a poisoned prototype could intercept the write and leave no own property
+    // behind. `defineProperty` always creates an own data property on `target` itself.
+    Object.defineProperty(target, key, {
+      value: newValue,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
     target = target[key];
   }
 }


### PR DESCRIPTION
## Problem

`setProp` wrote each path segment with `Object.assign`:

```ts
Object.assign(target, { [key]: newValue });
```

`Object.assign` uses `[[Set]]`, which walks the prototype chain. If any prototype in that chain exposes an **accessor** for the key being written, the setter runs and **no own property is created on the target at all**:

```js
Object.defineProperty(Object.prototype, "pwned", { configurable: true, set(v) { globalThis.__hit = v; } });
const t = {};
Object.assign(t, { pwned: 1 });
// setter invoked: true | own property created: false
```

`setProp` is on the deserialization path — `Serializer._createOutputBuilder.update()` and `deepCopy()` both feed it paths derived from input data — so writes there can be silently intercepted and redirected rather than landing on the object being rebuilt.

## Fix

Use `Object.defineProperty`, which always creates an own data property on `target` itself. Behaviour is otherwise identical, including array index writes and their effect on `length` (verified).

## Scope

**This is defence in depth, not a fix for a known exploit.** It requires an attacker to already control a prototype accessor. The existing guards are untouched and still do the primary work:

- `__proto__` is rejected outright via `UnsafePathKeys`
- traversal is limited to plain objects and arrays
- the own-property check in the walk stops `constructor` → `prototype` from reaching `Object.prototype`

## Why `constructor` / `prototype` are *not* added to `UnsafePathKeys`

I suggested exactly that in #1639 and then found it would be a regression, so recording the reasoning here.

They are legitimate property names in user data. `deepCopy()` calls `setProp(copy, path, result)` with paths coming straight from `traverseObject(source, ...)`, i.e. arbitrary keys of whatever object is being copied. Blanket-rejecting them would make `deepCopy`/deserialization throw on any object with a field named `constructor` or `prototype`. There's a test pinning this.

They don't need blocking anyway: the walk uses `hasProp` (`Object.prototype.hasOwnProperty.call`), so for a plain object `hasOwnProperty("constructor")` is `false` and a *fresh own property* is created instead of the inherited constructor being followed.

## Tests

New `src/internals/helpers/object.test.ts` (7 tests) covering shallow/nested/array writes, `__proto__` rejection, the `constructor`→`prototype` walk not polluting `Object.prototype`, legitimate `constructor`/`prototype` leaf keys, and the inherited-setter case.

**The inherited-setter test fails against the previous implementation** (`sideEffect` receives `"value"`, proving the setter was being invoked), so it is a real regression guard rather than a restatement of current behaviour.

Full TypeScript suite green: **313 passed / 44 files**, plus `tsc --noEmit`, `eslint`, `prettier`.

## Related

Came out of re-verifying the reports in #1638 / #1639 against `main`. Both advisories they cite were already fixed (#1543, #1551) and both issues were closed as duplicates; this is the one genuine improvement that fell out of that review.
