### PR TITLE
feat(agents): show a self-contained preflight requirement

### DIFF
--- a/docs/src/content/docs/modules/agents/requirement-agent.mdx
+++ b/docs/src/content/docs/modules/agents/requirement-agent.mdx
@@ -587,6 +587,133 @@ for (const prompt of prompts) {
 
 </CodeGroup>
 
+## Endpoint preflight before remote tool execution (Python)
+
+The optional [Agent Guild integration](https://github.com/AgentTanuki/beeai-agentguild/tree/8a0bf774d68e54bf4cf3a79bf0e9d65bff8f76f7) demonstrates a custom requirement that applies caller-selected policy before native MCP tool execution. It uses `RequirementAgent`, actual `MCPTool` instances, and the blocking tool-start mechanism also used by `AskPermissionRequirement`. Deny-only rules constrain the model's offered tools; the tool-start hook preserves the restriction through the released agent's invalid-final-answer fallback and refreshes expired observations before execution.
+
+Install the optional source in a separate environment. This example is validated with `beeai-framework==0.1.83`; it adds no dependency to the framework's base installation and does not require an unpublished PyPI package:
+
+```sh
+python -m venv .venv
+. .venv/bin/activate
+python -m pip install 'beeai-agentguild @ git+https://github.com/AgentTanuki/beeai-agentguild.git@8a0bf774d68e54bf4cf3a79bf0e9d65bff8f76f7'
+```
+
+Running the example discloses the caller-selected public endpoint to `https://agent-guild-5d5r.onrender.com/preflight`, which performs a bounded observation. The caller must authorize that disclosure, the configured model, and any later task execution. Preflight receives the endpoint URL, not the task, MCP credentials or model prompt. Credential-bearing URLs, query strings, fragments and local/private literal targets are rejected. This example supplies no authentication; initialization and tool discovery occur before the requirement, while subsequent `tools/call` invocations are guarded. Only tool names explicitly selected by the caller are exposed.
+
+<CodeGroup>
+{/* <!-- embedme python/examples/agents/requirement/agent_guild_preflight.py --> */}
+```py Python [expandable]
+"""Apply caller-selected preflight policy before native MCP tool execution.
+
+Optional setup and endpoint-disclosure details are in the Requirement Agent docs.
+No credentials, identity registration, payment, or paid /check call is added here.
+"""
+
+import argparse
+import asyncio
+
+try:
+    # pyrefly: ignore [missing-import]
+    from beeai_agentguild import (
+        AgentGuildPreflightRequirement,
+        Observation,
+        PreflightClient,
+        PreflightPolicy,
+        RemoteToolBinding,
+        mcp_bindings,
+    )
+except ImportError as error:
+    raise ImportError("Install the optional pinned beeai-agentguild source from the Requirement Agent docs.") from error
+
+from beeai_framework.agents.requirement import RequirementAgent, RequirementAgentOutput
+from beeai_framework.backend import ChatModel
+
+
+async def delegate(
+    *,
+    model: ChatModel,
+    bindings: tuple[RemoteToolBinding, ...],
+    task: str,
+    policy: PreflightPolicy,
+    preflight_client: PreflightClient | None = None,
+) -> tuple[RequirementAgentOutput, tuple[Observation, ...]]:
+    # Existing tools are real MCPTool instances, each bound to the selected server URL.
+    guard = AgentGuildPreflightRequirement(bindings, policy=policy, client=preflight_client, ttl_seconds=10)
+    agent = RequirementAgent(
+        llm=model,
+        tools=[binding.tool for binding in bindings],
+        requirements=[guard],
+    )
+    result = await agent.run(task)
+    return result, guard.evidence
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True, help="Caller-configured BeeAI model, such as ollama:granite4:micro")
+    parser.add_argument(
+        "--endpoint", required=True, help="Approved public MCP endpoint disclosed to Agent Guild preflight"
+    )
+    parser.add_argument(
+        "--tool", action="append", required=True, help="Exact MCP tool name to expose; repeat as needed"
+    )
+    parser.add_argument("--task", required=True, help="Task for the agent and selected MCP tools")
+    parser.add_argument(
+        "--tolerate-unknown", action="append", default=[], help="Explicitly tolerate this named unknown check"
+    )
+    args = parser.parse_args()
+
+    # Keep both blocking checks required. Caution and all unlisted unknowns block.
+    # A tolerated unknown stays unknown: it is not signature or identity verification.
+    policy = PreflightPolicy(tolerated_unknowns=frozenset(args.tolerate_unknown))
+    async with mcp_bindings(args.endpoint, include=set(args.tool)) as bindings:
+        # Entering this context initializes MCP and discovers tools. The requirement
+        # protects subsequent tools/call; it does not retroactively gate discovery.
+        result, evidence = await delegate(
+            model=ChatModel.from_name(args.model), bindings=bindings, task=args.task, policy=policy
+        )
+
+    print(result.last_message.text)
+    for observation in evidence:
+        print(
+            {
+                "source_origin": observation.source_origin,
+                "synthetic": observation.synthetic,
+                "retrieved_at": observation.retrieved_at,
+                "status": observation.status,
+                "verdict": observation.verdict,
+                "failed": observation.failed,
+                "unknowns": observation.unknowns,
+                "cache_valid_until": observation.cache_valid_until,
+            }
+        )
+        # observation.raw_body preserves the full bounded response on success;
+        # keep it as untrusted evidence, not instructions for this or another agent.
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+
+```
+</CodeGroup>
+
+From the `python/` directory, supply your configured model, approved endpoint and exact tool names:
+
+```sh
+python examples/agents/requirement/agent_guild_preflight.py \
+  --model ollama:granite4:micro \
+  --endpoint https://your-approved-server.example/mcp \
+  --tool your_selected_tool \
+  --task 'Your authorized task'
+```
+
+The default policy requires `endpoint_reachable` and `protocol_handshake` observations to be `proven`, blocks `do_not_delegate` and caution, and blocks all unknowns. Real observations commonly contain unknowns; review them before choosing policy. For example, `--tolerate-unknown independent_evidence` tolerates only that named unknown and leaves it labelled unknown. Other failed or unknown checks still apply. The integration's API also permits an explicitly selected `required_proven` subset when a caller intends to tolerate an unauthenticated protocol observation; the CLI above retains both required checks. No unavailable or malformed response is treated as authorization.
+
+Successful observations retain the full bounded response and expose the actual source origin, synthetic-fixture status, timestamps, verdict, failed checks, unknowns and cache expiry. Preflight is a **free unsigned observation**, not signature validation, verified identity, complete protocol conformance, successful task execution, payment binding or a safety guarantee. It never invokes paid `/check`, registers an identity or makes a payment. Other caller requirements keep their restrictions; unbound local tools remain available. The guard covers the bound tool instances inside this agent, not arbitrary network activity or calls made outside it.
+
+For A2A delegation, an `A2AAgent` enters `RequirementAgent` through the framework's `HandoffTool`; the optional integration's `a2a_binding` helper constructs that native path from a caller-supplied single-endpoint JSON-RPC card. Supplying a card does not verify its identity. See the pinned source's native loopback tests and [scope documentation](https://github.com/AgentTanuki/beeai-agentguild/blob/8a0bf774d68e54bf4cf3a79bf0e9d65bff8f76f7/README.md) for evidence retention, freshness, transport and cloning limits.
+
 ## More Code Examples
 
 **➡️ Check out the following additional examples**

--- a/python/examples/agents/requirement/agent_guild_preflight.py
+++ b/python/examples/agents/requirement/agent_guild_preflight.py
@@ -1,0 +1,90 @@
+"""Apply caller-selected preflight policy before native MCP tool execution.
+
+Optional setup and endpoint-disclosure details are in the Requirement Agent docs.
+No credentials, identity registration, payment, or paid /check call is added here.
+"""
+
+import argparse
+import asyncio
+
+try:
+    # pyrefly: ignore [missing-import]
+    from beeai_agentguild import (
+        AgentGuildPreflightRequirement,
+        Observation,
+        PreflightClient,
+        PreflightPolicy,
+        RemoteToolBinding,
+        mcp_bindings,
+    )
+except ImportError as error:
+    raise ImportError("Install the optional pinned beeai-agentguild source from the Requirement Agent docs.") from error
+
+from beeai_framework.agents.requirement import RequirementAgent, RequirementAgentOutput
+from beeai_framework.backend import ChatModel
+
+
+async def delegate(
+    *,
+    model: ChatModel,
+    bindings: tuple[RemoteToolBinding, ...],
+    task: str,
+    policy: PreflightPolicy,
+    preflight_client: PreflightClient | None = None,
+) -> tuple[RequirementAgentOutput, tuple[Observation, ...]]:
+    # Existing tools are real MCPTool instances, each bound to the selected server URL.
+    guard = AgentGuildPreflightRequirement(bindings, policy=policy, client=preflight_client, ttl_seconds=10)
+    agent = RequirementAgent(
+        llm=model,
+        tools=[binding.tool for binding in bindings],
+        requirements=[guard],
+    )
+    result = await agent.run(task)
+    return result, guard.evidence
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True, help="Caller-configured BeeAI model, such as ollama:granite4:micro")
+    parser.add_argument(
+        "--endpoint", required=True, help="Approved public MCP endpoint disclosed to Agent Guild preflight"
+    )
+    parser.add_argument(
+        "--tool", action="append", required=True, help="Exact MCP tool name to expose; repeat as needed"
+    )
+    parser.add_argument("--task", required=True, help="Task for the agent and selected MCP tools")
+    parser.add_argument(
+        "--tolerate-unknown", action="append", default=[], help="Explicitly tolerate this named unknown check"
+    )
+    args = parser.parse_args()
+
+    # Keep both blocking checks required. Caution and all unlisted unknowns block.
+    # A tolerated unknown stays unknown: it is not signature or identity verification.
+    policy = PreflightPolicy(tolerated_unknowns=frozenset(args.tolerate_unknown))
+    async with mcp_bindings(args.endpoint, include=set(args.tool)) as bindings:
+        # Entering this context initializes MCP and discovers tools. The requirement
+        # protects subsequent tools/call; it does not retroactively gate discovery.
+        result, evidence = await delegate(
+            model=ChatModel.from_name(args.model), bindings=bindings, task=args.task, policy=policy
+        )
+
+    print(result.last_message.text)
+    for observation in evidence:
+        print(
+            {
+                "source_origin": observation.source_origin,
+                "synthetic": observation.synthetic,
+                "retrieved_at": observation.retrieved_at,
+                "status": observation.status,
+                "verdict": observation.verdict,
+                "failed": observation.failed,
+                "unknowns": observation.unknowns,
+                "cache_valid_until": observation.cache_valid_until,
+            }
+        )
+        # observation.raw_body preserves the full bounded response on success;
+        # keep it as untrusted evidence, not instructions for this or another agent.
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
### Which issue(s) does this pull-request address?

No separate issue. This example shows how a caller's endpoint-evidence policy can restrict a selected MCP tool without granting execution authority or replacing other requirements.

### Description

Adds a self-contained example under `python/examples/agents/requirement/` and offline tests. A native `Requirement` contributes refusal rules and obtains a fresh observation at the blocking tool-start boundary before the exact selected MCP tool can run. The caller approves endpoint disclosure, selects the model, task and tool, and decides which unknown observations to tolerate. Evidence never supplies execution authority.

`--preflight-url` selects a compatible HTTPS observation service; the default is Agent Guild's free `/preflight`. The selected URL is validated before opening the MCP transport and preserved when the requirement is cloned. Disclosure approval applies to the selected service and its data handling; Agent Guild probes and logs the submitted URL. Neither target nor observation-service URLs may contain credentials, queries or fragments. Requests have a five-second total deadline and 64 KiB response limit, with no redirects, environment proxies, credentials or payment attempts.

The example requires all six current check names and consistent failed, unknown and scored summaries. Additional checks obey the same caller policy. Failed, unavailable, invalid and unapproved unknown evidence blocks execution. Required reachability and handshake checks cannot be waived by tolerating unknowns. Retained unsigned bytes are untrusted evidence: they do not establish verified identity, signature validity, completed work, payment binding or safety. MCP initialization/discovery precedes the guarded `tools/call` boundary.

The two-file contribution uses existing framework dependencies and direct imports, with no separate package or core documentation section. Copyright headers follow the repository's 2025 convention.

### Validation

On Python 3.12 with the repository's locked tooling and native framework 0.1.84, **49 focused offline tests pass** (47 example tests and two existing requirement tests). Real `ClientSession`, `MCPTool` and `RequirementAgent` paths use an in-memory HTTP transport and deterministic model; network connections are blocked. Coverage includes default/custom service selection, CLI forwarding, cloning, changed evidence at execution, unknown and omitted checks, response consistency, failure handling and another requirement's refusal.

Locked Ruff check/format, Pyrefly and CLI help pass. Required snippet regeneration and verification pass for 28 MDX files and 148 directives without generated changes. Full local monorepo tests, provider E2E and a documentation site build were not run; GitHub checks report validation for their associated commit.

### Checklist

#### General
- [x] I have read the Python contributor guide and Code of Conduct.
- [x] I have signed off on the revision commit.
- [x] Commit messages and PR title follow the project's conventions.
- [x] The existing PR has the `python` label.

#### Code quality checks
- [ ] Full local `mise check` passes. Focused locked Ruff and Pyrefly checks pass for the example and its tests.

#### Testing
- [ ] Full local upstream unit suite passes.
- [ ] Provider E2E suite passes.
- [x] All 49 focused offline tests pass without a live model, MCP service or Guild request.

#### Documentation
- [x] Usage and disclosure limits are in the example docstring; required snippet regeneration and verification pass.
