### PR TITLE
fix(agents): use union instead of intersection for ConditionalRequirement target validation

### DIFF
--- a/python/beeai_framework/agents/requirement/requirements/conditional.py
+++ b/python/beeai_framework/agents/requirement/requirements/conditional.py
@@ -102,7 +102,7 @@ class ConditionalRequirement(Generic[TInput], Requirement[TInput]):
     async def init(self, *, tools: list[AnyTool], ctx: RunContext) -> None:
         await super().init(tools=tools, ctx=ctx)
 
-        targets = self._before & self._after & self._force_after & {self.source}
+        targets = self._before | self._after | self._force_after | {self.source}
         _assert_all_rules_found(targets, tools)
 
         for tool in tools:

--- a/python/tests/agents/test_conditional_requirement.py
+++ b/python/tests/agents/test_conditional_requirement.py
@@ -1,0 +1,39 @@
+# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from beeai_framework.agents.requirement.requirements.conditional import ConditionalRequirement
+from beeai_framework.context import RunContext
+from beeai_framework.tools import tool
+
+
+@tool()
+def real_tool() -> str:
+    """A real tool used for tests."""
+
+    return "real"
+
+
+@tool()
+def other_tool() -> str:
+    """Another real tool used for tests."""
+
+    return "other"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_init_raises_on_unknown_tool_in_only_before() -> None:
+    requirement = ConditionalRequirement(target=real_tool, only_before=["this_tool_does_not_exist"])
+
+    with pytest.raises(ValueError, match="this_tool_does_not_exist"):
+        await requirement.init(tools=[real_tool], ctx=RunContext.__new__(RunContext))
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_init_accepts_known_tool_in_only_before() -> None:
+    requirement = ConditionalRequirement(target=real_tool, only_before=["other_tool"])
+
+    await requirement.init(tools=[real_tool, other_tool], ctx=RunContext.__new__(RunContext))


### PR DESCRIPTION
While not required for a fix this small, no existing issue covers this — found via code review.

`ConditionalRequirement.init()` builds `targets` as the intersection of `_before`, `_after`, `_force_after`, and `{source}` before passing it to `_assert_all_rules_found()`, which checks that every name in `targets` corresponds to an actual tool. But `_check_invariant()` already enforces that `_before`, `_after`, and `_force_after` are pairwise disjoint (raising ValueError otherwise), so their intersection is always empty by construction — the validation is a permanent no-op regardless of what's passed to `only_before`, `only_after`, `force_after`, or `target`.

Concretely: `ConditionalRequirement(target=some_tool, only_before=["typo_tool_name"])` passes `init()` silently even when no tool named `typo_tool_name` exists, instead of raising the intended "Tool 'typo_tool_name' is specified as ... but not found."

Fixed by using union, so every referenced name is actually checked.

### How did you test it
Added `tests/agents/test_conditional_requirement.py` (no prior test coverage existed for this class): one test confirming a typo'd `only_before` entry now raises `ValueError`, one confirming a valid entry still passes cleanly. Verified both fail/pass correctly against pre-fix code via `git stash`. Full unit suite: 339 passed, 1 skipped (pre-existing, unrelated to this change), same as before this diff. `ruff check`, `ruff format --check`, and `pyrefly check` all clean.